### PR TITLE
release: v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: CI & Release
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo test
+        run: cargo test --all-features
+
+      - name: cargo clippy
+        run: cargo clippy -- -D warnings
+
+  release:
+    name: Release
+    needs: check
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name_default: rl
+            name_debug: rl_debug
+
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name_default: rl.exe
+            name_debug: rl_debug.exe
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build default
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Copy default binary (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: cp target/${{ matrix.target }}/release/rl ${{ matrix.name_default }}
+
+      - name: Copy default binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: copy target\${{ matrix.target }}\release\rl.exe ${{ matrix.name_default }}
+        shell: cmd
+
+      - name: Build debug feature
+        run: cargo build --release --features debug --target ${{ matrix.target }}
+
+      - name: Copy debug binary (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: cp target/${{ matrix.target }}/release/rl ${{ matrix.name_debug }}
+
+      - name: Copy debug binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: copy target\${{ matrix.target }}\release\rl.exe ${{ matrix.name_debug }}
+        shell: cmd
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: |
+            ${{ matrix.name_default }}
+            ${{ matrix.name_debug }}
+
+  publish:
+    name: Publish Release
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+          generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +59,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +70,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +79,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
  "yansi",
 ]
 
@@ -84,16 +90,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cfg-if"
@@ -160,6 +187,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,7 +212,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -192,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -221,10 +262,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "either"
@@ -254,6 +354,28 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -291,10 +413,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "is-terminal"
@@ -304,7 +471,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -318,6 +485,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -371,16 +547,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -408,6 +620,35 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -477,6 +718,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +756,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -531,8 +802,23 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "criterion",
+ "crossterm",
  "env_logger",
  "log",
+ "ratatui",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -542,6 +828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +841,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -594,10 +892,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -627,10 +996,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"
@@ -647,6 +1039,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -704,13 +1102,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -720,12 +1140,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,25 @@ keywords = ["language", "interpreter", "cli"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-log = { version = "0.4", features = ["release_max_level_off"] }
-env_logger = "0.11"
+log = { version = "0.4", features = ["release_max_level_off"] , optional = true }
+env_logger = {version = "0.11" , optional = true}
 ariadne = "0.5"
+ratatui = {version = "0.29", optional = true}
+crossterm = {version = "0.28", optional = true}
 
 [dev-dependencies]
 criterion = "0.5"
+
+[features]
+default = ["repl", "repl_tui", "run", "eval"]
+run = []
+repl = []
+repl_terminal = []
+repl_tui = ["dep:ratatui","dep:crossterm"]
+debug = ["dep:env_logger", "dep:log"]
+eval = []
+vm = []
+cranelift = []
 
 [[bench]]
 name = "test_benchmark"

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -58,4 +58,8 @@ pub enum ExpressionKind {
         return_type: Option<TypeAnnotation>,
         body: Vec<Statement>,
     },
+    CallExpr {
+        callee: Box<Expression>,
+        args: Vec<Expression>,
+    },
 }

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -2,7 +2,7 @@ use crate::lexer::tokentypes;
 use crate::utils::span::Span;
 
 /// An expression paired with its source span.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Expression {
     pub kind: ExpressionKind,
     pub span: Span,
@@ -14,7 +14,7 @@ impl Expression {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ExpressionKind {
     Integer(i64),
     Binary {

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1,3 +1,4 @@
+use crate::ast::statements::{Param, Statement, TypeAnnotation};
 use crate::lexer::tokentypes;
 use crate::utils::span::Span;
 
@@ -50,5 +51,11 @@ pub enum ExpressionKind {
         target: Box<Expression>,
         index: Box<Expression>,
         value: Box<Expression>,
+    },
+
+    Lambda {
+        params: Vec<Param>,
+        return_type: Option<TypeAnnotation>,
+        body: Vec<Statement>,
     },
 }

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -65,7 +65,7 @@ pub enum StatementKind {
 
     FunctionDeclaration {
         name: String,
-        params: Vec<String>,
+        params: Vec<Param>,
         body: Vec<Statement>,
     },
     Return(Option<Expression>),
@@ -93,4 +93,10 @@ pub enum TypeAnnotation {
     CString,
     CChar,
     CArray(Box<TypeAnnotation>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Param {
+    pub param_name: String,
+    pub param_type: TypeAnnotation,
 }

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -2,7 +2,7 @@ use crate::ast::nodes::Expression;
 use crate::utils::span::Span;
 
 /// A statement paired with its source span.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Statement {
     pub kind: StatementKind,
     pub span: Span,
@@ -14,7 +14,7 @@ impl Statement {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum StatementKind {
     VariableDeclaration {
         name: String,
@@ -62,6 +62,13 @@ pub enum StatementKind {
         elseif_branch: Option<Vec<Statement>>,
         else_branch: Option<Box<Statement>>,
     },
+
+    FunctionDeclaration {
+        name: String,
+        params: Vec<String>,
+        body: Vec<Statement>,
+    },
+    Return(Option<Expression>),
 
     /// the start of awesomeness
     Import {

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -52,6 +52,11 @@ pub enum StatementKind {
         range: Box<Statement>,
         body: Vec<Statement>,
     },
+    ForEach {
+        variable: String,
+        iterable: Expression,
+        body: Vec<Statement>,
+    },
     Range(Vec<i64>),
     ConditionalBranch {
         condition: Option<Expression>,

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -93,6 +93,8 @@ pub enum TypeAnnotation {
     CString,
     CChar,
     CArray(Box<TypeAnnotation>),
+    Fn,
+    Null,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -71,6 +71,9 @@ pub enum StatementKind {
     },
     Return(Option<Expression>),
 
+    Break,
+    Continue,
+
     /// the start of awesomeness
     Import {
         /// list of the functions name

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -66,6 +66,7 @@ pub enum StatementKind {
     FunctionDeclaration {
         name: String,
         params: Vec<Param>,
+        return_type: TypeAnnotation,
         body: Vec<Statement>,
     },
     Return(Option<Expression>),

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -19,12 +19,14 @@ use crate::{
     },
 };
 
+#[derive(Debug, Clone)]
 pub struct PItem {
     pub value: Value,
     pub type_annotation: TypeAnnotation,
     pub is_const: bool,
 }
 
+#[derive(Debug, Clone)]
 pub enum EnvironmentItem {
     PItem(PItem),
 }
@@ -217,6 +219,17 @@ impl Evaluator {
                 self.call_path(path, evaluated_args, expression.span)?
             }
 
+            ExpressionKind::CallExpr { callee, args } => {
+                let func_val = self.evaluate(callee)?;
+                let mut evaluated_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    let val = self.evaluate(arg)?;
+                    self.check_not_null(&val, arg.span)?;
+                    evaluated_args.push(val);
+                }
+                self.call_value(func_val, evaluated_args, expression.span)?
+            }
+
             ExpressionKind::Lambda {
                 params,
                 return_type,
@@ -225,9 +238,78 @@ impl Evaluator {
                 params: params.clone(),
                 body: body.clone(),
                 return_type: return_type.clone(),
+                captured_env: self.environment.clone(),
             },
         };
         Ok(value)
+    }
+
+    pub fn call_value(
+        &mut self,
+        func: Value,
+        args: Vec<Value>,
+        span: Span,
+    ) -> Result<Value, Error> {
+        if let Value::Function {
+            params,
+            body,
+            return_type,
+            captured_env,
+        } = func
+        {
+            if params.len() != args.len() {
+                return Err(self.err(
+                    format!(
+                        "function '' expects {} argument(s), got {}",
+                        params.len(),
+                        args.len()
+                    ),
+                    span,
+                ));
+            }
+
+            let saved_env = std::mem::take(&mut self.environment);
+            let saved_return = self.return_value.take();
+
+            self.environment = captured_env;
+            self.push_scope();
+
+            for (param, arg) in params.iter().zip(args) {
+                let arg_type = Self::infer_type(&arg);
+                self.insert_value(param.param_name.clone(), arg, arg_type, span)?;
+            }
+
+            for statement in &body {
+                self.evaluate_statement(statement)?;
+                if self.return_value.is_some() {
+                    break;
+                }
+            }
+
+            let result = self.return_value.take().unwrap_or(Value::Null);
+
+            self.environment = saved_env;
+            self.return_value = saved_return;
+
+            if let Some(expected) = &return_type {
+                if *expected != TypeAnnotation::Null {
+                    let actual = Self::infer_type(&result);
+                    if *expected != actual {
+                        return Err(self.err(
+                            format!(
+                                "function '' declared to return {:?} but returned {:?}",
+                                expected, actual
+                            ),
+                            span,
+                        ));
+                    }
+                }
+            }
+
+            return Ok(result);
+        }
+
+        Err(self.err("value is not callable", span))
     }
 
     pub fn call_path(
@@ -249,6 +331,7 @@ impl Evaluator {
                 params,
                 body,
                 return_type,
+                captured_env,
             } = func
             {
                 if params.len() != args.len() {
@@ -270,7 +353,7 @@ impl Evaluator {
                 // Fresh single-frame environment for the callee (Bug 4: push its
                 // own scope so the params live in their own block, consistent
                 // with evaluate_block semantics).
-                self.environment = vec![HashMap::new()];
+                self.environment = captured_env;
                 self.push_scope();
 
                 for (param, arg) in params.iter().zip(args) {

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -197,7 +197,7 @@ impl Evaluator {
                 self.environment = vec![HashMap::new()];
 
                 for (param, arg) in params.iter().zip(args) {
-                    self.insert_value(param.clone(), arg, span)?;
+                    self.insert_value(param.param_name.clone(), arg, span)?;
                 }
                 self.evaluate_block(&body)?;
 

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -322,7 +322,7 @@ impl Evaluator {
     ) -> Result<Value, Error> {
         if let Some(f) = self.root_module.resolve(path) {
             let f = Arc::clone(f);
-            return Ok(f(self, args));
+            return f(self, args);
         }
 
         // detect user defined functions

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -113,7 +113,7 @@ impl Evaluator {
             Value::Values(items) => {
                 let inner = items
                     .first()
-                    .map(|v| Self::infer_type(v))
+                    .map(Self::infer_type)
                     .unwrap_or(TypeAnnotation::Null);
                 TypeAnnotation::Array(Box::new(inner))
             }
@@ -293,18 +293,18 @@ impl Evaluator {
             self.environment = saved_env;
             self.return_value = saved_return;
 
-            if let Some(expected) = &return_type {
-                if *expected != TypeAnnotation::Null {
-                    let actual = Self::infer_type(&result);
-                    if *expected != actual {
-                        return Err(self.err(
-                            format!(
-                                "function '' declared to return {:?} but returned {:?}",
-                                expected, actual
-                            ),
-                            span,
-                        ));
-                    }
+            if let Some(expected) = &return_type
+                && *expected != TypeAnnotation::Null
+            {
+                let actual = Self::infer_type(&result);
+                if *expected != actual {
+                    return Err(self.err(
+                        format!(
+                            "function '' declared to return {:?} but returned {:?}",
+                            expected, actual
+                        ),
+                        span,
+                    ));
                 }
             }
 
@@ -379,18 +379,18 @@ impl Evaluator {
                 // Return-type check: skip when the annotation is Null (i.e. no
                 // `->` was written) — that means the function is void and the
                 // return value is intentionally ignored (Bug 3 fix).
-                if let Some(expected) = &return_type {
-                    if *expected != TypeAnnotation::Null {
-                        let actual = Self::infer_type(&result);
-                        if *expected != actual {
-                            return Err(self.err(
-                                format!(
-                                    "function '{}' declared to return {:?} but returned {:?}",
-                                    path[0], expected, actual
-                                ),
-                                span,
-                            ));
-                        }
+                if let Some(expected) = &return_type
+                    && *expected != TypeAnnotation::Null
+                {
+                    let actual = Self::infer_type(&result);
+                    if *expected != actual {
+                        return Err(self.err(
+                            format!(
+                                "function '{}' declared to return {:?} but returned {:?}",
+                                path[0], expected, actual
+                            ),
+                            span,
+                        ));
                     }
                 }
 

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -20,6 +20,7 @@ pub struct Evaluator {
     pub environment: Vec<HashMap<String, (Value, bool)>>,
     pub source_file: Option<SourceFile>,
     pub root_module: Module,
+    pub return_value: Option<Value>,
 }
 
 impl Default for Evaluator {
@@ -34,6 +35,7 @@ impl Evaluator {
             environment: vec![HashMap::new()],
             source_file: None,
             root_module: Module::new(""),
+            return_value: None,
         }
     }
 
@@ -173,6 +175,40 @@ impl Evaluator {
             let f = Arc::clone(f);
             return Ok(f(self, args));
         }
+
+        // detect user defined functions
+        if path.len() == 1 {
+            let func = self.get_value(&path[0], span)?;
+
+            if let Value::Function { params, body } = func {
+                if params.len() != args.len() {
+                    return Err(self.err(
+                        format!(
+                            "function '{}' expects {} argument(s), got {}",
+                            path[0],
+                            params.len(),
+                            args.len()
+                        ),
+                        span,
+                    ));
+                }
+
+                let saved_env = std::mem::take(&mut self.environment);
+                self.environment = vec![HashMap::new()];
+
+                for (param, arg) in params.iter().zip(args) {
+                    self.insert_value(param.clone(), arg, span)?;
+                }
+                self.evaluate_block(&body)?;
+
+                let result = self.return_value.take().unwrap_or(Value::Null);
+
+                self.environment = saved_env;
+
+                return Ok(result);
+            }
+        }
+
         let mut err = self.err(format!("undefined function {}", path.join("::")), span);
         // suggest a stdlib leaf name if the last segment is a close typo
         if let Some(last) = path.last() {

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    ast::nodes::{Expression, ExpressionKind},
+    ast::{
+        nodes::{Expression, ExpressionKind},
+        statements::TypeAnnotation,
+    },
     interpreter::{
         native::{IntoNativeFn, Module},
         stdlib,
@@ -16,8 +19,18 @@ use crate::{
     },
 };
 
+pub struct PItem {
+    pub value: Value,
+    pub type_annotation: Option<TypeAnnotation>,
+    pub is_const: bool,
+}
+
+pub enum EnvironmentItem {
+    PItem(PItem),
+}
+
 pub struct Evaluator {
-    pub environment: Vec<HashMap<String, (Value, bool)>>,
+    pub environment: Vec<HashMap<String, EnvironmentItem>>,
     pub source_file: Option<SourceFile>,
     pub root_module: Module,
     pub return_value: Option<Value>,
@@ -151,7 +164,7 @@ impl Evaluator {
             ExpressionKind::Identifier(name) => self.get_value(name, expression.span)?,
             ExpressionKind::Assign { name, value } => {
                 let val = self.evaluate(value)?;
-                self.insert_value(name.clone(), val.clone(), expression.span)?;
+                self.insert_value(name.clone(), val.clone(), None, expression.span)?;
                 val
             }
             ExpressionKind::Call { path, args } => {
@@ -197,7 +210,7 @@ impl Evaluator {
                 self.environment = vec![HashMap::new()];
 
                 for (param, arg) in params.iter().zip(args) {
-                    self.insert_value(param.param_name.clone(), arg, span)?;
+                    self.insert_value(param.param_name.clone(), arg, None, span)?;
                 }
                 self.evaluate_block(&body)?;
 

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -179,6 +179,7 @@ impl Evaluator {
             let candidates = stdlib::display::KEYWORDS
                 .iter()
                 .chain(stdlib::math::KEYWORDS)
+                .chain(stdlib::math::constants::KEYWORDS)
                 .chain(stdlib::io::KEYWORDS)
                 .copied();
             if let Some(suggestion) = closest_match(last, candidates) {

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -38,6 +38,7 @@ pub struct Evaluator {
     pub return_value: Option<Value>,
     pub is_breaking: bool,
     pub is_continuing: bool,
+    pub output_buffer: Option<String>,
 }
 
 impl Default for Evaluator {
@@ -55,6 +56,7 @@ impl Evaluator {
             return_value: None,
             is_breaking: false,
             is_continuing: false,
+            output_buffer: None,
         }
     }
 

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -21,7 +21,7 @@ use crate::{
 
 pub struct PItem {
     pub value: Value,
-    pub type_annotation: Option<TypeAnnotation>,
+    pub type_annotation: TypeAnnotation,
     pub is_const: bool,
 }
 
@@ -164,7 +164,30 @@ impl Evaluator {
             ExpressionKind::Identifier(name) => self.get_value(name, expression.span)?,
             ExpressionKind::Assign { name, value } => {
                 let val = self.evaluate(value)?;
-                self.insert_value(name.clone(), val.clone(), None, expression.span)?;
+                let inferred_type = match &val {
+                    Value::Integer(_) => TypeAnnotation::Int,
+                    Value::Float(_) => TypeAnnotation::Float,
+                    Value::String(_) => TypeAnnotation::String,
+                    Value::Bool(_) => TypeAnnotation::Bool,
+                    Value::Char(_) => TypeAnnotation::Char,
+                    Value::Values(items) => {
+                        let inner = items
+                            .first()
+                            .map(|v| match v {
+                                Value::Integer(_) => TypeAnnotation::Int,
+                                Value::Float(_) => TypeAnnotation::Float,
+                                Value::String(_) => TypeAnnotation::String,
+                                Value::Bool(_) => TypeAnnotation::Bool,
+                                Value::Char(_) => TypeAnnotation::Char,
+                                _ => TypeAnnotation::Null,
+                            })
+                            .unwrap_or(TypeAnnotation::Null);
+                        TypeAnnotation::Array(Box::new(inner))
+                    }
+                    Value::Null => TypeAnnotation::Null,
+                    Value::Function { .. } => TypeAnnotation::Fn,
+                };
+                self.assign_value(name.clone(), val.clone(), inferred_type, expression.span)?;
                 val
             }
             ExpressionKind::Call { path, args } => {
@@ -210,8 +233,32 @@ impl Evaluator {
                 self.environment = vec![HashMap::new()];
 
                 for (param, arg) in params.iter().zip(args) {
-                    self.insert_value(param.param_name.clone(), arg, None, span)?;
+                    let arg_type = match &arg {
+                        Value::Integer(_) => TypeAnnotation::Int,
+                        Value::Float(_) => TypeAnnotation::Float,
+                        Value::String(_) => TypeAnnotation::String,
+                        Value::Bool(_) => TypeAnnotation::Bool,
+                        Value::Char(_) => TypeAnnotation::Char,
+                        Value::Values(items) => {
+                            let inner = items
+                                .first()
+                                .map(|v| match v {
+                                    Value::Integer(_) => TypeAnnotation::Int,
+                                    Value::Float(_) => TypeAnnotation::Float,
+                                    Value::String(_) => TypeAnnotation::String,
+                                    Value::Bool(_) => TypeAnnotation::Bool,
+                                    Value::Char(_) => TypeAnnotation::Char,
+                                    _ => TypeAnnotation::Null,
+                                })
+                                .unwrap_or(TypeAnnotation::Null);
+                            TypeAnnotation::Array(Box::new(inner))
+                        }
+                        Value::Null => TypeAnnotation::Null,
+                        Value::Function { .. } => TypeAnnotation::Fn,
+                    };
+                    self.insert_value(param.param_name.clone(), arg, arg_type, span)?;
                 }
+
                 self.evaluate_block(&body)?;
 
                 let result = self.return_value.take().unwrap_or(Value::Null);

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -216,7 +216,12 @@ impl Evaluator {
         if path.len() == 1 {
             let func = self.get_value(&path[0], span)?;
 
-            if let Value::Function { params, body } = func {
+            if let Value::Function {
+                params,
+                body,
+                return_type,
+            } = func
+            {
                 if params.len() != args.len() {
                     return Err(self.err(
                         format!(
@@ -259,11 +264,51 @@ impl Evaluator {
                     self.insert_value(param.param_name.clone(), arg, arg_type, span)?;
                 }
 
-                self.evaluate_block(&body)?;
+                for statement in &body {
+                    self.evaluate_statement(statement)?;
+                    if self.return_value.is_some() {
+                        break;
+                    }
+                }
 
                 let result = self.return_value.take().unwrap_or(Value::Null);
 
                 self.environment = saved_env;
+
+                if let Some(expected) = &return_type {
+                    let actual = match &result {
+                        Value::Integer(_) => TypeAnnotation::Int,
+                        Value::Float(_) => TypeAnnotation::Float,
+                        Value::String(_) => TypeAnnotation::String,
+                        Value::Bool(_) => TypeAnnotation::Bool,
+                        Value::Char(_) => TypeAnnotation::Char,
+                        Value::Values(items) => {
+                            let inner = items
+                                .first()
+                                .map(|v| match v {
+                                    Value::Integer(_) => TypeAnnotation::Int,
+                                    Value::Float(_) => TypeAnnotation::Float,
+                                    Value::String(_) => TypeAnnotation::String,
+                                    Value::Bool(_) => TypeAnnotation::Bool,
+                                    Value::Char(_) => TypeAnnotation::Char,
+                                    _ => TypeAnnotation::Null,
+                                })
+                                .unwrap_or(TypeAnnotation::Null);
+                            TypeAnnotation::Array(Box::new(inner))
+                        }
+                        Value::Null => TypeAnnotation::Null,
+                        Value::Function { .. } => TypeAnnotation::Fn,
+                    };
+                    if *expected != actual {
+                        return Err(self.err(
+                            format!(
+                                "function '{}' declared to return {:?} but returned {:?}",
+                                path[0], expected, actual
+                            ),
+                            span,
+                        ));
+                    }
+                }
 
                 return Ok(result);
             }

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -34,6 +34,8 @@ pub struct Evaluator {
     pub source_file: Option<SourceFile>,
     pub root_module: Module,
     pub return_value: Option<Value>,
+    pub is_breaking: bool,
+    pub is_continuing: bool,
 }
 
 impl Default for Evaluator {
@@ -49,6 +51,8 @@ impl Evaluator {
             source_file: None,
             root_module: Module::new(""),
             return_value: None,
+            is_breaking: false,
+            is_continuing: false,
         }
     }
 

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -235,32 +235,12 @@ impl Evaluator {
                 }
 
                 let saved_env = std::mem::take(&mut self.environment);
+                let saved_return = self.return_value.take();
                 self.environment = vec![HashMap::new()];
+                self.push_scope();
 
                 for (param, arg) in params.iter().zip(args) {
-                    let arg_type = match &arg {
-                        Value::Integer(_) => TypeAnnotation::Int,
-                        Value::Float(_) => TypeAnnotation::Float,
-                        Value::String(_) => TypeAnnotation::String,
-                        Value::Bool(_) => TypeAnnotation::Bool,
-                        Value::Char(_) => TypeAnnotation::Char,
-                        Value::Values(items) => {
-                            let inner = items
-                                .first()
-                                .map(|v| match v {
-                                    Value::Integer(_) => TypeAnnotation::Int,
-                                    Value::Float(_) => TypeAnnotation::Float,
-                                    Value::String(_) => TypeAnnotation::String,
-                                    Value::Bool(_) => TypeAnnotation::Bool,
-                                    Value::Char(_) => TypeAnnotation::Char,
-                                    _ => TypeAnnotation::Null,
-                                })
-                                .unwrap_or(TypeAnnotation::Null);
-                            TypeAnnotation::Array(Box::new(inner))
-                        }
-                        Value::Null => TypeAnnotation::Null,
-                        Value::Function { .. } => TypeAnnotation::Fn,
-                    };
+                    let arg_type = Self::infer_type(&arg);
                     self.insert_value(param.param_name.clone(), arg, arg_type, span)?;
                 }
 
@@ -274,39 +254,20 @@ impl Evaluator {
                 let result = self.return_value.take().unwrap_or(Value::Null);
 
                 self.environment = saved_env;
+                self.return_value = saved_return;
 
                 if let Some(expected) = &return_type {
-                    let actual = match &result {
-                        Value::Integer(_) => TypeAnnotation::Int,
-                        Value::Float(_) => TypeAnnotation::Float,
-                        Value::String(_) => TypeAnnotation::String,
-                        Value::Bool(_) => TypeAnnotation::Bool,
-                        Value::Char(_) => TypeAnnotation::Char,
-                        Value::Values(items) => {
-                            let inner = items
-                                .first()
-                                .map(|v| match v {
-                                    Value::Integer(_) => TypeAnnotation::Int,
-                                    Value::Float(_) => TypeAnnotation::Float,
-                                    Value::String(_) => TypeAnnotation::String,
-                                    Value::Bool(_) => TypeAnnotation::Bool,
-                                    Value::Char(_) => TypeAnnotation::Char,
-                                    _ => TypeAnnotation::Null,
-                                })
-                                .unwrap_or(TypeAnnotation::Null);
-                            TypeAnnotation::Array(Box::new(inner))
+                    if *expected != TypeAnnotation::Null {
+                        let actual = Self::infer_type(&result);
+                        if *expected != actual {
+                            return Err(self.err(
+                                format!(
+                                    "function '{}' declared to return {:?} but returned {:?}",
+                                    path[0], expected, actual
+                                ),
+                                span,
+                            ));
                         }
-                        Value::Null => TypeAnnotation::Null,
-                        Value::Function { .. } => TypeAnnotation::Fn,
-                    };
-                    if *expected != actual {
-                        return Err(self.err(
-                            format!(
-                                "function '{}' declared to return {:?} but returned {:?}",
-                                path[0], expected, actual
-                            ),
-                            span,
-                        ));
                     }
                 }
 
@@ -328,5 +289,25 @@ impl Evaluator {
             }
         }
         Err(err)
+    }
+
+    /// Infer the [`TypeAnnotation`] of a runtime [`Value`].
+    pub fn infer_type(value: &Value) -> TypeAnnotation {
+        match value {
+            Value::Integer(_) => TypeAnnotation::Int,
+            Value::Float(_) => TypeAnnotation::Float,
+            Value::String(_) => TypeAnnotation::String,
+            Value::Bool(_) => TypeAnnotation::Bool,
+            Value::Char(_) => TypeAnnotation::Char,
+            Value::Values(items) => {
+                let inner = items
+                    .first()
+                    .map(|v| Self::infer_type(v))
+                    .unwrap_or(TypeAnnotation::Null);
+                TypeAnnotation::Array(Box::new(inner))
+            }
+            Value::Null => TypeAnnotation::Null,
+            Value::Function { .. } => TypeAnnotation::Fn,
+        }
     }
 }

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -216,6 +216,16 @@ impl Evaluator {
                 }
                 self.call_path(path, evaluated_args, expression.span)?
             }
+
+            ExpressionKind::Lambda {
+                params,
+                return_type,
+                body,
+            } => Value::Function {
+                params: params.clone(),
+                body: body.clone(),
+                return_type: return_type.clone(),
+            },
         };
         Ok(value)
     }

--- a/src/interpreter/evaluator_types/index_assign.rs
+++ b/src/interpreter/evaluator_types/index_assign.rs
@@ -1,6 +1,9 @@
 use crate::{
     ast::nodes::{Expression, ExpressionKind},
-    interpreter::{evaluator::Evaluator, values::Value},
+    interpreter::{
+        evaluator::{EnvironmentItem, Evaluator},
+        values::Value,
+    },
     utils::{errors::Error, span::Span},
 };
 
@@ -47,23 +50,35 @@ impl Evaluator {
         }
 
         for scope in self.environment.iter().rev() {
-            if let Some((_, true)) = scope.get(&root) {
-                return Err(self.err(format!("cannot assign to constant '{}'", root), span));
+            if let Some(env_item) = scope.get(&root) {
+                match env_item {
+                    EnvironmentItem::PItem(p) => {
+                        if p.is_const {
+                            return Err(
+                                self.err(format!("cannot assign to constant '{}'", root), span)
+                            );
+                        }
+                    }
+                }
             }
         }
 
         for scope in self.environment.iter_mut().rev() {
-            if let Some((root_val, _)) = scope.get_mut(&root) {
-                let mut current = root_val;
-                for i in &indices[..indices.len() - 1] {
-                    if let Value::Values(items) = current {
-                        current = &mut items[*i];
+            if let Some(env_item) = scope.get_mut(&root) {
+                match env_item {
+                    EnvironmentItem::PItem(p) => {
+                        let mut current = &mut p.value;
+                        for i in &indices[..indices.len() - 1] {
+                            if let Value::Values(items) = current {
+                                current = &mut items[*i];
+                            }
+                        }
+                        if let Value::Values(items) = current {
+                            items[*indices.last().unwrap()] = val.clone();
+                        }
+                        return Ok(val);
                     }
                 }
-                if let Value::Values(items) = current {
-                    items[*indices.last().unwrap()] = val.clone();
-                }
-                return Ok(val);
             }
         }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4,4 +4,4 @@ pub mod native;
 mod scopes;
 mod stdlib;
 mod utils;
-mod values;
+pub mod values;

--- a/src/interpreter/native.rs
+++ b/src/interpreter/native.rs
@@ -5,7 +5,7 @@ use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
 
-pub type NativeFn = Arc<dyn Fn(&mut Evaluator, Vec<Value>) -> Value + Send + Sync>;
+pub type NativeFn = Arc<dyn Fn(&mut Evaluator, Vec<Value>) -> Result<Value, Error> + Send + Sync>;
 
 pub struct Module {
     pub name: String,
@@ -32,7 +32,7 @@ impl Module {
 
     pub fn with_raw_function<F>(mut self, name: impl Into<String>, f: F) -> Self
     where
-        F: Fn(&mut Evaluator, Vec<Value>) -> Value + Send + Sync + 'static,
+        F: Fn(&mut Evaluator, Vec<Value>) -> Result<Value, Error> + Send + Sync + 'static,
     {
         self.functions.insert(name.into(), Arc::new(f));
         self
@@ -56,76 +56,90 @@ impl Module {
 }
 
 pub trait FromValue: Sized {
-    fn from_value(v: Value) -> Self;
-}
-
-fn type_error(expected: &str, got: &Value) -> ! {
-    Error::init(
-        format!("expected {}, got {:?}", expected, got),
-        None,
-        None,
-    )
-    .print_error();
-    unreachable!()
+    fn from_value(v: Value) -> Result<Self, Error>;
 }
 
 impl FromValue for Value {
-    fn from_value(v: Value) -> Self {
-        v
+    fn from_value(v: Value) -> Result<Self, Error> {
+        Ok(v)
     }
 }
 
 impl FromValue for i64 {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
-            Value::Integer(i) => i,
-            other => type_error("integer", &other),
+            Value::Integer(i) => Ok(i),
+            other => Err(Error::init(
+                format!("expected integer, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
 
 impl FromValue for f64 {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
-            Value::Float(f) => f,
-            Value::Integer(i) => i as f64,
-            other => type_error("float", &other),
+            Value::Float(f) => Ok(f),
+            Value::Integer(i) => Ok(i as f64),
+            other => Err(Error::init(
+                format!("expected float, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
 
 impl FromValue for String {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
-            Value::String(s) => s,
-            other => type_error("string", &other),
+            Value::String(s) => Ok(s),
+            other => Err(Error::init(
+                format!("expected string, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
 
 impl FromValue for bool {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
-            Value::Bool(b) => b,
-            other => type_error("bool", &other),
+            Value::Bool(b) => Ok(b),
+            other => Err(Error::init(
+                format!("expected bool, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
 
 impl FromValue for char {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
-            Value::Char(c) => c,
-            other => type_error("char", &other),
+            Value::Char(c) => Ok(c),
+            other => Err(Error::init(
+                format!("expected char, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
 
 impl<T: FromValue> FromValue for Vec<T> {
-    fn from_value(v: Value) -> Self {
+    fn from_value(v: Value) -> Result<Self, Error> {
         match v {
             Value::Values(items) => items.into_iter().map(T::from_value).collect(),
-            other => type_error("array", &other),
+            other => Err(Error::init(
+                format!("expected array, got {}", other.type_name()),
+                None,
+                None,
+            )),
         }
     }
 }
@@ -186,30 +200,28 @@ pub trait IntoNativeFn<Args> {
     fn into_native(self) -> NativeFn;
 }
 
-fn arity_error(expected: usize, got: usize) -> ! {
-    Error::init(
-        format!("expected {} argument(s), got {}", expected, got),
-        None,
-        None,
-    )
-    .print_error();
-    unreachable!()
-}
-
 impl<F, R> IntoNativeFn<()> for F
 where
     F: Fn(&mut Evaluator) -> R + Send + Sync + 'static,
     R: IntoValue,
 {
     fn into_native(self) -> NativeFn {
-        Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Value {
-            if !args.is_empty() {
-                arity_error(0, args.len());
-            }
-            self(rt).into_value()
-        })
+        Arc::new(
+            move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
+                if !args.is_empty() {
+                    return Err(Error::init(
+                        format!("expected 0 argument(s), got {}", args.len()),
+                        None,
+                        None,
+                    ));
+                }
+                Ok(self(rt).into_value())
+            },
+        )
     }
 }
+
+pub struct Fallible<T>(std::marker::PhantomData<T>);
 
 macro_rules! impl_into_native_fn {
     ($count:literal, $(($ty:ident, $var:ident)),+) => {
@@ -220,28 +232,99 @@ macro_rules! impl_into_native_fn {
             $($ty: FromValue),+
         {
             fn into_native(self) -> NativeFn {
-                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Value {
+                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
                     if args.len() != $count {
-                        arity_error($count, args.len());
+                        return Err(Error::init(
+                            format!("expected {} argument(s), got {}", $count, args.len()),
+                            None, None,
+                        ));
                     }
                     let mut iter = args.into_iter();
-                    $(
-                        let $var = <$ty>::from_value(iter.next().unwrap());
-                    )+
-                    self(rt, $($var),+).into_value()
+                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    Ok(self(rt, $($var),+).into_value())
+                })
+            }
+        }
+
+        impl<F, R, $($ty),+> IntoNativeFn<(Fallible<($($ty,)+)>,)> for F
+        where
+            F: Fn(&mut Evaluator, $($ty),+) -> Result<R, Error> + Send + Sync + 'static,
+            R: IntoValue,
+            $($ty: FromValue),+
+        {
+            fn into_native(self) -> NativeFn {
+                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
+                    if args.len() != $count {
+                        return Err(Error::init(
+                            format!("expected {} argument(s), got {}", $count, args.len()),
+                            None, None,
+                        ));
+                    }
+                    let mut iter = args.into_iter();
+                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    Ok(self(rt, $($var),+)?.into_value())
                 })
             }
         }
     };
 }
-
 impl_into_native_fn!(1, (A1, a1));
 impl_into_native_fn!(2, (A1, a1), (A2, a2));
 impl_into_native_fn!(3, (A1, a1), (A2, a2), (A3, a3));
 impl_into_native_fn!(4, (A1, a1), (A2, a2), (A3, a3), (A4, a4));
 impl_into_native_fn!(5, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5));
-impl_into_native_fn!(6, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5), (A6, a6));
-impl_into_native_fn!(7, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5), (A6, a6), (A7, a7));
-impl_into_native_fn!(8, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5), (A6, a6), (A7, a7), (A8, a8));
-impl_into_native_fn!(9, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5), (A6, a6), (A7, a7), (A8, a8), (A9, a9));
-impl_into_native_fn!(10, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5), (A6, a6), (A7, a7), (A8, a8), (A9, a9), (A10, a10));
+impl_into_native_fn!(
+    6,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6)
+);
+impl_into_native_fn!(
+    7,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7)
+);
+impl_into_native_fn!(
+    8,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8)
+);
+impl_into_native_fn!(
+    9,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9)
+);
+impl_into_native_fn!(
+    10,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9),
+    (A10, a10)
+);

--- a/src/interpreter/scopes.rs
+++ b/src/interpreter/scopes.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 
 use crate::{
-    interpreter::{evaluator::Evaluator, values::Value},
+    ast::statements::TypeAnnotation,
+    interpreter::{
+        evaluator::{EnvironmentItem, Evaluator, PItem},
+        values::Value,
+    },
     utils::{errors::Error, span::Span, suggest::closest_match},
 };
 
@@ -16,8 +20,12 @@ impl Evaluator {
 
     pub fn get_value(&self, name: &str, span: Span) -> Result<Value, Error> {
         for scope in self.environment.iter().rev() {
-            if let Some((val, _)) = scope.get(name) {
-                return Ok(val.clone());
+            if let Some(item) = scope.get(name) {
+                match item {
+                    EnvironmentItem::PItem(p) => {
+                        return Ok(p.value.clone());
+                    }
+                }
             }
         }
         let all_keys = self
@@ -31,35 +39,75 @@ impl Evaluator {
         Err(err)
     }
 
-    pub fn insert_value(&mut self, name: String, value: Value, span: Span) -> Result<(), Error> {
+    pub fn insert_value(
+        &mut self,
+        name: String,
+        value: Value,
+        type_annotation: Option<TypeAnnotation>,
+        span: Span,
+    ) -> Result<(), Error> {
         for scope in self.environment.iter().rev() {
-            if let Some((_, true)) = scope.get(&name) {
-                return Err(self.err(format!("cannot assign to constant '{}'", name), span));
+            if let Some(item) = scope.get(&name) {
+                match item {
+                    EnvironmentItem::PItem(p) => {
+                        if p.is_const {
+                            return Err(
+                                self.err(format!("cannot assign to constant '{}'", name), span)
+                            );
+                        }
+                    }
+                }
             }
         }
         if let Some(scope) = self.environment.last_mut() {
-            scope.insert(name, (value, false));
+            scope.insert(
+                name,
+                EnvironmentItem::PItem(PItem {
+                    value,
+                    type_annotation,
+                    is_const: false,
+                }),
+            );
         }
         Ok(())
     }
 
-    pub fn insert_const(&mut self, name: String, value: Value, span: Span) -> Result<(), Error> {
+    pub fn insert_const(
+        &mut self,
+        name: String,
+        value: Value,
+        type_annotation: Option<TypeAnnotation>,
+        span: Span,
+    ) -> Result<(), Error> {
         let scope = self.environment.last_mut().unwrap();
         if scope.contains_key(&name) {
             return Err(self.err(format!("'{}' is already declared", name), span));
         }
-        scope.insert(name, (value, true));
+        scope.insert(
+            name,
+            EnvironmentItem::PItem(PItem {
+                value,
+                type_annotation,
+                is_const: true,
+            }),
+        );
         Ok(())
     }
 
     pub fn assign_value(&mut self, name: String, value: Value, span: Span) -> Result<(), Error> {
         for scope in self.environment.iter_mut().rev() {
             if let Some(entry) = scope.get_mut(&name) {
-                if entry.1 {
-                    return Err(self.err(format!("cannot assign to constant '{}'", name), span));
+                match entry {
+                    EnvironmentItem::PItem(p) => {
+                        if p.is_const {
+                            return Err(
+                                self.err(format!("cannot assign to constant '{}'", name), span)
+                            );
+                        }
+                        p.value = value;
+                        return Ok(());
+                    }
                 }
-                entry.0 = value;
-                return Ok(());
             }
         }
         Err(self.err(format!("undefined variable '{}'", name), span))

--- a/src/interpreter/scopes.rs
+++ b/src/interpreter/scopes.rs
@@ -43,7 +43,7 @@ impl Evaluator {
         &mut self,
         name: String,
         value: Value,
-        type_annotation: Option<TypeAnnotation>,
+        type_annotation: TypeAnnotation,
         span: Span,
     ) -> Result<(), Error> {
         for scope in self.environment.iter().rev() {
@@ -76,7 +76,7 @@ impl Evaluator {
         &mut self,
         name: String,
         value: Value,
-        type_annotation: Option<TypeAnnotation>,
+        type_annotation: TypeAnnotation,
         span: Span,
     ) -> Result<(), Error> {
         let scope = self.environment.last_mut().unwrap();
@@ -94,7 +94,13 @@ impl Evaluator {
         Ok(())
     }
 
-    pub fn assign_value(&mut self, name: String, value: Value, span: Span) -> Result<(), Error> {
+    pub fn assign_value(
+        &mut self,
+        name: String,
+        value: Value,
+        value_type: TypeAnnotation,
+        span: Span,
+    ) -> Result<(), Error> {
         for scope in self.environment.iter_mut().rev() {
             if let Some(entry) = scope.get_mut(&name) {
                 match entry {
@@ -104,6 +110,26 @@ impl Evaluator {
                                 self.err(format!("cannot assign to constant '{}'", name), span)
                             );
                         }
+                        let declared = p.type_annotation.clone();
+
+                        let types_match = match (&declared, &value_type) {
+                            (TypeAnnotation::Array(_), TypeAnnotation::Array(inner))
+                                if **inner == TypeAnnotation::Null =>
+                            {
+                                true
+                            }
+                            _ => declared == value_type,
+                        };
+                        if !types_match {
+                            return Err(self.err(
+                                format!(
+                                    "cannot assign {:?} to variable '{}' declared as {:?}",
+                                    value_type, name, declared
+                                ),
+                                span,
+                            ));
+                        }
+
                         p.value = value;
                         return Ok(());
                     }

--- a/src/interpreter/stdlib/display/len.rs
+++ b/src/interpreter/stdlib/display/len.rs
@@ -1,13 +1,16 @@
 use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
 
-pub fn std_len(_: &mut Evaluator, v: Value) -> i64 {
+pub fn std_len(_: &mut Evaluator, v: Value) -> Result<i64, Error> {
     match v {
-        Value::Values(items) => items.len() as i64,
-        Value::String(s) => s.len() as i64,
-        _ => {
-            Error::init("len() expects an array or string".to_string(), None, None)
-                .print_error();
-            unreachable!()
-        }
+        Value::Values(items) => Ok(items.len() as i64),
+        Value::String(s) => Ok(s.len() as i64),
+        other => Err(Error::init(
+            format!(
+                "len() expects an array or string, got {}",
+                other.type_name()
+            ),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/display/print.rs
+++ b/src/interpreter/stdlib/display/print.rs
@@ -1,7 +1,8 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
+use crate::utils::errors::Error;
 
-pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
+pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
     let text = args
         .iter()
         .enumerate()
@@ -19,5 +20,5 @@ pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
     } else {
         print!("{}", text);
     }
-    Value::Null
+    Ok(Value::Null)
 }

--- a/src/interpreter/stdlib/display/print.rs
+++ b/src/interpreter/stdlib/display/print.rs
@@ -1,12 +1,23 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 
-pub fn std_print(_: &mut Evaluator, args: Vec<Value>) -> Value {
-    for (i, arg) in args.iter().enumerate() {
-        if i > 0 {
-            print!(" ");
-        }
-        print!("{}", arg);
+pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
+    let text = args
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            if i > 0 {
+                format!(" {}", a)
+            } else {
+                format!("{}", a)
+            }
+        })
+        .collect::<String>();
+
+    if let Some(buffer) = &mut evaluator.output_buffer {
+        buffer.push_str(&text);
+    } else {
+        print!("{}", text);
     }
     Value::Null
 }

--- a/src/interpreter/stdlib/display/println.rs
+++ b/src/interpreter/stdlib/display/println.rs
@@ -1,7 +1,8 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
+use crate::utils::errors::Error;
 
-pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
+pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
     let text = args
         .iter()
         .enumerate()
@@ -20,5 +21,5 @@ pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
     } else {
         println!("{}", text);
     }
-    Value::Null
+    Ok(Value::Null)
 }

--- a/src/interpreter/stdlib/display/println.rs
+++ b/src/interpreter/stdlib/display/println.rs
@@ -1,13 +1,24 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 
-pub fn std_println(_: &mut Evaluator, args: Vec<Value>) -> Value {
-    for (i, arg) in args.iter().enumerate() {
-        if i > 0 {
-            print!(" ");
-        }
-        print!("{}", arg);
+pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Value {
+    let text = args
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            if i > 0 {
+                format!(" {}", a)
+            } else {
+                format!("{}", a)
+            }
+        })
+        .collect::<String>();
+
+    if let Some(buffer) = &mut evaluator.output_buffer {
+        buffer.push_str(&text);
+        buffer.push('\n');
+    } else {
+        println!("{}", text);
     }
-    println!();
     Value::Null
 }

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -2,9 +2,9 @@ use std::io;
 
 use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
 
-pub fn std_input(_: &mut Evaluator, args: Vec<Value>) -> Value {
+pub fn std_input(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
     match args.len() {
-        0 => read_line(),
+        0 => Ok(read_line()),
         1 => {
             let prompt = match args.into_iter().next().unwrap() {
                 Value::Integer(i) => i.to_string(),
@@ -16,12 +16,13 @@ pub fn std_input(_: &mut Evaluator, args: Vec<Value>) -> Value {
                 _ => "".to_string(),
             };
             println!("{}", prompt);
-            read_line()
+            Ok(read_line())
         }
-        _ => {
-            Error::init("incorrect usage".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        n => Err(Error::init(
+            format!("input() expects 0 or 1 argument(s), got {}", n),
+            None,
+            None,
+        )),
     }
 }
 

--- a/src/interpreter/stdlib/math/abs.rs
+++ b/src/interpreter/stdlib/math/abs.rs
@@ -4,13 +4,14 @@ use crate::{
 };
 
 /// returns the absolute value of number
-pub fn std_abs(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_abs(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Integer(i.abs()),
-        Value::Float(f) => Value::Float(f.abs()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Integer(i.abs())),
+        Value::Float(f) => Ok(Value::Float(f.abs())),
+        other => Err(Error::init(
+            format!("abs() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/abs.rs
+++ b/src/interpreter/stdlib/math/abs.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_abs(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Integer(i.abs()),
+        Value::Float(f) => Value::Float(f.abs()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/acos.rs
+++ b/src/interpreter/stdlib/math/acos.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_acos(_: &mut Evaluator, x: f64) -> f64 {
+    x.acos()
+}

--- a/src/interpreter/stdlib/math/asin.rs
+++ b/src/interpreter/stdlib/math/asin.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_asin(_: &mut Evaluator, x: f64) -> f64 {
+    x.asin()
+}

--- a/src/interpreter/stdlib/math/atan.rs
+++ b/src/interpreter/stdlib/math/atan.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_atan(_: &mut Evaluator, x: f64) -> f64 {
+    x.atan()
+}

--- a/src/interpreter/stdlib/math/atan2.rs
+++ b/src/interpreter/stdlib/math/atan2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_atan2(_: &mut Evaluator, x: f64, y: f64) -> f64 {
+    y.atan2(x)
+}

--- a/src/interpreter/stdlib/math/ceil.rs
+++ b/src/interpreter/stdlib/math/ceil.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_ceil(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_ceil(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Integer(i),
-        Value::Float(f) => Value::Float(f.ceil()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Integer(i)),
+        Value::Float(f) => Ok(Value::Float(f.ceil())),
+        other => Err(Error::init(
+            format!("ceil() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/ceil.rs
+++ b/src/interpreter/stdlib/math/ceil.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_ceil(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Integer(i),
+        Value::Float(f) => Value::Float(f.ceil()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/clamp.rs
+++ b/src/interpreter/stdlib/math/clamp.rs
@@ -1,0 +1,19 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Value {
+    match (value, min, max) {
+        (Value::Integer(value), Value::Integer(low), Value::Integer(high)) => {
+            Value::Integer(value.clamp(low, high))
+        }
+        (Value::Float(value), Value::Float(low), Value::Float(high)) => {
+            Value::Float(value.clamp(low, high))
+        }
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/clamp.rs
+++ b/src/interpreter/stdlib/math/clamp.rs
@@ -3,17 +3,23 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Value {
+pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Result<Value, Error> {
     match (value, min, max) {
         (Value::Integer(value), Value::Integer(low), Value::Integer(high)) => {
-            Value::Integer(value.clamp(low, high))
+            Ok(Value::Integer(value.clamp(low, high)))
         }
         (Value::Float(value), Value::Float(low), Value::Float(high)) => {
-            Value::Float(value.clamp(low, high))
+            Ok(Value::Float(value.clamp(low, high)))
         }
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        (value, min, max) => Err(Error::init(
+            format!(
+                "clamp() expects a number, got ({}, {}, {})",
+                value.type_name(),
+                min.type_name(),
+                max.type_name()
+            ),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/constants/e.rs
+++ b/src/interpreter/stdlib/math/constants/e.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_e(_: &mut Evaluator) -> f64 {
+    std::f64::consts::E
+}

--- a/src/interpreter/stdlib/math/constants/euler_gamma.rs
+++ b/src/interpreter/stdlib/math/constants/euler_gamma.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_euler_gamma(_: &mut Evaluator) -> f64 {
+    std::f64::consts::EULER_GAMMA
+}

--- a/src/interpreter/stdlib/math/constants/frac_1_pi.rs
+++ b/src/interpreter/stdlib/math/constants/frac_1_pi.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_1_pi(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_1_PI
+}

--- a/src/interpreter/stdlib/math/constants/frac_1_sqrt_2.rs
+++ b/src/interpreter/stdlib/math/constants/frac_1_sqrt_2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_1_sqrt_2(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_1_SQRT_2
+}

--- a/src/interpreter/stdlib/math/constants/frac_2_pi.rs
+++ b/src/interpreter/stdlib/math/constants/frac_2_pi.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_2_pi(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_2_PI
+}

--- a/src/interpreter/stdlib/math/constants/frac_2_sqrt_pi.rs
+++ b/src/interpreter/stdlib/math/constants/frac_2_sqrt_pi.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_2_sqrt_pi(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_2_SQRT_PI
+}

--- a/src/interpreter/stdlib/math/constants/frac_pi_2.rs
+++ b/src/interpreter/stdlib/math/constants/frac_pi_2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_pi_2(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_PI_2
+}

--- a/src/interpreter/stdlib/math/constants/frac_pi_3.rs
+++ b/src/interpreter/stdlib/math/constants/frac_pi_3.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_pi_3(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_PI_3
+}

--- a/src/interpreter/stdlib/math/constants/frac_pi_4.rs
+++ b/src/interpreter/stdlib/math/constants/frac_pi_4.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_pi_4(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_PI_4
+}

--- a/src/interpreter/stdlib/math/constants/frac_pi_6.rs
+++ b/src/interpreter/stdlib/math/constants/frac_pi_6.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_pi_6(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_PI_6
+}

--- a/src/interpreter/stdlib/math/constants/frac_pi_8.rs
+++ b/src/interpreter/stdlib/math/constants/frac_pi_8.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_frac_pi_8(_: &mut Evaluator) -> f64 {
+    std::f64::consts::FRAC_PI_8
+}

--- a/src/interpreter/stdlib/math/constants/inf.rs
+++ b/src/interpreter/stdlib/math/constants/inf.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_inf(_: &mut Evaluator) -> f64 {
+    f64::INFINITY
+}

--- a/src/interpreter/stdlib/math/constants/is_inf.rs
+++ b/src/interpreter/stdlib/math/constants/is_inf.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_is_inf(_: &mut Evaluator, x: f64) -> bool {
+    x.is_infinite()
+}

--- a/src/interpreter/stdlib/math/constants/is_nan.rs
+++ b/src/interpreter/stdlib/math/constants/is_nan.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_is_nan(_: &mut Evaluator, x: f64) -> bool {
+    x.is_nan()
+}

--- a/src/interpreter/stdlib/math/constants/ln_10.rs
+++ b/src/interpreter/stdlib/math/constants/ln_10.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_ln_10(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LN_10
+}

--- a/src/interpreter/stdlib/math/constants/ln_2.rs
+++ b/src/interpreter/stdlib/math/constants/ln_2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_ln_2(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LN_2
+}

--- a/src/interpreter/stdlib/math/constants/log10_2.rs
+++ b/src/interpreter/stdlib/math/constants/log10_2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_log10_2(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LOG10_2
+}

--- a/src/interpreter/stdlib/math/constants/log10_e.rs
+++ b/src/interpreter/stdlib/math/constants/log10_e.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_log10_e(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LOG10_E
+}

--- a/src/interpreter/stdlib/math/constants/log2_10.rs
+++ b/src/interpreter/stdlib/math/constants/log2_10.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_log2_10(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LOG2_10
+}

--- a/src/interpreter/stdlib/math/constants/log2_e.rs
+++ b/src/interpreter/stdlib/math/constants/log2_e.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_log2_e(_: &mut Evaluator) -> f64 {
+    std::f64::consts::LOG2_E
+}

--- a/src/interpreter/stdlib/math/constants/mod.rs
+++ b/src/interpreter/stdlib/math/constants/mod.rs
@@ -1,0 +1,83 @@
+pub mod e;
+pub mod euler_gamma;
+pub mod frac_1_pi;
+pub mod frac_1_sqrt_2;
+pub mod frac_2_pi;
+pub mod frac_2_sqrt_pi;
+pub mod frac_pi_2;
+pub mod frac_pi_3;
+pub mod frac_pi_4;
+pub mod frac_pi_6;
+pub mod frac_pi_8;
+pub mod inf;
+pub mod is_inf;
+pub mod is_nan;
+pub mod ln_10;
+pub mod ln_2;
+pub mod log10_2;
+pub mod log10_e;
+pub mod log2_10;
+pub mod log2_e;
+pub mod nan;
+pub mod phi;
+pub mod pi;
+pub mod sqrt_2;
+pub mod tua;
+
+use crate::interpreter::native::Module;
+
+pub const KEYWORDS: &[&str] = &[
+    "E",
+    "PI",
+    "FRAC_1_PI",
+    "FRAC_1_SQRT_2",
+    "FRAC_2_PI",
+    "FRAC_2_SQRT_PI",
+    "FRAC_PI_2",
+    "FRAC_PI_3",
+    "FRAC_PI_4",
+    "FRAC_PI_6",
+    "FRAC_PI_8",
+    "INF",
+    "NAN",
+    "is_inf",
+    "is_nan",
+    "LN_10",
+    "LN_2",
+    "LOG10_2",
+    "LOG10_E",
+    "LOG2_10",
+    "LOG2_E",
+    "SQRT_2",
+    "EULER_GAMMA",
+    "PHI",
+];
+
+pub fn module() -> Module {
+    Module::new("consts")
+        .with_function("E", e::std_e)
+        .with_function("PI", pi::std_pi)
+        .with_function("PHI", phi::std_phi)
+        .with_function("TUA", tua::std_tua)
+        .with_function("INF", inf::std_inf)
+        .with_function("NAN", nan::std_nan)
+        .with_function("is_inf", is_inf::std_is_inf)
+        .with_function("is_nan", is_nan::std_is_nan)
+        .with_function("FRAC_1_PI", frac_1_pi::std_frac_1_pi)
+        .with_function("FRAC_2_PI", frac_2_pi::std_frac_2_pi)
+        .with_function("FRAC_1_SQRT_2", frac_1_sqrt_2::std_frac_1_sqrt_2)
+        .with_function("FRAC_2_SQRT_PI", frac_2_sqrt_pi::std_frac_2_sqrt_pi)
+        .with_function("EULER_GAMMA", euler_gamma::std_euler_gamma)
+        .with_function("LN_10", ln_10::std_ln_10)
+        .with_function("LN_2", ln_2::std_ln_2)
+        .with_function("LOG2_E", log2_e::std_log2_e)
+        .with_function("LOG2_10", log2_10::std_log2_10)
+        .with_function("LOG10_2", log10_2::std_log10_2)
+        .with_function("LOG10_E", log10_e::std_log10_e)
+        .with_function("FRAC_PI_2", frac_pi_2::std_frac_pi_2)
+        .with_function("FRAC_PI_3", frac_pi_3::std_frac_pi_3)
+        .with_function("FRAC_PI_4", frac_pi_4::std_frac_pi_4)
+        .with_function("FRAC_PI_6", frac_pi_6::std_frac_pi_6)
+        .with_function("FRAC_PI_8", frac_pi_8::std_frac_pi_8)
+        .with_function("SQRT_2", sqrt_2::std_sqrt_2)
+}

--- a/src/interpreter/stdlib/math/constants/nan.rs
+++ b/src/interpreter/stdlib/math/constants/nan.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_nan(_: &mut Evaluator) -> f64 {
+    f64::NAN
+}

--- a/src/interpreter/stdlib/math/constants/phi.rs
+++ b/src/interpreter/stdlib/math/constants/phi.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_phi(_: &mut Evaluator) -> f64 {
+    std::f64::consts::GOLDEN_RATIO
+}

--- a/src/interpreter/stdlib/math/constants/pi.rs
+++ b/src/interpreter/stdlib/math/constants/pi.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_pi(_: &mut Evaluator) -> f64 {
+    std::f64::consts::PI
+}

--- a/src/interpreter/stdlib/math/constants/sqrt_2.rs
+++ b/src/interpreter/stdlib/math/constants/sqrt_2.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_sqrt_2(_: &mut Evaluator) -> f64 {
+    std::f64::consts::SQRT_2
+}

--- a/src/interpreter/stdlib/math/constants/tua.rs
+++ b/src/interpreter/stdlib/math/constants/tua.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_tua(_: &mut Evaluator) -> f64 {
+    std::f64::consts::TAU
+}

--- a/src/interpreter/stdlib/math/degrees.rs
+++ b/src/interpreter/stdlib/math/degrees.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_degrees(_: &mut Evaluator, x: f64) -> f64 {
+    x.to_degrees()
+}

--- a/src/interpreter/stdlib/math/exp.rs
+++ b/src/interpreter/stdlib/math/exp.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_exp(_: &mut Evaluator, x: f64) -> f64 {
+    x.exp()
+}

--- a/src/interpreter/stdlib/math/factorial.rs
+++ b/src/interpreter/stdlib/math/factorial.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_factorial(_: &mut Evaluator, x: i64) -> i64 {
+    (1..=x).product()
+}

--- a/src/interpreter/stdlib/math/fibonacci.rs
+++ b/src/interpreter/stdlib/math/fibonacci.rs
@@ -1,0 +1,9 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_fibonacci(_: &mut Evaluator, x: i64) -> i64 {
+    let (mut a, mut b) = (0, 1);
+    for _ in 0..x {
+        (a, b) = (b, a + b);
+    }
+    a
+}

--- a/src/interpreter/stdlib/math/floor.rs
+++ b/src/interpreter/stdlib/math/floor.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_floor(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_floor(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Integer(i),
-        Value::Float(f) => Value::Float(f.floor()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Integer(i)),
+        Value::Float(f) => Ok(Value::Float(f.floor())),
+        other => Err(Error::init(
+            format!("floor() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/floor.rs
+++ b/src/interpreter/stdlib/math/floor.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_floor(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Integer(i),
+        Value::Float(f) => Value::Float(f.floor()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/gcd.rs
+++ b/src/interpreter/stdlib/math/gcd.rs
@@ -1,0 +1,10 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_gcd(_: &mut Evaluator, x: i64, y: i64) -> i64 {
+    let mut a = x as u64;
+    let mut b = y as u64;
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a as i64
+}

--- a/src/interpreter/stdlib/math/hypot.rs
+++ b/src/interpreter/stdlib/math/hypot.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_hypot(_: &mut Evaluator, x: f64, y: f64) -> f64 {
+    x.hypot(y)
+}

--- a/src/interpreter/stdlib/math/is_prime.rs
+++ b/src/interpreter/stdlib/math/is_prime.rs
@@ -8,12 +8,12 @@ pub fn std_is_prime(_: &mut Evaluator, x: i64) -> bool {
     if x < 4 {
         return true;
     }
-    if x % 2 == 0 || x % 3 == 0 {
+    if x.is_multiple_of(2) || x.is_multiple_of(3) {
         return false;
     }
     let mut i = 5;
     while i * i <= x {
-        if x % i == 0 || x % (i + 2) == 0 {
+        if x.is_multiple_of(i) || x.is_multiple_of(i + 2) {
             return false;
         }
         i += 6;

--- a/src/interpreter/stdlib/math/is_prime.rs
+++ b/src/interpreter/stdlib/math/is_prime.rs
@@ -1,0 +1,22 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_is_prime(_: &mut Evaluator, x: i64) -> bool {
+    let x = x as u64;
+    if x < 2 {
+        return false;
+    }
+    if x < 4 {
+        return true;
+    }
+    if x % 2 == 0 || x % 3 == 0 {
+        return false;
+    }
+    let mut i = 5;
+    while i * i <= x {
+        if x % i == 0 || x % (i + 2) == 0 {
+            return false;
+        }
+        i += 6;
+    }
+    true
+}

--- a/src/interpreter/stdlib/math/lcm.rs
+++ b/src/interpreter/stdlib/math/lcm.rs
@@ -1,0 +1,12 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_lcm(_: &mut Evaluator, x: i64, y: i64) -> i64 {
+    let mut a = x as u64;
+    let mut b = y as u64;
+    let a_ = x as u64;
+    let b_ = y as u64;
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    (a_ / a * b_) as i64
+}

--- a/src/interpreter/stdlib/math/lerp.rs
+++ b/src/interpreter/stdlib/math/lerp.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_lerp(_: &mut Evaluator, x: f64, y: f64, t: f64) -> f64 {
+    x + (y - x) * t
+}

--- a/src/interpreter/stdlib/math/log.rs
+++ b/src/interpreter/stdlib/math/log.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_log(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Float((i as f64).ln()),
+        Value::Float(f) => Value::Float(f.ln()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/log.rs
+++ b/src/interpreter/stdlib/math/log.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_log(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_log(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Float((i as f64).ln()),
-        Value::Float(f) => Value::Float(f.ln()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Float((i as f64).ln())),
+        Value::Float(f) => Ok(Value::Float(f.ln())),
+        other => Err(Error::init(
+            format!("log() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/log10.rs
+++ b/src/interpreter/stdlib/math/log10.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_log10(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_log10(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Float((i as f64).log10()),
-        Value::Float(f) => Value::Float(f.log10()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Float((i as f64).log10())),
+        Value::Float(f) => Ok(Value::Float(f.log10())),
+        other => Err(Error::init(
+            format!("log10() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/log10.rs
+++ b/src/interpreter/stdlib/math/log10.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_log10(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Float((i as f64).log10()),
+        Value::Float(f) => Value::Float(f.log10()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/log2.rs
+++ b/src/interpreter/stdlib/math/log2.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_log2(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Float((i as f64).log2()),
+        Value::Float(f) => Value::Float(f.log2()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/log2.rs
+++ b/src/interpreter/stdlib/math/log2.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_log2(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_log2(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Float((i as f64).log2()),
-        Value::Float(f) => Value::Float(f.log2()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Float((i as f64).log2())),
+        Value::Float(f) => Ok(Value::Float(f.log2())),
+        other => Err(Error::init(
+            format!("log2() expects a number, got {}", other.type_name()),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/map_range.rs
+++ b/src/interpreter/stdlib/math/map_range.rs
@@ -1,0 +1,12 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_map_range(
+    _: &mut Evaluator,
+    value: f64,
+    in_min: f64,
+    out_min: f64,
+    in_max: f64,
+    out_max: f64,
+) -> f64 {
+    (value - in_min) / (in_max - in_min) * (out_max - out_min) + out_min
+}

--- a/src/interpreter/stdlib/math/max.rs
+++ b/src/interpreter/stdlib/math/max.rs
@@ -3,13 +3,18 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_max(_: &mut Evaluator, a: Value, b: Value) -> Value {
+pub fn std_max(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Value::Integer(a.max(b)),
-        (Value::Float(a), Value::Float(b)) => Value::Float(a.max(b)),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.max(b))),
+        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.max(b))),
+        (a, b) => Err(Error::init(
+            format!(
+                "max() expects a number, got ({}, {})",
+                a.type_name(),
+                b.type_name()
+            ),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/max.rs
+++ b/src/interpreter/stdlib/math/max.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_max(_: &mut Evaluator, a: Value, b: Value) -> Value {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => Value::Integer(a.max(b)),
+        (Value::Float(a), Value::Float(b)) => Value::Float(a.max(b)),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/min.rs
+++ b/src/interpreter/stdlib/math/min.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_min(_: &mut Evaluator, a: Value, b: Value) -> Value {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => Value::Integer(a.min(b)),
+        (Value::Float(a), Value::Float(b)) => Value::Float(a.min(b)),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/min.rs
+++ b/src/interpreter/stdlib/math/min.rs
@@ -3,13 +3,18 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_min(_: &mut Evaluator, a: Value, b: Value) -> Value {
+pub fn std_min(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Value::Integer(a.min(b)),
-        (Value::Float(a), Value::Float(b)) => Value::Float(a.min(b)),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.min(b))),
+        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.min(b))),
+        (a, b) => Err(Error::init(
+            format!(
+                "min() expects a number, got ({}, {})",
+                a.type_name(),
+                b.type_name()
+            ),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -74,7 +74,7 @@ pub fn module() -> Module {
         .with_function("sin", sin::std_sin)
         .with_function("cos", cos::std_cos)
         .with_function("tan", tan::std_tan)
-        .with_function("pow", power::std_pow)
+        .with_raw_function("pow", power::std_pow)
         .with_function("mod", modulo::std_mod)
         .with_function("abs", abs::std_abs)
         .with_function("ceil", ceil::std_ceil)

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -8,6 +8,7 @@ pub mod clamp;
 pub mod constants;
 pub mod cos;
 pub mod degrees;
+pub mod exp;
 pub mod floor;
 pub mod log;
 pub mod log10;
@@ -26,7 +27,7 @@ use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
     "sin", "cos", "tan", "pow", "mod", "abs", "ceil", "clamp", "floor", "round", "log", "log2",
-    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2", "radians", "degrees",
+    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2", "radians", "degrees", "exp",
 ];
 
 pub fn module() -> Module {
@@ -53,5 +54,6 @@ pub fn module() -> Module {
         .with_function("asin", asin::std_asin)
         .with_function("degrees", degrees::std_degrees)
         .with_function("radians", radians::std_radians)
+        .with_function("exp", exp::std_exp)
         .with_module(constants::module())
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -1,7 +1,18 @@
+pub mod abs;
+pub mod ceil;
+pub mod clamp;
 pub mod cos;
+pub mod floor;
+pub mod log;
+pub mod log10;
+pub mod log2;
+pub mod max;
+pub mod min;
 pub mod modulo;
 pub mod power;
+pub mod round;
 pub mod sin;
+pub mod sqrt;
 pub mod tan;
 
 use crate::interpreter::native::Module;
@@ -13,4 +24,15 @@ pub fn module() -> Module {
         .with_function("tan", tan::std_tan)
         .with_function("pow", power::std_pow)
         .with_function("mod", modulo::std_mod)
+        .with_function("abs", abs::std_abs)
+        .with_function("ceil", ceil::std_ceil)
+        .with_function("clamp", clamp::std_clamp)
+        .with_function("floor", floor::std_floor)
+        .with_function("round", round::std_round)
+        .with_function("log", log::std_log)
+        .with_function("log2", log2::std_log2)
+        .with_function("log10", log10::std_log10)
+        .with_function("max", max::std_max)
+        .with_function("min", min::std_min)
+        .with_function("sqrt", sqrt::std_sqrt)
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -1,6 +1,7 @@
 pub mod abs;
 pub mod ceil;
 pub mod clamp;
+pub mod constants;
 pub mod cos;
 pub mod floor;
 pub mod log;
@@ -17,7 +18,10 @@ pub mod tan;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["sin", "cos", "tan", "pow", "mod"];
+pub const KEYWORDS: &[&str] = &[
+    "sin", "cos", "tan", "pow", "mod", "abs", "ceil", "clamp", "floor", "round", "log", "log2",
+    "log10", "max", "min", "sqrt",
+];
 
 pub fn module() -> Module {
     Module::new("math")
@@ -37,4 +41,5 @@ pub fn module() -> Module {
         .with_function("max", max::std_max)
         .with_function("min", min::std_min)
         .with_function("sqrt", sqrt::std_sqrt)
+        .with_module(constants::module())
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -1,4 +1,8 @@
 pub mod abs;
+pub mod acos;
+pub mod asin;
+pub mod atan;
+pub mod atan2;
 pub mod ceil;
 pub mod clamp;
 pub mod constants;
@@ -20,7 +24,7 @@ use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
     "sin", "cos", "tan", "pow", "mod", "abs", "ceil", "clamp", "floor", "round", "log", "log2",
-    "log10", "max", "min", "sqrt",
+    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2",
 ];
 
 pub fn module() -> Module {
@@ -41,5 +45,9 @@ pub fn module() -> Module {
         .with_function("max", max::std_max)
         .with_function("min", min::std_min)
         .with_function("sqrt", sqrt::std_sqrt)
+        .with_function("atan", atan::std_atan)
+        .with_function("atan2", atan2::std_atan2)
+        .with_function("acos", acos::std_acos)
+        .with_function("asin", asin::std_asin)
         .with_module(constants::module())
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -9,16 +9,25 @@ pub mod constants;
 pub mod cos;
 pub mod degrees;
 pub mod exp;
+pub mod factorial;
+pub mod fibonacci;
 pub mod floor;
+pub mod gcd;
+pub mod hypot;
+pub mod is_prime;
+pub mod lcm;
+pub mod lerp;
 pub mod log;
 pub mod log10;
 pub mod log2;
+pub mod map_range;
 pub mod max;
 pub mod min;
 pub mod modulo;
 pub mod power;
 pub mod radians;
 pub mod round;
+pub mod sign;
 pub mod sin;
 pub mod sqrt;
 pub mod tan;
@@ -26,8 +35,38 @@ pub mod tan;
 use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
-    "sin", "cos", "tan", "pow", "mod", "abs", "ceil", "clamp", "floor", "round", "log", "log2",
-    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2", "radians", "degrees", "exp",
+    "sin",
+    "cos",
+    "tan",
+    "pow",
+    "mod",
+    "abs",
+    "ceil",
+    "clamp",
+    "floor",
+    "round",
+    "log",
+    "log2",
+    "log10",
+    "max",
+    "min",
+    "sqrt",
+    "atan",
+    "acos",
+    "asin",
+    "atan2",
+    "radians",
+    "degrees",
+    "exp",
+    "factorial",
+    "fibonacci",
+    "gcd",
+    "lcm",
+    "hypot",
+    "lerp",
+    "map_range",
+    "sign",
+    "is_prime",
 ];
 
 pub fn module() -> Module {
@@ -55,5 +94,14 @@ pub fn module() -> Module {
         .with_function("degrees", degrees::std_degrees)
         .with_function("radians", radians::std_radians)
         .with_function("exp", exp::std_exp)
+        .with_function("factorial", factorial::std_factorial)
+        .with_function("fibonacci", fibonacci::std_fibonacci)
+        .with_function("gcd", gcd::std_gcd)
+        .with_function("lcm", lcm::std_lcm)
+        .with_function("lerp", lerp::std_lerp)
+        .with_function("is_prime", is_prime::std_is_prime)
+        .with_function("hypot", hypot::std_hypot)
+        .with_function("sign", sign::std_sign)
+        .with_function("map_range", map_range::std_map_range)
         .with_module(constants::module())
 }

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -7,6 +7,7 @@ pub mod ceil;
 pub mod clamp;
 pub mod constants;
 pub mod cos;
+pub mod degrees;
 pub mod floor;
 pub mod log;
 pub mod log10;
@@ -15,6 +16,7 @@ pub mod max;
 pub mod min;
 pub mod modulo;
 pub mod power;
+pub mod radians;
 pub mod round;
 pub mod sin;
 pub mod sqrt;
@@ -24,7 +26,7 @@ use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
     "sin", "cos", "tan", "pow", "mod", "abs", "ceil", "clamp", "floor", "round", "log", "log2",
-    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2",
+    "log10", "max", "min", "sqrt", "atan", "acos", "asin", "atan2", "radians", "degrees",
 ];
 
 pub fn module() -> Module {
@@ -49,5 +51,7 @@ pub fn module() -> Module {
         .with_function("atan2", atan2::std_atan2)
         .with_function("acos", acos::std_acos)
         .with_function("asin", asin::std_asin)
+        .with_function("degrees", degrees::std_degrees)
+        .with_function("radians", radians::std_radians)
         .with_module(constants::module())
 }

--- a/src/interpreter/stdlib/math/modulo.rs
+++ b/src/interpreter/stdlib/math/modulo.rs
@@ -1,17 +1,19 @@
 use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
 
-pub fn std_mod(_: &mut Evaluator, a: Value, b: Value) -> Value {
+pub fn std_mod(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Value::Integer(a % b),
-        (Value::Float(a), Value::Float(b)) => Value::Float(a % b),
-        _ => {
-            Error::init(
-                "only integers and floats are supported".to_string(),
-                None,
-                None,
-            )
-            .print_error();
-            unreachable!()
-        }
+        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a % b)),
+        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a % b)),
+        (Value::Integer(a), Value::Float(b)) => Ok(Value::Float(a as f64 % b)),
+        (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a % b as f64)),
+        (a, b) => Err(Error::init(
+            format!(
+                "mod() expects a number, got ({}, {})",
+                a.type_name(),
+                b.type_name()
+            ),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/power.rs
+++ b/src/interpreter/stdlib/math/power.rs
@@ -1,23 +1,29 @@
 use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
 
-pub fn std_pow(_: &mut Evaluator, base: Value, exponent: Value) -> Value {
+pub fn std_pow(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    if args.len() != 2 {
+        return Err(Error::init(
+            format!("pow() expects 2 arguments, got {}", args.len()),
+            None,
+            None,
+        ));
+    }
+    let mut iter = args.into_iter();
+    let base = iter.next().unwrap();
+    let exponent = iter.next().unwrap();
+
     match (base, exponent) {
         (Value::Integer(a), Value::Integer(b)) => {
-            let a = a as i32;
             let b = b as u32;
-            Value::Integer(a.pow(b) as i64)
+            Ok(Value::Integer(a.pow(b) as i64))
         }
-        (Value::Integer(a), Value::Float(b)) => Value::Float((a as f64).powf(b)),
-        (Value::Float(a), Value::Float(b)) => Value::Float(a.powf(b)),
-        (Value::Float(a), Value::Integer(b)) => Value::Float(a.powi(b as i32)),
-        _ => {
-            Error::init(
-                "only integers and floats are supported".to_string(),
-                None,
-                None,
-            )
-            .print_error();
-            unreachable!()
-        }
+        (Value::Integer(a), Value::Float(b)) => Ok(Value::Float((a as f64).powf(b))),
+        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.powf(b))),
+        (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a.powi(b as i32))),
+        _ => Err(Error::init(
+            "pow() expects numeric arguments".to_string(),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/power.rs
+++ b/src/interpreter/stdlib/math/power.rs
@@ -15,7 +15,7 @@ pub fn std_pow(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
     match (base, exponent) {
         (Value::Integer(a), Value::Integer(b)) => {
             let b = b as u32;
-            Ok(Value::Integer(a.pow(b) as i64))
+            Ok(Value::Integer(a.pow(b)))
         }
         (Value::Integer(a), Value::Float(b)) => Ok(Value::Float((a as f64).powf(b))),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.powf(b))),

--- a/src/interpreter/stdlib/math/radians.rs
+++ b/src/interpreter/stdlib/math/radians.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_radians(_: &mut Evaluator, x: f64) -> f64 {
+    x.to_radians()
+}

--- a/src/interpreter/stdlib/math/round.rs
+++ b/src/interpreter/stdlib/math/round.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_round(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_round(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Integer(i),
-        Value::Float(f) => Value::Float(f.round()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Integer(i)),
+        Value::Float(f) => Ok(Value::Float(f.round())),
+        other => Err(Error::init(
+            format!("round() expects a number, got {}", other.type_name(),),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/stdlib/math/round.rs
+++ b/src/interpreter/stdlib/math/round.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_round(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Integer(i),
+        Value::Float(f) => Value::Float(f.round()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/sign.rs
+++ b/src/interpreter/stdlib/math/sign.rs
@@ -1,0 +1,11 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn std_sign(_: &mut Evaluator, x: f64) -> f64 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}

--- a/src/interpreter/stdlib/math/sqrt.rs
+++ b/src/interpreter/stdlib/math/sqrt.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_sqrt(_: &mut Evaluator, a: Value) -> Value {
+    match a {
+        Value::Integer(i) => Value::Float((i as f64).sqrt()),
+        Value::Float(f) => Value::Float(f.sqrt()),
+        _ => {
+            Error::init("".to_string(), None, None).print_error();
+            unreachable!()
+        }
+    }
+}

--- a/src/interpreter/stdlib/math/sqrt.rs
+++ b/src/interpreter/stdlib/math/sqrt.rs
@@ -3,13 +3,14 @@ use crate::{
     utils::errors::Error,
 };
 
-pub fn std_sqrt(_: &mut Evaluator, a: Value) -> Value {
+pub fn std_sqrt(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
     match a {
-        Value::Integer(i) => Value::Float((i as f64).sqrt()),
-        Value::Float(f) => Value::Float(f.sqrt()),
-        _ => {
-            Error::init("".to_string(), None, None).print_error();
-            unreachable!()
-        }
+        Value::Integer(i) => Ok(Value::Float((i as f64).sqrt())),
+        Value::Float(f) => Ok(Value::Float(f.sqrt())),
+        other => Err(Error::init(
+            format!("round() expects a number, got {}", other.type_name(),),
+            None,
+            None,
+        )),
     }
 }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -148,6 +148,23 @@ impl Evaluator {
                     }
                 }
             }
+
+            StatementKind::FunctionDeclaration { name, params, body } => {
+                let func = Value::Function {
+                    params: params.clone(),
+                    body: body.clone(),
+                };
+                self.insert_value(name.clone(), func.clone(), statement.span)?;
+            }
+
+            StatementKind::Return(expr) => {
+                let value = match expr {
+                    Some(e) => self.evaluate(e)?,
+                    None => Value::Null,
+                };
+
+                self.return_value = Some(value);
+            }
         }
         Ok(())
     }
@@ -181,9 +198,14 @@ impl Evaluator {
     }
 
     pub fn evaluate_block(&mut self, statements: &[Statement]) -> Result<(), Error> {
+        self.push_scope();
         for statement in statements {
             self.evaluate_statement(statement)?;
+            if self.return_value.is_some() {
+                break;
+            }
         }
+        self.pop_scope();
         Ok(())
     }
 }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -284,14 +284,12 @@ impl Evaluator {
                 )?;
 
                 let snapshot = self.environment.clone();
-                if let Some(scope) = self.environment.last_mut() {
-                    if let Some(crate::interpreter::evaluator::EnvironmentItem::PItem(p)) =
+                if let Some(scope) = self.environment.last_mut()
+                    && let Some(crate::interpreter::evaluator::EnvironmentItem::PItem(p)) =
                         scope.get_mut(name)
-                    {
-                        if let Value::Function { captured_env, .. } = &mut p.value {
-                            *captured_env = snapshot;
-                        }
-                    }
+                    && let Value::Function { captured_env, .. } = &mut p.value
+                {
+                    *captured_env = snapshot;
                 }
             }
 

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -274,6 +274,7 @@ impl Evaluator {
                     params: params.clone(),
                     body: body.clone(),
                     return_type: Some(return_type.clone()),
+                    captured_env: vec![],
                 };
                 self.insert_value(
                     name.clone(),
@@ -281,6 +282,17 @@ impl Evaluator {
                     crate::ast::statements::TypeAnnotation::Fn,
                     statement.span,
                 )?;
+
+                let snapshot = self.environment.clone();
+                if let Some(scope) = self.environment.last_mut() {
+                    if let Some(crate::interpreter::evaluator::EnvironmentItem::PItem(p)) =
+                        scope.get_mut(name)
+                    {
+                        if let Value::Function { captured_env, .. } = &mut p.value {
+                            *captured_env = snapshot;
+                        }
+                    }
+                }
             }
 
             StatementKind::Return(expr) => {

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -141,8 +141,31 @@ impl Evaluator {
                 }
             }
 
-            StatementKind::ForRange { .. } => {
-                return Ok(()); // for now
+            StatementKind::ForRange {
+                variable,
+                range,
+                body,
+            } => {
+                let items = match &range.kind {
+                    StatementKind::Range(items) => items.clone(),
+                    _ => {
+                        return Err(
+                            self.err("for-range: expected a range statement", statement.span)
+                        );
+                    }
+                };
+
+                for item in items {
+                    self.push_scope();
+                    self.insert_value(
+                        variable.clone(),
+                        Value::Integer(item),
+                        crate::ast::statements::TypeAnnotation::Int,
+                        statement.span,
+                    )?;
+                    self.evaluate_block(body)?;
+                    self.pop_scope();
+                }
             }
 
             StatementKind::ConditionalBranch { condition, body } => match condition {

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -11,7 +11,7 @@ impl Evaluator {
         match &statement.kind {
             StatementKind::VariableDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                self.insert_value(name.clone(), val, statement.span)?;
+                self.insert_value(name.clone(), val, None, statement.span)?;
             }
 
             StatementKind::Array { name, value, .. } => {
@@ -19,12 +19,12 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                self.insert_value(name.clone(), Value::Values(items), statement.span)?;
+                self.insert_value(name.clone(), Value::Values(items), None, statement.span)?;
             }
 
             StatementKind::ConstantDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                self.insert_const(name.clone(), val, statement.span)?;
+                self.insert_const(name.clone(), val, None, statement.span)?;
             }
 
             StatementKind::ConstantArray { name, value, .. } => {
@@ -32,7 +32,7 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                self.insert_const(name.clone(), Value::Values(items), statement.span)?;
+                self.insert_const(name.clone(), Value::Values(items), None, statement.span)?;
             }
 
             StatementKind::Expression(expr) => {
@@ -154,7 +154,7 @@ impl Evaluator {
                     params: params.clone(),
                     body: body.clone(),
                 };
-                self.insert_value(name.clone(), func.clone(), statement.span)?;
+                self.insert_value(name.clone(), func.clone(), None, statement.span)?;
             }
 
             StatementKind::Return(expr) => {

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -180,6 +180,46 @@ impl Evaluator {
                 }
             }
 
+            StatementKind::ForEach {
+                variable,
+                iterable,
+                body,
+            } => {
+                let arr = self.evaluate(iterable)?;
+                let items = match arr {
+                    Value::Values(items) => items,
+                    other => {
+                        return Err(self
+                            .err("for-each: expected an array", statement.span)
+                            .with_label(
+                                iterable.span,
+                                format!("this is {}, expected array", other.type_name()),
+                            ));
+                    }
+                };
+                for item in items {
+                    let item_type = Evaluator::infer_type(&item);
+                    self.push_scope();
+                    self.insert_value(variable.clone(), item, item_type, statement.span)?;
+
+                    self.evaluate_block(body)?;
+                    self.pop_scope();
+
+                    if self.is_breaking {
+                        self.is_breaking = false;
+                        break;
+                    }
+
+                    if self.is_continuing {
+                        self.is_continuing = false;
+                    }
+
+                    if self.return_value.is_some() {
+                        break;
+                    }
+                }
+            }
+
             StatementKind::ConditionalBranch { condition, body } => match condition {
                 Some(condition) => {
                     let v = self.evaluate(condition)?;

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -165,6 +165,18 @@ impl Evaluator {
                     )?;
                     self.evaluate_block(body)?;
                     self.pop_scope();
+
+                    if self.is_breaking {
+                        self.is_breaking = false;
+                    }
+
+                    if self.is_continuing {
+                        self.is_continuing = false;
+                    }
+
+                    if self.return_value.is_some() {
+                        break;
+                    }
                 }
             }
 

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -220,10 +220,16 @@ impl Evaluator {
                 }
             }
 
-            StatementKind::FunctionDeclaration { name, params, body } => {
+            StatementKind::FunctionDeclaration {
+                name,
+                params,
+                return_type,
+                body,
+            } => {
                 let func = Value::Function {
                     params: params.clone(),
                     body: body.clone(),
+                    return_type: Some(return_type.clone()),
                 };
                 self.insert_value(
                     name.clone(),

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ast::statements::{Statement, StatementKind, TypeAnnotation},
+    ast::statements::{Statement, StatementKind},
     interpreter::{evaluator::Evaluator, values::Value},
     utils::errors::Error,
 };
@@ -11,30 +11,7 @@ impl Evaluator {
         match &statement.kind {
             StatementKind::VariableDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                let inferred_type = match &val {
-                    Value::Integer(_) => TypeAnnotation::Int,
-                    Value::Float(_) => TypeAnnotation::Float,
-                    Value::String(_) => TypeAnnotation::String,
-                    Value::Bool(_) => TypeAnnotation::Bool,
-                    Value::Char(_) => TypeAnnotation::Char,
-                    Value::Values(items) => {
-                        let inner = items
-                            .first()
-                            .map(|v| match v {
-                                Value::Integer(_) => TypeAnnotation::Int,
-                                Value::Float(_) => TypeAnnotation::Float,
-                                Value::String(_) => TypeAnnotation::String,
-                                Value::Bool(_) => TypeAnnotation::Bool,
-                                Value::Char(_) => TypeAnnotation::Char,
-                                _ => TypeAnnotation::Null,
-                            })
-                            .unwrap_or(TypeAnnotation::Null);
-                        TypeAnnotation::Array(Box::new(inner))
-                    }
-                    Value::Null => TypeAnnotation::Null,
-                    Value::Function { .. } => TypeAnnotation::Fn,
-                };
-
+                let inferred_type = Evaluator::infer_type(&val);
                 self.insert_value(name.clone(), val, inferred_type, statement.span)?;
             }
 
@@ -43,47 +20,13 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                let inner = items
-                    .first()
-                    .map(|v| match v {
-                        Value::Integer(_) => TypeAnnotation::Int,
-                        Value::Float(_) => TypeAnnotation::Float,
-                        Value::String(_) => TypeAnnotation::String,
-                        Value::Bool(_) => TypeAnnotation::Bool,
-                        Value::Char(_) => TypeAnnotation::Char,
-                        _ => TypeAnnotation::Null,
-                    })
-                    .unwrap_or(TypeAnnotation::Null);
-                let arr_type = TypeAnnotation::Array(Box::new(inner));
+                let arr_type = Evaluator::infer_type(&Value::Values(items.clone()));
                 self.insert_value(name.clone(), Value::Values(items), arr_type, statement.span)?;
             }
 
             StatementKind::ConstantDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                let inferred_type = match &val {
-                    Value::Integer(_) => TypeAnnotation::Int,
-                    Value::Float(_) => TypeAnnotation::Float,
-                    Value::String(_) => TypeAnnotation::String,
-                    Value::Bool(_) => TypeAnnotation::Bool,
-                    Value::Char(_) => TypeAnnotation::Char,
-                    Value::Values(items) => {
-                        let inner = items
-                            .first()
-                            .map(|v| match v {
-                                Value::Integer(_) => TypeAnnotation::Int,
-                                Value::Float(_) => TypeAnnotation::Float,
-                                Value::String(_) => TypeAnnotation::String,
-                                Value::Bool(_) => TypeAnnotation::Bool,
-                                Value::Char(_) => TypeAnnotation::Char,
-                                _ => TypeAnnotation::Null,
-                            })
-                            .unwrap_or(TypeAnnotation::Null);
-                        TypeAnnotation::Array(Box::new(inner))
-                    }
-                    Value::Null => TypeAnnotation::Null,
-                    Value::Function { .. } => TypeAnnotation::Fn,
-                };
-
+                let inferred_type = Evaluator::infer_type(&val);
                 self.insert_const(name.clone(), val, inferred_type, statement.span)?;
             }
 
@@ -92,23 +35,14 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                let inner = items
-                    .first()
-                    .map(|v| match v {
-                        Value::Integer(_) => TypeAnnotation::Int,
-                        Value::Float(_) => TypeAnnotation::Float,
-                        Value::String(_) => TypeAnnotation::String,
-                        Value::Bool(_) => TypeAnnotation::Bool,
-                        Value::Char(_) => TypeAnnotation::Char,
-                        _ => TypeAnnotation::Null,
-                    })
-                    .unwrap_or(TypeAnnotation::Null);
-                let arr_type = TypeAnnotation::Array(Box::new(inner));
+                let arr_type = Evaluator::infer_type(&Value::Values(items.clone()));
                 self.insert_const(name.clone(), Value::Values(items), arr_type, statement.span)?;
             }
+
             StatementKind::Expression(expr) => {
                 self.evaluate(expr)?;
             }
+
             StatementKind::While { condition, body } => loop {
                 let v = self.evaluate(condition)?;
                 match v {
@@ -125,7 +59,9 @@ impl Evaluator {
                 }
                 self.evaluate_block(body)?;
             },
+
             StatementKind::Range(..) => {}
+
             StatementKind::For {
                 initializer,
                 condition,
@@ -152,6 +88,7 @@ impl Evaluator {
                 }
                 self.pop_scope();
             }
+
             StatementKind::Import { names, path } => {
                 // imports are resolved at parse time; nothing to evaluate
                 // or thats what i though
@@ -174,9 +111,11 @@ impl Evaluator {
                     self.root_module.functions.insert(name, f);
                 }
             }
+
             StatementKind::ForRange { .. } => {
                 return Ok(()); // for now
             }
+
             StatementKind::ConditionalBranch { condition, body } => match condition {
                 Some(condition) => {
                     let v = self.evaluate(condition)?;
@@ -198,6 +137,7 @@ impl Evaluator {
                     self.evaluate_block(body)?;
                 }
             },
+
             StatementKind::Conditional {
                 if_branch,
                 elseif_branch,
@@ -233,8 +173,8 @@ impl Evaluator {
                 };
                 self.insert_value(
                     name.clone(),
-                    func.clone(),
-                    TypeAnnotation::Fn,
+                    func,
+                    crate::ast::statements::TypeAnnotation::Fn,
                     statement.span,
                 )?;
             }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    ast::statements::{Statement, StatementKind},
+    ast::statements::{Statement, StatementKind, TypeAnnotation},
     interpreter::{evaluator::Evaluator, values::Value},
     utils::errors::Error,
 };
@@ -11,7 +11,31 @@ impl Evaluator {
         match &statement.kind {
             StatementKind::VariableDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                self.insert_value(name.clone(), val, None, statement.span)?;
+                let inferred_type = match &val {
+                    Value::Integer(_) => TypeAnnotation::Int,
+                    Value::Float(_) => TypeAnnotation::Float,
+                    Value::String(_) => TypeAnnotation::String,
+                    Value::Bool(_) => TypeAnnotation::Bool,
+                    Value::Char(_) => TypeAnnotation::Char,
+                    Value::Values(items) => {
+                        let inner = items
+                            .first()
+                            .map(|v| match v {
+                                Value::Integer(_) => TypeAnnotation::Int,
+                                Value::Float(_) => TypeAnnotation::Float,
+                                Value::String(_) => TypeAnnotation::String,
+                                Value::Bool(_) => TypeAnnotation::Bool,
+                                Value::Char(_) => TypeAnnotation::Char,
+                                _ => TypeAnnotation::Null,
+                            })
+                            .unwrap_or(TypeAnnotation::Null);
+                        TypeAnnotation::Array(Box::new(inner))
+                    }
+                    Value::Null => TypeAnnotation::Null,
+                    Value::Function { .. } => TypeAnnotation::Fn,
+                };
+
+                self.insert_value(name.clone(), val, inferred_type, statement.span)?;
             }
 
             StatementKind::Array { name, value, .. } => {
@@ -19,12 +43,48 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                self.insert_value(name.clone(), Value::Values(items), None, statement.span)?;
+                let inner = items
+                    .first()
+                    .map(|v| match v {
+                        Value::Integer(_) => TypeAnnotation::Int,
+                        Value::Float(_) => TypeAnnotation::Float,
+                        Value::String(_) => TypeAnnotation::String,
+                        Value::Bool(_) => TypeAnnotation::Bool,
+                        Value::Char(_) => TypeAnnotation::Char,
+                        _ => TypeAnnotation::Null,
+                    })
+                    .unwrap_or(TypeAnnotation::Null);
+                let arr_type = TypeAnnotation::Array(Box::new(inner));
+                self.insert_value(name.clone(), Value::Values(items), arr_type, statement.span)?;
             }
 
             StatementKind::ConstantDeclaration { name, value, .. } => {
                 let val = self.evaluate(value)?;
-                self.insert_const(name.clone(), val, None, statement.span)?;
+                let inferred_type = match &val {
+                    Value::Integer(_) => TypeAnnotation::Int,
+                    Value::Float(_) => TypeAnnotation::Float,
+                    Value::String(_) => TypeAnnotation::String,
+                    Value::Bool(_) => TypeAnnotation::Bool,
+                    Value::Char(_) => TypeAnnotation::Char,
+                    Value::Values(items) => {
+                        let inner = items
+                            .first()
+                            .map(|v| match v {
+                                Value::Integer(_) => TypeAnnotation::Int,
+                                Value::Float(_) => TypeAnnotation::Float,
+                                Value::String(_) => TypeAnnotation::String,
+                                Value::Bool(_) => TypeAnnotation::Bool,
+                                Value::Char(_) => TypeAnnotation::Char,
+                                _ => TypeAnnotation::Null,
+                            })
+                            .unwrap_or(TypeAnnotation::Null);
+                        TypeAnnotation::Array(Box::new(inner))
+                    }
+                    Value::Null => TypeAnnotation::Null,
+                    Value::Function { .. } => TypeAnnotation::Fn,
+                };
+
+                self.insert_const(name.clone(), val, inferred_type, statement.span)?;
             }
 
             StatementKind::ConstantArray { name, value, .. } => {
@@ -32,9 +92,20 @@ impl Evaluator {
                 for item in value {
                     items.push(self.evaluate(item)?);
                 }
-                self.insert_const(name.clone(), Value::Values(items), None, statement.span)?;
+                let inner = items
+                    .first()
+                    .map(|v| match v {
+                        Value::Integer(_) => TypeAnnotation::Int,
+                        Value::Float(_) => TypeAnnotation::Float,
+                        Value::String(_) => TypeAnnotation::String,
+                        Value::Bool(_) => TypeAnnotation::Bool,
+                        Value::Char(_) => TypeAnnotation::Char,
+                        _ => TypeAnnotation::Null,
+                    })
+                    .unwrap_or(TypeAnnotation::Null);
+                let arr_type = TypeAnnotation::Array(Box::new(inner));
+                self.insert_const(name.clone(), Value::Values(items), arr_type, statement.span)?;
             }
-
             StatementKind::Expression(expr) => {
                 self.evaluate(expr)?;
             }
@@ -154,7 +225,12 @@ impl Evaluator {
                     params: params.clone(),
                     body: body.clone(),
                 };
-                self.insert_value(name.clone(), func.clone(), None, statement.span)?;
+                self.insert_value(
+                    name.clone(),
+                    func.clone(),
+                    TypeAnnotation::Fn,
+                    statement.span,
+                )?;
             }
 
             StatementKind::Return(expr) => {

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -58,6 +58,19 @@ impl Evaluator {
                     }
                 }
                 self.evaluate_block(body)?;
+
+                if self.is_breaking {
+                    self.is_breaking = false;
+                    break;
+                }
+
+                if self.is_continuing {
+                    self.is_continuing = false;
+                }
+
+                if self.return_value.is_some() {
+                    break;
+                }
             },
 
             StatementKind::Range(..) => {}
@@ -84,6 +97,22 @@ impl Evaluator {
                         }
                     }
                     self.evaluate_block(body)?;
+
+                    if self.is_breaking {
+                        self.is_breaking = false;
+                        break;
+                    }
+
+                    if self.is_continuing {
+                        self.is_continuing = false;
+                        self.evaluate(increment)?;
+                        continue;
+                    }
+
+                    if self.return_value.is_some() {
+                        break;
+                    }
+
                     self.evaluate(increment)?;
                 }
                 self.pop_scope();
@@ -187,6 +216,14 @@ impl Evaluator {
 
                 self.return_value = Some(value);
             }
+
+            StatementKind::Break => {
+                self.is_breaking = true;
+            }
+
+            StatementKind::Continue => {
+                self.is_continuing = true;
+            }
         }
         Ok(())
     }
@@ -223,7 +260,7 @@ impl Evaluator {
         self.push_scope();
         for statement in statements {
             self.evaluate_statement(statement)?;
-            if self.return_value.is_some() {
+            if self.return_value.is_some() || self.is_breaking || self.is_continuing {
                 break;
             }
         }

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::ast::statements::Statement;
+
 #[derive(Debug, Clone)]
 pub enum Value {
     Integer(i64),
@@ -9,6 +11,10 @@ pub enum Value {
     Char(char),
     Values(Vec<Value>),
     Null,
+    Function {
+        params: Vec<String>,
+        body: Vec<Statement>,
+    },
 }
 
 impl Value {
@@ -22,6 +28,7 @@ impl Value {
             Value::Char(_) => "char",
             Value::Values(_) => "array",
             Value::Null => "null",
+            Value::Function { .. } => "function",
         }
     }
 }
@@ -39,6 +46,7 @@ impl fmt::Display for Value {
                 write!(f, "[{}]", formatted.join(", "))
             }
             Value::Null => write!(f, "null"),
+            Value::Function { params, .. } => write!(f, "<fn({})>", params.join(", ")),
         }
     }
 }

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::ast::statements::Statement;
+use crate::ast::statements::{Param, Statement};
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -12,7 +12,7 @@ pub enum Value {
     Values(Vec<Value>),
     Null,
     Function {
-        params: Vec<String>,
+        params: Vec<Param>,
         body: Vec<Statement>,
     },
 }
@@ -46,7 +46,13 @@ impl fmt::Display for Value {
                 write!(f, "[{}]", formatted.join(", "))
             }
             Value::Null => write!(f, "null"),
-            Value::Function { params, .. } => write!(f, "<fn({})>", params.join(", ")),
+            Value::Function { params, .. } => {
+                let mut params_name = vec![];
+                for param in params {
+                    params_name.push(param.param_name.clone());
+                }
+                write!(f, "<fn({})>", params_name.join(", "))
+            }
         }
     }
 }

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
-use crate::ast::statements::{Param, Statement, TypeAnnotation};
+use crate::{
+    ast::statements::{Param, Statement, TypeAnnotation},
+    interpreter::evaluator::EnvironmentItem,
+};
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -15,6 +18,7 @@ pub enum Value {
         params: Vec<Param>,
         body: Vec<Statement>,
         return_type: Option<TypeAnnotation>,
+        captured_env: Vec<std::collections::HashMap<String, EnvironmentItem>>,
     },
 }
 

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::ast::statements::{Param, Statement};
+use crate::ast::statements::{Param, Statement, TypeAnnotation};
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -14,6 +14,7 @@ pub enum Value {
     Function {
         params: Vec<Param>,
         body: Vec<Statement>,
+        return_type: Option<TypeAnnotation>,
     },
 }
 

--- a/src/lexer/scanner.rs
+++ b/src/lexer/scanner.rs
@@ -102,6 +102,9 @@ impl Tokenizer {
                 if self.peek() == '=' {
                     self.advance();
                     self.add_token(TokenType::MinusEqual);
+                } else if self.peek() == '>' {
+                    self.advance();
+                    self.add_token(TokenType::Arrow);
                 } else {
                     self.add_token(TokenType::Minus);
                 }

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -50,6 +50,7 @@ impl Tokenizer {
             Span::new(eof_char_index, eof_char_index),
         ));
 
+        #[cfg(feature = "debug")]
         log::debug!("Recognized {} token(s)", lexer.tokens.len());
         Ok(lexer.tokens)
     }

--- a/src/lexer/tokentypes.rs
+++ b/src/lexer/tokentypes.rs
@@ -66,6 +66,8 @@ pub enum TokenType {
     Char,
     Array,
 
+    Arrow,
+
     Newline,
 
     Eof,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 pub mod ast;
+#[cfg(feature = "eval")]
 pub mod interpreter;
 pub mod lexer;
 pub mod logic_loops;
 pub mod parser;
+#[cfg(feature = "repl_tui")]
 pub mod repl;
+#[cfg(feature = "repl_terminal")]
 pub mod repl_terminal;
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod ast;
 pub mod interpreter;
 pub mod lexer;
+pub mod logic_loops;
 pub mod parser;
 pub mod repl;
+pub mod repl_terminal;
 pub mod utils;

--- a/src/logic_loops.rs
+++ b/src/logic_loops.rs
@@ -13,16 +13,16 @@ use super::{
     utils::source::SourceFile,
 };
 
-pub fn validate_source_arg(arguments: &[String]) -> Result<String, ()> {
+pub fn validate_source_arg(arguments: &[String]) -> Result<String, &'static str> {
     let path = arguments.get(2).ok_or_else(|| {
         Error::init(
             "no source file provided".to_string(),
             None,
             Some(ErrorReason::init(Reason::Compile, None)),
         )
-        .print_error()
+        .print_error();
+        "no source file provided"
     })?;
-
     if !path.ends_with(".rl") {
         Error::init(
             "file extension is not .rl".to_string(),
@@ -30,45 +30,40 @@ pub fn validate_source_arg(arguments: &[String]) -> Result<String, ()> {
             Some(ErrorReason::init(Reason::Compile, None)),
         )
         .print_error();
-        return Err(());
+        return Err("file extension is not .rl");
     }
-
     std::fs::read_to_string(path).map_err(|_| {
         Error::init(
             "failed to read file".to_string(),
             None,
             Some(ErrorReason::init(Reason::Compile, None)),
         )
-        .print_error()
+        .print_error();
+        "failed to read file"
     })
 }
-
 pub fn lexing_loop(source: SourceFile) -> Vec<Token> {
     #[cfg(feature = "debug")]
     info!("lexing the source file...");
-    let tokens = match Tokenizer::lex(source.clone()) {
+    match Tokenizer::lex(source.clone()) {
         Ok(t) => t,
         Err(e) => {
             e.report_to_stderr();
             std::process::exit(1);
         }
-    };
-
-    tokens
+    }
 }
 
 pub fn parsing_loop(source: SourceFile, tokens: Vec<Token>) -> Vec<Statement> {
     #[cfg(feature = "debug")]
     info!("parsing the tokens into ast tree...");
-    let statements = match Parser::parse(tokens, source.clone()) {
+    match Parser::parse(tokens, source.clone()) {
         Ok(s) => s,
         Err(e) => {
             e.report_to_stderr();
             std::process::exit(1);
         }
-    };
-
-    statements
+    }
 }
 
 #[cfg(feature = "eval")]

--- a/src/logic_loops.rs
+++ b/src/logic_loops.rs
@@ -1,0 +1,88 @@
+#[cfg(feature = "debug")]
+use log::{debug, info};
+
+use crate::utils::errors::{Error, ErrorReason, Reason};
+
+#[cfg(feature = "eval")]
+use super::interpreter::evaluator::Evaluator;
+
+use super::{
+    ast::statements::Statement,
+    lexer::{tokenizer::Tokenizer, tokentypes::Token},
+    parser::parser_logic::Parser,
+    utils::source::SourceFile,
+};
+
+pub fn validate_source_arg(arguments: &[String]) -> Result<String, ()> {
+    let path = arguments.get(2).ok_or_else(|| {
+        Error::init(
+            "no source file provided".to_string(),
+            None,
+            Some(ErrorReason::init(Reason::Compile, None)),
+        )
+        .print_error()
+    })?;
+
+    if !path.ends_with(".rl") {
+        Error::init(
+            "file extension is not .rl".to_string(),
+            None,
+            Some(ErrorReason::init(Reason::Compile, None)),
+        )
+        .print_error();
+        return Err(());
+    }
+
+    std::fs::read_to_string(path).map_err(|_| {
+        Error::init(
+            "failed to read file".to_string(),
+            None,
+            Some(ErrorReason::init(Reason::Compile, None)),
+        )
+        .print_error()
+    })
+}
+
+pub fn lexing_loop(source: SourceFile) -> Vec<Token> {
+    #[cfg(feature = "debug")]
+    info!("lexing the source file...");
+    let tokens = match Tokenizer::lex(source.clone()) {
+        Ok(t) => t,
+        Err(e) => {
+            e.report_to_stderr();
+            std::process::exit(1);
+        }
+    };
+
+    tokens
+}
+
+pub fn parsing_loop(source: SourceFile, tokens: Vec<Token>) -> Vec<Statement> {
+    #[cfg(feature = "debug")]
+    info!("parsing the tokens into ast tree...");
+    let statements = match Parser::parse(tokens, source.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            e.report_to_stderr();
+            std::process::exit(1);
+        }
+    };
+
+    statements
+}
+
+#[cfg(feature = "eval")]
+pub fn eval_loop(source: SourceFile, statements: Vec<Statement>) {
+    #[cfg(feature = "debug")]
+    info!("evaluating the ast tree...");
+    let mut evaluator = Evaluator::default().with_stdlib().with_source_file(source);
+    for statement in statements {
+        if let Err(e) = evaluator.evaluate_statement(&statement) {
+            e.report_to_stderr();
+            std::process::exit(1);
+        }
+    }
+
+    #[cfg(feature = "debug")]
+    info!("evaluation done");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,10 @@ use rl_lang::utils::{
 };
 
 #[cfg(feature = "repl_tui")]
-use rl_lang::repl::start_repl;
+use rl_lang::repl;
 
 #[cfg(feature = "repl_terminal")]
-use rl_lang::repl_terminal::repl;
+use rl_lang::repl_terminal;
 
 /// entry point for `rl` interpreter
 ///
@@ -53,12 +53,13 @@ fn main() {
         if cfg!(feature = "repl_tui") {
             #[cfg(feature = "debug")]
             log::info!("starting repl TUI");
-            start_repl();
+            repl::start_repl();
         } else if cfg!(feature = "repl_terminal") {
             #[cfg(feature = "debug")]
             log::info!("starting repl terminal shell");
             println!("[Starting REPL shell]");
-            start_repl();
+            #[cfg(feature = "repl_terminal")]
+            repl_terminal::start_repl();
         }
         return;
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,18 @@
+#[cfg(feature = "debug")]
 use log::{debug, info};
-use rl_lang::{
-    interpreter::evaluator::Evaluator,
-    lexer::tokenizer::Tokenizer,
-    parser::parser_logic::Parser,
-    repl,
-    utils::{
-        errors::{Error, ErrorReason, Reason},
-        source::SourceFile,
-    },
+
+use rl_lang::logic_loops::{eval_loop, lexing_loop, parsing_loop, validate_source_arg};
+
+use rl_lang::utils::{
+    errors::{Error, ErrorReason, Reason},
+    source::SourceFile,
 };
+
+#[cfg(feature = "repl_tui")]
+use rl_lang::repl::start_repl;
+
+#[cfg(feature = "repl_terminal")]
+use rl_lang::repl_terminal::repl;
 
 /// entry point for `rl` interpreter
 ///
@@ -23,32 +27,41 @@ use rl_lang::{
 /// 3. **evaluating**
 fn main() {
     // initializing the logger
+    #[cfg(feature = "debug")]
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Debug)
         .target(env_logger::Target::Pipe(Box::new(
             std::fs::File::create("log.txt").unwrap(),
         )))
         .init();
+    #[cfg(feature = "debug")]
     info!("logger initialized");
 
     // arguments
+    #[cfg(feature = "debug")]
     info!("reading arguments");
+
     let arguments: Vec<String> = std::env::args().collect();
+
+    #[cfg(feature = "debug")]
     debug!("used arguments [{:?}]", arguments);
-    if arguments.len() == 3 && arguments[1] != "run" {
-        eprintln!("Usage: rlp run <source-file.rl>");
-        return;
-    } else if arguments.len() == 3 && arguments[1] == "run" {
+
+    if cfg!(feature = "run") && arguments[1] == "run" {
+        #[cfg(feature = "debug")]
         log::info!("starting the interpreter");
-    } else if arguments.len() == 2 && arguments[1] == "repl" {
-        log::info!("starting repl shell");
-        println!("[Starting REPL shell]");
-        repl::repl();
+    } else if cfg!(feature = "repl") && arguments.len() == 2 && arguments[1] == "repl" {
+        if cfg!(feature = "repl_tui") {
+            #[cfg(feature = "debug")]
+            log::info!("starting repl TUI");
+            start_repl();
+        } else if cfg!(feature = "repl_terminal") {
+            #[cfg(feature = "debug")]
+            log::info!("starting repl terminal shell");
+            println!("[Starting REPL shell]");
+            start_repl();
+        }
         return;
     } else {
-        log::info!("falling back to repl");
-        println!("[Starting REPL shell]");
-        repl::repl();
         return;
     }
 
@@ -63,53 +76,19 @@ fn main() {
         return;
     }
 
-    let source_file = match std::fs::read_to_string(&arguments[2]) {
-        Ok(file) => file,
-
-        Err(_) => {
-            Error::init(
-                "failed to read file".to_string(),
-                None,
-                Some(ErrorReason::init(Reason::Compile, None)),
-            )
-            .print_error();
-            return;
-        }
-    };
+    let source_file = validate_source_arg(&arguments).unwrap_or_else(|_| std::process::exit(1));
 
     println!("[Parsing source file: {}]", arguments[2]);
     let source = SourceFile::new(arguments[2].as_str(), source_file);
 
     // phase one: lexing the source file into tokens
-    info!("lexing the source file...");
-    let tokens = match Tokenizer::lex(source.clone()) {
-        Ok(t) => t,
-        Err(e) => {
-            e.report_to_stderr();
-            std::process::exit(1);
-        }
-    };
+    let tokens = lexing_loop(source.clone());
 
     // phase two: parsing the tokens into ast tree
-    info!("parsing the tokens into ast tree...");
-    let statements = match Parser::parse(tokens, source.clone()) {
-        Ok(s) => s,
-        Err(e) => {
-            e.report_to_stderr();
-            std::process::exit(1);
-        }
-    };
+    let statements = parsing_loop(source.clone(), tokens);
 
     // phase three: evaluating the ast tree
-    info!("evaluating the ast tree...");
-    let mut evaluator = Evaluator::default()
-        .with_stdlib()
-        .with_source_file(source);
-    for statement in statements {
-        if let Err(e) = evaluator.evaluate_statement(&statement) {
-            e.report_to_stderr();
-            std::process::exit(1);
-        }
+    if cfg!(feature = "eval") {
+        eval_loop(source, statements);
     }
-    info!("evaluation done")
 }

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -252,6 +252,28 @@ impl Parser {
                         );
                     }
 
+                    // is it a call on the result of an index, e.g. fns[0](arg)?
+                    if self.match_type(&[TokenType::LeftParen]) {
+                        let mut args = Vec::new();
+                        if self.peek() != TokenType::RightParen {
+                            loop {
+                                args.push(self.parse_expression()?);
+                                if !self.match_type(&[TokenType::Comma]) {
+                                    break;
+                                }
+                            }
+                        }
+                        self.match_type(&[TokenType::RightParen]);
+                        let span = start.join(self.previous_span());
+                        return Ok(Expression::new(
+                            ExpressionKind::CallExpr {
+                                callee: Box::new(expr),
+                                args,
+                            },
+                            span,
+                        ));
+                    }
+
                     // is it index-assign?
                     if self.match_type(&[TokenType::Assign]) {
                         log::debug!("found array item assignment");

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -158,13 +158,16 @@ impl Parser {
     }
 
     pub fn parse_primary(&mut self) -> Result<Expression, Error> {
+        #[cfg(feature = "debug")]
         log::debug!("current index: {:?}", self.current);
+        #[cfg(feature = "debug")]
         log::debug!("current token: {:?}", self.peek());
 
         let start = self.peek_span();
 
         // is it identifier
         if self.match_type(&[TokenType::Identifier(String::new())]) {
+            #[cfg(feature = "debug")]
             log::debug!("found identifier");
             let ident_span = self.previous_span();
             if let TokenType::Identifier(first) = self.previous() {
@@ -182,6 +185,7 @@ impl Parser {
 
                 // is it function call?
                 if self.match_type(&[TokenType::LeftParen]) {
+                    #[cfg(feature = "debug")]
                     log::debug!("found function call");
                     let mut args = Vec::new();
                     if !(std::mem::discriminant(&self.peek())
@@ -210,6 +214,7 @@ impl Parser {
 
                 // is it assignment?
                 if self.match_type(&[TokenType::Assign]) {
+                    #[cfg(feature = "debug")]
                     log::debug!("found variable assignment");
                     let value = self.parse_expression()?;
                     let span = start.join(value.span);
@@ -276,6 +281,7 @@ impl Parser {
 
                     // is it index-assign?
                     if self.match_type(&[TokenType::Assign]) {
+                        #[cfg(feature = "debug")]
                         log::debug!("found array item assignment");
                         let value = self.parse_expression()?;
                         let span = start.join(value.span);
@@ -318,6 +324,7 @@ impl Parser {
         }
         // is it integer?
         if self.match_type(&[TokenType::NumberLiteral(0)]) {
+            #[cfg(feature = "debug")]
             log::debug!("found number");
             let span = self.previous_span();
             if let TokenType::NumberLiteral(n) = self.previous() {
@@ -327,6 +334,7 @@ impl Parser {
 
         // is it String?
         if self.match_type(&[TokenType::StringLiteral(String::new())]) {
+            #[cfg(feature = "debug")]
             log::debug!("found string");
             let span = self.previous_span();
             if let TokenType::StringLiteral(s) = self.previous() {
@@ -340,6 +348,7 @@ impl Parser {
             TokenType::CharacterLiteral(_)
         ) {
             self.advance();
+            #[cfg(feature = "debug")]
             log::debug!("found characher");
             let span = self.previous_span();
             if let TokenType::CharacterLiteral(c) = self.previous() {
@@ -357,6 +366,7 @@ impl Parser {
 
         // is it float??
         if self.match_type(&[TokenType::FloatLiteral(0.0)]) {
+            #[cfg(feature = "debug")]
             log::debug!("oh no found float");
             let span = self.previous_span();
             if let TokenType::FloatLiteral(f) = self.previous() {
@@ -372,6 +382,7 @@ impl Parser {
 
         // is it (Expression)?
         if self.match_type(&[TokenType::LeftParen]) {
+            #[cfg(feature = "debug")]
             log::debug!("found group start");
             let inner = self.parse_expression()?;
             self.match_type(&[TokenType::RightParen]);

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -360,6 +360,49 @@ impl Parser {
             ));
         }
 
+        // is it lambda?
+        if self.match_type(&[TokenType::Fn]) {
+            let lambda_start = self.previous_span();
+            self.match_type(&[TokenType::LeftParen]);
+
+            let mut params: Vec<crate::ast::statements::Param> = Vec::new();
+            while !self.match_type(&[TokenType::RightParen]) {
+                let param_type = self.parse_param_type()?;
+                let param_name = match self.peek() {
+                    TokenType::Identifier(n) => {
+                        self.advance();
+                        n
+                    }
+                    _ => return Err(self.err("expected parameter name", self.peek_span())),
+                };
+                params.push(crate::ast::statements::Param {
+                    param_name,
+                    param_type,
+                });
+                if !self.match_type(&[TokenType::Comma]) {
+                    break;
+                }
+            }
+            self.match_type(&[TokenType::RightParen]);
+
+            let return_type = if self.match_type(&[TokenType::Arrow]) {
+                Some(self.parse_param_type()?)
+            } else {
+                None
+            };
+
+            let body = self.parse_block()?;
+            let span = lambda_start.join(self.previous_span());
+            return Ok(Expression::new(
+                ExpressionKind::Lambda {
+                    params,
+                    return_type,
+                    body,
+                },
+                span,
+            ));
+        }
+
         Err(self.err("expected expression", self.peek_span()))
     }
 }

--- a/src/parser/parser_logic.rs
+++ b/src/parser/parser_logic.rs
@@ -26,6 +26,8 @@ impl Parser {
             tokens,
             current: 0,
         };
+
+        #[cfg(feature = "debug")]
         log::info!("parser initialized");
         let mut statements = Vec::new();
 
@@ -33,6 +35,7 @@ impl Parser {
             statements.push(parser.parse_statement_to_ast()?);
         }
 
+        #[cfg(feature = "debug")]
         log::info!("parsing complete");
         Ok(statements)
     }

--- a/src/parser/statements/const_declaration.rs
+++ b/src/parser/statements/const_declaration.rs
@@ -7,7 +7,9 @@ use crate::{
 
 impl Parser {
     pub fn parse_const_declartion(&mut self, start: Span) -> Result<Statement, Error> {
+        #[cfg(feature = "debug")]
         log::debug!("{:?}", self.peek());
+        #[cfg(feature = "debug")]
         log::debug!("parsing type");
         if self.match_type(&[TokenType::Array]) && self.peek() == TokenType::LeftBracket {
             self.advance();

--- a/src/parser/statements/for_statement.rs
+++ b/src/parser/statements/for_statement.rs
@@ -76,7 +76,23 @@ impl Parser {
                 let span = start.join(self.previous_span());
                 Box::new(Statement::new(StatementKind::Range(iterable_list), span))
             } else {
-                return Err(self.err("expected range or array", self.peek_span()));
+                if matches!(self.peek(), TokenType::Identifier(_)) {
+                    let iterable_expression = self.parse_expression()?;
+                    let body = self.parse_block()?;
+                    let span = start.join(self.previous_span());
+                    return Ok(Statement::new(
+                        StatementKind::ForEach {
+                            variable: variable_name,
+                            iterable: iterable_expression,
+                            body,
+                        },
+                        span,
+                    ));
+                }
+                return Err(self.err(
+                    "expected range (e.g. 1..10), array literal ([1, 2, 3], or array variable",
+                    self.peek_span(),
+                ));
             };
 
             let body = self.parse_block()?;

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -30,6 +30,44 @@ impl Parser {
         // parameters
         let mut params = Vec::new();
         while !self.match_type(&[TokenType::RightParen]) {
+            fn nested_array(env: &mut Parser) -> Result<(), Error> {
+                if !env.match_type(&[TokenType::LeftBracket]) {
+                    return Err(env.err("expected '[' after arr", env.peek_span()));
+                }
+
+                if matches!(env.peek(), TokenType::Array) {
+                    env.advance();
+                    nested_array(env)?;
+                } else if !env.match_type(&[
+                    TokenType::Int,
+                    TokenType::Float,
+                    TokenType::Bool,
+                    TokenType::Char,
+                    TokenType::String,
+                ]) {
+                    return Err(env.err("expected parameter type", env.peek_span()));
+                }
+
+                if !env.match_type(&[TokenType::RightBracket]) {
+                    return Err(env.err("expected ']' after type", env.peek_span()));
+                }
+
+                Ok(())
+            }
+
+            if matches!(self.peek(), TokenType::Array) {
+                self.advance();
+                nested_array(self)?;
+            } else if !self.match_type(&[
+                TokenType::Int,
+                TokenType::Float,
+                TokenType::Bool,
+                TokenType::Char,
+                TokenType::String,
+            ]) {
+                return Err(self.err("expected parameter type", self.peek_span()));
+            }
+
             match self.peek() {
                 TokenType::Identifier(p) => {
                     self.advance();

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -36,7 +36,7 @@ impl Parser {
                     self.advance();
                     params.push(Param {
                         param_name: p,
-                        param_type: param_type,
+                        param_type,
                     });
                 }
                 _ => return Err(self.err("expected parameter name", self.peek_span())),
@@ -66,7 +66,7 @@ impl Parser {
             StatementKind::FunctionDeclaration {
                 name,
                 params,
-                return_type: return_type,
+                return_type,
                 body,
             },
             span,

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -1,0 +1,62 @@
+use crate::{
+    ast::statements::{Statement, StatementKind},
+    lexer::tokentypes::TokenType,
+    parser::parser_logic::Parser,
+    utils::{errors::Error, span::Span},
+};
+
+impl Parser {
+    // fn name(param1, param2) {
+    //     body
+    // }
+    //
+    // fn name(param1, param2) -> int {   ← return type ignored for now
+    //     body
+    // }
+
+    pub fn parse_function(&mut self, start: Span) -> Result<Statement, Error> {
+        // function name
+        let name = match self.peek() {
+            TokenType::Identifier(n) => {
+                self.advance();
+                n
+            }
+            _ => return Err(self.err("expected function name", self.peek_span())),
+        };
+
+        // opening paren
+        self.match_type(&[TokenType::LeftParen]);
+
+        // parameters
+        let mut params = Vec::new();
+        while !self.match_type(&[TokenType::RightParen]) {
+            match self.peek() {
+                TokenType::Identifier(p) => {
+                    self.advance();
+                    params.push(p);
+                }
+                _ => return Err(self.err("expected parameter name", self.peek_span())),
+            }
+            if !self.match_type(&[TokenType::Comma]) {
+                break;
+            }
+        }
+        self.match_type(&[TokenType::RightParen]);
+
+        // optional return type annotation — skip it for now
+        if self.match_type(&[TokenType::Arrow]) {
+            // consume the type token (int, float, str, etc.)
+            self.advance();
+        }
+
+        // body
+
+        let body = self.parse_block()?;
+
+        let span = start.join(self.previous_span());
+        Ok(Statement::new(
+            StatementKind::FunctionDeclaration { name, params, body },
+            span,
+        ))
+    }
+}

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -27,83 +27,10 @@ impl Parser {
         // opening paren
         self.match_type(&[TokenType::LeftParen]);
 
-        fn nested_array(env: &mut Parser) -> Result<Box<TypeAnnotation>, Error> {
-            if !env.match_type(&[TokenType::LeftBracket]) {
-                return Err(env.err("expected '[' after arr", env.peek_span()));
-            }
-
-            let param_type = if matches!(env.peek(), TokenType::Array) {
-                env.advance();
-                Box::new(TypeAnnotation::Array(nested_array(env)?))
-            } else {
-                match env.peek() {
-                    TokenType::Int => {
-                        env.advance();
-                        Box::new(TypeAnnotation::Int)
-                    }
-                    TokenType::Float => {
-                        env.advance();
-                        Box::new(TypeAnnotation::Float)
-                    }
-                    TokenType::Bool => {
-                        env.advance();
-                        Box::new(TypeAnnotation::Bool)
-                    }
-                    TokenType::String => {
-                        env.advance();
-                        Box::new(TypeAnnotation::String)
-                    }
-                    TokenType::Char => {
-                        env.advance();
-                        Box::new(TypeAnnotation::Char)
-                    }
-                    _ => {
-                        return Err(env.err("expected parameter type", env.peek_span()));
-                    }
-                }
-            };
-
-            if !env.match_type(&[TokenType::RightBracket]) {
-                return Err(env.err("expected ']' after type", env.peek_span()));
-            }
-
-            Ok(param_type)
-        }
-
         // parameters
         let mut params: Vec<Param> = Vec::new();
         while !self.match_type(&[TokenType::RightParen]) {
-            let param_type = if matches!(self.peek(), TokenType::Array) {
-                self.advance();
-                TypeAnnotation::Array(nested_array(self)?)
-            } else {
-                match self.peek() {
-                    TokenType::Int => {
-                        self.advance();
-                        TypeAnnotation::Int
-                    }
-                    TokenType::Float => {
-                        self.advance();
-                        TypeAnnotation::Float
-                    }
-                    TokenType::Bool => {
-                        self.advance();
-                        TypeAnnotation::Bool
-                    }
-                    TokenType::String => {
-                        self.advance();
-                        TypeAnnotation::String
-                    }
-                    TokenType::Char => {
-                        self.advance();
-                        TypeAnnotation::Char
-                    }
-                    _ => {
-                        return Err(self.err("expected parameter type", self.peek_span()));
-                    }
-                }
-            };
-
+            let param_type = self.parse_param_type()?;
             match self.peek() {
                 TokenType::Identifier(p) => {
                     self.advance();
@@ -122,37 +49,10 @@ impl Parser {
 
         // optional return type annotation — skip it for now
         let return_type = if self.match_type(&[TokenType::Arrow]) {
-            let x = if matches!(self.peek(), TokenType::Array) {
-                self.advance();
-                TypeAnnotation::Array(nested_array(self)?)
-            } else {
-                match self.peek() {
-                    TokenType::Int => {
-                        self.advance();
-                        TypeAnnotation::Int
-                    }
-                    TokenType::Float => {
-                        self.advance();
-                        TypeAnnotation::Float
-                    }
-                    TokenType::Bool => {
-                        self.advance();
-                        TypeAnnotation::Bool
-                    }
-                    TokenType::String => {
-                        self.advance();
-                        TypeAnnotation::String
-                    }
-                    TokenType::Char => {
-                        self.advance();
-                        TypeAnnotation::Char
-                    }
-                    _ => {
-                        return Err(self.err("expected parameter type", self.peek_span()));
-                    }
-                }
-            };
-            x
+            match self.parse_param_type() {
+                Ok(a) => a,
+                Err(_) => TypeAnnotation::Null,
+            }
         } else {
             TypeAnnotation::Null
         };

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::statements::{Statement, StatementKind},
+    ast::statements::{Param, Statement, StatementKind, TypeAnnotation},
     lexer::tokentypes::TokenType,
     parser::parser_logic::Parser,
     utils::{errors::Error, span::Span},
@@ -28,50 +28,89 @@ impl Parser {
         self.match_type(&[TokenType::LeftParen]);
 
         // parameters
-        let mut params = Vec::new();
+        let mut params: Vec<Param> = Vec::new();
         while !self.match_type(&[TokenType::RightParen]) {
-            fn nested_array(env: &mut Parser) -> Result<(), Error> {
+            fn nested_array(env: &mut Parser) -> Result<Box<TypeAnnotation>, Error> {
                 if !env.match_type(&[TokenType::LeftBracket]) {
                     return Err(env.err("expected '[' after arr", env.peek_span()));
                 }
 
-                if matches!(env.peek(), TokenType::Array) {
+                let param_type = if matches!(env.peek(), TokenType::Array) {
                     env.advance();
-                    nested_array(env)?;
-                } else if !env.match_type(&[
-                    TokenType::Int,
-                    TokenType::Float,
-                    TokenType::Bool,
-                    TokenType::Char,
-                    TokenType::String,
-                ]) {
-                    return Err(env.err("expected parameter type", env.peek_span()));
-                }
+                    Box::new(TypeAnnotation::Array(nested_array(env)?))
+                } else {
+                    match env.peek() {
+                        TokenType::Int => {
+                            env.advance();
+                            Box::new(TypeAnnotation::Int)
+                        }
+                        TokenType::Float => {
+                            env.advance();
+                            Box::new(TypeAnnotation::Float)
+                        }
+                        TokenType::Bool => {
+                            env.advance();
+                            Box::new(TypeAnnotation::Bool)
+                        }
+                        TokenType::String => {
+                            env.advance();
+                            Box::new(TypeAnnotation::String)
+                        }
+                        TokenType::Char => {
+                            env.advance();
+                            Box::new(TypeAnnotation::Char)
+                        }
+                        _ => {
+                            return Err(env.err("expected parameter type", env.peek_span()));
+                        }
+                    }
+                };
 
                 if !env.match_type(&[TokenType::RightBracket]) {
                     return Err(env.err("expected ']' after type", env.peek_span()));
                 }
 
-                Ok(())
+                Ok(param_type)
             }
 
-            if matches!(self.peek(), TokenType::Array) {
+            let param_type = if matches!(self.peek(), TokenType::Array) {
                 self.advance();
-                nested_array(self)?;
-            } else if !self.match_type(&[
-                TokenType::Int,
-                TokenType::Float,
-                TokenType::Bool,
-                TokenType::Char,
-                TokenType::String,
-            ]) {
-                return Err(self.err("expected parameter type", self.peek_span()));
-            }
+                TypeAnnotation::Array(nested_array(self)?)
+            } else {
+                match self.peek() {
+                    TokenType::Int => {
+                        self.advance();
+                        TypeAnnotation::Int
+                    }
+                    TokenType::Float => {
+                        self.advance();
+                        TypeAnnotation::Float
+                    }
+                    TokenType::Bool => {
+                        self.advance();
+                        TypeAnnotation::Bool
+                    }
+                    TokenType::String => {
+                        self.advance();
+                        TypeAnnotation::String
+                    }
+                    TokenType::Char => {
+                        self.advance();
+                        TypeAnnotation::Char
+                    }
+                    _ => {
+                        return Err(self.err("expected parameter type", self.peek_span()));
+                    }
+                }
+            };
 
             match self.peek() {
                 TokenType::Identifier(p) => {
                     self.advance();
-                    params.push(p);
+                    params.push(Param {
+                        param_name: p,
+                        param_type: param_type,
+                    });
                 }
                 _ => return Err(self.err("expected parameter name", self.peek_span())),
             }

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -27,52 +27,52 @@ impl Parser {
         // opening paren
         self.match_type(&[TokenType::LeftParen]);
 
+        fn nested_array(env: &mut Parser) -> Result<Box<TypeAnnotation>, Error> {
+            if !env.match_type(&[TokenType::LeftBracket]) {
+                return Err(env.err("expected '[' after arr", env.peek_span()));
+            }
+
+            let param_type = if matches!(env.peek(), TokenType::Array) {
+                env.advance();
+                Box::new(TypeAnnotation::Array(nested_array(env)?))
+            } else {
+                match env.peek() {
+                    TokenType::Int => {
+                        env.advance();
+                        Box::new(TypeAnnotation::Int)
+                    }
+                    TokenType::Float => {
+                        env.advance();
+                        Box::new(TypeAnnotation::Float)
+                    }
+                    TokenType::Bool => {
+                        env.advance();
+                        Box::new(TypeAnnotation::Bool)
+                    }
+                    TokenType::String => {
+                        env.advance();
+                        Box::new(TypeAnnotation::String)
+                    }
+                    TokenType::Char => {
+                        env.advance();
+                        Box::new(TypeAnnotation::Char)
+                    }
+                    _ => {
+                        return Err(env.err("expected parameter type", env.peek_span()));
+                    }
+                }
+            };
+
+            if !env.match_type(&[TokenType::RightBracket]) {
+                return Err(env.err("expected ']' after type", env.peek_span()));
+            }
+
+            Ok(param_type)
+        }
+
         // parameters
         let mut params: Vec<Param> = Vec::new();
         while !self.match_type(&[TokenType::RightParen]) {
-            fn nested_array(env: &mut Parser) -> Result<Box<TypeAnnotation>, Error> {
-                if !env.match_type(&[TokenType::LeftBracket]) {
-                    return Err(env.err("expected '[' after arr", env.peek_span()));
-                }
-
-                let param_type = if matches!(env.peek(), TokenType::Array) {
-                    env.advance();
-                    Box::new(TypeAnnotation::Array(nested_array(env)?))
-                } else {
-                    match env.peek() {
-                        TokenType::Int => {
-                            env.advance();
-                            Box::new(TypeAnnotation::Int)
-                        }
-                        TokenType::Float => {
-                            env.advance();
-                            Box::new(TypeAnnotation::Float)
-                        }
-                        TokenType::Bool => {
-                            env.advance();
-                            Box::new(TypeAnnotation::Bool)
-                        }
-                        TokenType::String => {
-                            env.advance();
-                            Box::new(TypeAnnotation::String)
-                        }
-                        TokenType::Char => {
-                            env.advance();
-                            Box::new(TypeAnnotation::Char)
-                        }
-                        _ => {
-                            return Err(env.err("expected parameter type", env.peek_span()));
-                        }
-                    }
-                };
-
-                if !env.match_type(&[TokenType::RightBracket]) {
-                    return Err(env.err("expected ']' after type", env.peek_span()));
-                }
-
-                Ok(param_type)
-            }
-
             let param_type = if matches!(self.peek(), TokenType::Array) {
                 self.advance();
                 TypeAnnotation::Array(nested_array(self)?)
@@ -121,10 +121,41 @@ impl Parser {
         self.match_type(&[TokenType::RightParen]);
 
         // optional return type annotation — skip it for now
-        if self.match_type(&[TokenType::Arrow]) {
-            // consume the type token (int, float, str, etc.)
-            self.advance();
-        }
+        let return_type = if self.match_type(&[TokenType::Arrow]) {
+            let x = if matches!(self.peek(), TokenType::Array) {
+                self.advance();
+                TypeAnnotation::Array(nested_array(self)?)
+            } else {
+                match self.peek() {
+                    TokenType::Int => {
+                        self.advance();
+                        TypeAnnotation::Int
+                    }
+                    TokenType::Float => {
+                        self.advance();
+                        TypeAnnotation::Float
+                    }
+                    TokenType::Bool => {
+                        self.advance();
+                        TypeAnnotation::Bool
+                    }
+                    TokenType::String => {
+                        self.advance();
+                        TypeAnnotation::String
+                    }
+                    TokenType::Char => {
+                        self.advance();
+                        TypeAnnotation::Char
+                    }
+                    _ => {
+                        return Err(self.err("expected parameter type", self.peek_span()));
+                    }
+                }
+            };
+            x
+        } else {
+            TypeAnnotation::Null
+        };
 
         // body
 
@@ -132,7 +163,12 @@ impl Parser {
 
         let span = start.join(self.previous_span());
         Ok(Statement::new(
-            StatementKind::FunctionDeclaration { name, params, body },
+            StatementKind::FunctionDeclaration {
+                name,
+                params,
+                return_type: return_type,
+                body,
+            },
             span,
         ))
     }

--- a/src/parser/statements/if_statement.rs
+++ b/src/parser/statements/if_statement.rs
@@ -10,6 +10,7 @@ impl Parser {
     pub fn parse_if(&mut self, start: Span) -> Result<Statement, Error> {
         let if_condition = self.parse_expression()?;
         let if_body = self.parse_block()?;
+        #[cfg(feature = "debug")]
         log::debug!("parsed if branch");
         let if_branch_span = start.join(self.previous_span());
         let if_branch = Statement::new(
@@ -41,6 +42,7 @@ impl Parser {
                     },
                     span,
                 );
+                #[cfg(feature = "debug")]
                 log::debug!("parsed else if branch");
                 elseif_branch.push(branch);
                 while matches!(self.peek(), TokenType::Newline) {
@@ -56,6 +58,7 @@ impl Parser {
         let else_branch = if else_body.is_empty() {
             None
         } else {
+            #[cfg(feature = "debug")]
             log::debug!("parsed else branch");
             let span = else_start.unwrap_or(if_branch_span).join(else_end_span);
             Some(Box::new(Statement::new(

--- a/src/parser/statements/import_statement.rs
+++ b/src/parser/statements/import_statement.rs
@@ -14,20 +14,55 @@ impl Parser {
         // std::display will be separated to std display and thrown in another Vec<String>
         // checks for comma and coloncolon ummm might make loop
 
-        let mut names = Vec::new();
-        loop {
-            match self.peek() {
-                TokenType::Identifier(name) => {
-                    // consuming the token
-                    self.advance();
-                    // adding the target to names list
-                    names.push(name);
+        let first = match self.peek() {
+            TokenType::Identifier(name) => name,
+            _ => return Err(self.err("expected identifier after 'get'", self.peek_span())),
+        };
+        self.advance();
+
+        if self.match_type(&[TokenType::ColonColon]) {
+            let mut segments = vec![first];
+            loop {
+                match self.peek() {
+                    TokenType::Identifier(seg) => {
+                        self.advance();
+                        segments.push(seg);
+                    }
+
+                    _ => return Err(self.err("expected identifier after '::'", self.peek_span())),
                 }
-                _ => return Err(self.err("expected identifier after 'get'", self.peek_span())),
+                if !self.match_type(&[TokenType::ColonColon]) {
+                    break;
+                }
             }
 
-            if !self.match_type(&[TokenType::Comma]) {
-                break;
+            let name = segments.pop().unwrap();
+            let span = start.join(self.previous_span());
+            return Ok(Statement::new(
+                StatementKind::Import {
+                    names: vec![name],
+                    path: segments,
+                },
+                span,
+            ));
+        }
+
+        let mut names = vec![first];
+        if self.match_type(&[TokenType::Comma]) {
+            loop {
+                match self.peek() {
+                    TokenType::Identifier(name) => {
+                        // consuming the token
+                        self.advance();
+                        // adding the target to names list
+                        names.push(name);
+                    }
+                    _ => return Err(self.err("expected identifier after 'get'", self.peek_span())),
+                }
+
+                if !self.match_type(&[TokenType::Comma]) {
+                    break;
+                }
             }
         }
 

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -1,5 +1,6 @@
 mod const_declaration;
 mod for_statement;
+mod function_declaration;
 mod if_statement;
 mod import_statement;
 mod variable_declaration;
@@ -65,6 +66,27 @@ impl Parser {
                 self.advance();
                 log::info!("found `if` while parsing");
                 self.parse_if(start)
+            }
+
+            TokenType::Fn => {
+                self.advance();
+                log::info!("found 'fn' while parsing");
+                self.parse_function(start)
+            }
+
+            TokenType::Return => {
+                self.advance();
+                // if next token can start an expression, parse it
+                let expr = if !matches!(self.peek(), TokenType::Newline)
+                    && !matches!(self.peek(), TokenType::RightBrace)
+                    && !self.is_at_end()
+                {
+                    Some(self.parse_expression()?)
+                } else {
+                    None
+                };
+                let span = start.join(self.previous_span());
+                Ok(Statement::new(StatementKind::Return(expr), span))
             }
             _ => {
                 log::info!("parsing the current tokens as expression");

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -56,11 +56,9 @@ impl Parser {
                 self.parse_while(start)
             }
             TokenType::For => {
-                let span = self.peek_span();
-                Ok(Statement::new(
-                    StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), span)),
-                    span,
-                )) // for now
+                self.advance();
+                log::info!("found `for` while parsing");
+                self.parse_for(start)
             }
             TokenType::If => {
                 self.advance();

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -23,6 +23,7 @@ impl Parser {
         match self.peek() {
             TokenType::Newline => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found newline while parsing... skipping");
                 let span = self.previous_span();
                 Ok(Statement::new(
@@ -36,38 +37,45 @@ impl Parser {
                 // consume it
                 self.advance();
                 // log it
+                #[cfg(feature = "debug")]
                 log::info!("found `get` for import while parsing");
                 // parse it
                 self.parse_import(start)
             }
             TokenType::Dec => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found `declaration` for variable while parsing");
                 self.parse_variable_declartion(start)
             }
             TokenType::Const => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found `declaration` for constant while parsing");
                 self.parse_const_declartion(start)
             }
             TokenType::While => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found `while` while parsing");
                 self.parse_while(start)
             }
             TokenType::For => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found `for` while parsing");
                 self.parse_for(start)
             }
             TokenType::If => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found `if` while parsing");
                 self.parse_if(start)
             }
 
             TokenType::Fn => {
                 self.advance();
+                #[cfg(feature = "debug")]
                 log::info!("found 'fn' while parsing");
                 self.parse_function(start)
             }
@@ -100,6 +108,7 @@ impl Parser {
             }
 
             _ => {
+                #[cfg(feature = "debug")]
                 log::info!("parsing the current tokens as expression");
                 let expr = self.parse_expression()?;
                 let span = expr.span;
@@ -115,6 +124,7 @@ impl Parser {
         }
         let mut statements = Vec::new();
 
+        #[cfg(feature = "debug")]
         log::info!("parsing body into statements");
         while !self.match_type(&[TokenType::RightBrace, TokenType::Eof]) {
             if matches!(self.peek(), TokenType::Newline) {

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -88,6 +88,19 @@ impl Parser {
                 let span = start.join(self.previous_span());
                 Ok(Statement::new(StatementKind::Return(expr), span))
             }
+
+            TokenType::Break => {
+                self.advance();
+                let span = start.join(self.previous_span());
+                Ok(Statement::new(StatementKind::Break, span))
+            }
+
+            TokenType::Continue => {
+                self.advance();
+                let span = start.join(self.previous_span());
+                Ok(Statement::new(StatementKind::Continue, span))
+            }
+
             _ => {
                 log::info!("parsing the current tokens as expression");
                 let expr = self.parse_expression()?;

--- a/src/parser/statements/variable_declaration.rs
+++ b/src/parser/statements/variable_declaration.rs
@@ -11,36 +11,8 @@ impl Parser {
         log::debug!("parsing type");
         if self.match_type(&[TokenType::Array]) && self.peek() == TokenType::LeftBracket {
             self.advance();
-            let annoation_type = match self.peek() {
-                TokenType::Int => {
-                    self.advance();
-                    TypeAnnotation::Int
-                }
-                TokenType::Float => {
-                    self.advance();
-                    TypeAnnotation::Float
-                }
-                TokenType::Bool => {
-                    self.advance();
-                    TypeAnnotation::Bool
-                }
-                TokenType::String => {
-                    self.advance();
-                    TypeAnnotation::String
-                }
-                TokenType::Char => {
-                    self.advance();
-                    TypeAnnotation::Char
-                }
-                TokenType::Array => {
-                    self.advance();
-                    self.match_type(&[TokenType::LeftBracket]);
-                    let inner = self.parse_type(true)?;
-                    self.match_type(&[TokenType::RightBracket]);
-                    TypeAnnotation::Array(Box::new(inner))
-                }
-                _ => return Err(self.err("expected type after `dec`", self.peek_span())),
-            };
+            let annoation_type = self.parse_param_type()?;
+
             if !self.match_type(&[TokenType::RightBracket]) {
                 return Err(self.err("expected `]` after type", self.peek_span()));
             }
@@ -138,6 +110,10 @@ impl Parser {
                     self.advance();
                     TypeAnnotation::Char
                 }
+                TokenType::Fn => {
+                    self.advance();
+                    TypeAnnotation::Fn
+                }
                 TokenType::Array => {
                     self.advance();
                     self.match_type(&[TokenType::LeftBracket]);
@@ -167,6 +143,10 @@ impl Parser {
                 TokenType::Char => {
                     self.advance();
                     TypeAnnotation::CChar
+                }
+                TokenType::Fn => {
+                    self.advance();
+                    TypeAnnotation::Fn
                 }
                 TokenType::Array => {
                     self.advance();

--- a/src/parser/statements/variable_declaration.rs
+++ b/src/parser/statements/variable_declaration.rs
@@ -7,7 +7,9 @@ use crate::{
 
 impl Parser {
     pub fn parse_variable_declartion(&mut self, start: Span) -> Result<Statement, Error> {
+        #[cfg(feature = "debug")]
         log::debug!("{:?}", self.peek());
+        #[cfg(feature = "debug")]
         log::debug!("parsing type");
         if self.match_type(&[TokenType::Array]) && self.peek() == TokenType::LeftBracket {
             self.advance();

--- a/src/parser/utils/mod.rs
+++ b/src/parser/utils/mod.rs
@@ -133,15 +133,13 @@ impl Parser {
         match self.peek() {
             TokenType::LeftBracket => {
                 self.advance();
-                match self.parse_param_type()? {
-                    a => match self.peek() {
-                        TokenType::RightBracket => {
-                            self.advance();
-                            Ok(Box::new(TypeAnnotation::Array(Box::new(a))))
-                        }
-
-                        _ => Err(self.err("expected ']'", self.peek_span())),
-                    },
+                let a = self.parse_param_type()?;
+                match self.peek() {
+                    TokenType::RightBracket => {
+                        self.advance();
+                        Ok(Box::new(TypeAnnotation::Array(Box::new(a))))
+                    }
+                    _ => Err(self.err("expected ']'", self.peek_span())),
                 }
             }
 

--- a/src/parser/utils/mod.rs
+++ b/src/parser/utils/mod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    lexer::tokentypes::TokenType, parser::parser_logic::Parser, utils::span::Span,
+    ast::statements::TypeAnnotation,
+    lexer::tokentypes::TokenType,
+    parser::parser_logic::Parser,
+    utils::{errors::Error, span::Span},
 };
 
 impl Parser {
@@ -84,5 +87,59 @@ impl Parser {
         }
         log::debug!("Token {:?} did not match any in [{:?}]", self.peek(), types);
         false
+    }
+
+    pub fn parse_param_type(&mut self) -> Result<TypeAnnotation, Error> {
+        if matches!(self.peek(), TokenType::Array) {
+            self.advance();
+            return Ok(TypeAnnotation::Array(self.nested_array_type()?));
+        }
+        match self.peek() {
+            TokenType::Int => {
+                self.advance();
+                Ok(TypeAnnotation::Int)
+            }
+            TokenType::Float => {
+                self.advance();
+                Ok(TypeAnnotation::Float)
+            }
+            TokenType::Bool => {
+                self.advance();
+                Ok(TypeAnnotation::Bool)
+            }
+            TokenType::String => {
+                self.advance();
+                Ok(TypeAnnotation::String)
+            }
+            TokenType::Char => {
+                self.advance();
+                Ok(TypeAnnotation::Char)
+            }
+            TokenType::Fn => {
+                self.advance();
+                Ok(TypeAnnotation::Fn)
+            }
+            _ => Err(self.err("expected type", self.peek_span())),
+        }
+    }
+
+    pub fn nested_array_type(&mut self) -> Result<Box<TypeAnnotation>, Error> {
+        match self.peek() {
+            TokenType::LeftBracket => {
+                self.advance();
+                match self.parse_param_type()? {
+                    a => match self.peek() {
+                        TokenType::RightBracket => {
+                            self.advance();
+                            Ok(Box::new(TypeAnnotation::Array(Box::new(a))))
+                        }
+
+                        _ => Err(self.err("expected ']'", self.peek_span())),
+                    },
+                }
+            }
+
+            _ => Err(self.err("expected '['", self.peek_span())),
+        }
     }
 }

--- a/src/parser/utils/mod.rs
+++ b/src/parser/utils/mod.rs
@@ -24,6 +24,7 @@ impl Parser {
     ///
     /// if Eof -> true which indicates the last token
     pub fn is_at_end(&self) -> bool {
+        #[cfg(feature = "debug")]
         if matches!(self.peek(), TokenType::Eof) {
             log::debug!("countered token [TokenType::Eof] indicating end of tokens for the file");
         }
@@ -34,12 +35,14 @@ impl Parser {
     pub fn advance(&mut self) {
         if !self.is_at_end() {
             self.current += 1;
+            #[cfg(feature = "debug")]
             log::debug!("advancing the parser current token: {}", self.current);
         }
     }
 
     /// returns [`TokenType`] of current token without consuming it
     pub fn peek(&self) -> TokenType {
+        #[cfg(feature = "debug")]
         log::debug!(
             "returning current token: [{:?}]",
             &self.tokens[self.current].token
@@ -49,6 +52,7 @@ impl Parser {
 
     /// returns the previous [`TokenType`] that got consumed
     pub fn previous(&self) -> TokenType {
+        #[cfg(feature = "debug")]
         log::debug!(
             "returning previous token: [{:?}]",
             &self.tokens[self.current - 1].token
@@ -80,11 +84,13 @@ impl Parser {
     pub fn match_type(&mut self, types: &[TokenType]) -> bool {
         for token_type in types {
             if self.check(token_type) {
+                #[cfg(feature = "debug")]
                 log::debug!("Token {:?} matched one in [{:?}]", self.peek(), types);
                 self.advance();
                 return true;
             }
         }
+        #[cfg(feature = "debug")]
         log::debug!("Token {:?} did not match any in [{:?}]", self.peek(), types);
         false
     }

--- a/src/repl/command_handler.rs
+++ b/src/repl/command_handler.rs
@@ -1,4 +1,4 @@
-use std::{fs, panic, path::PathBuf};
+use std::{fs, path::PathBuf};
 
 use ratatui::style::{Color, Modifier, Style};
 
@@ -115,7 +115,7 @@ pub fn handle_command(
             let content: String = output
                 .iter()
                 .filter_map(|l| match l {
-                    OutputLine::Input(s) => Some(s.clone()),
+                    OutputLine::Input(s) if !s.trim_start().starts_with(':') => Some(s.clone()),
                     _ => None,
                 })
                 .collect::<Vec<_>>()
@@ -153,36 +153,37 @@ pub fn handle_command(
                 Ok(content) => {
                     let source =
                         SourceFile::new(path.to_str().unwrap_or("<file>"), content.clone());
-                    let eval_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                        let tokens = Tokenizer::lex(source.clone())?;
-                        let stmts = Parser::parse(tokens, source.clone())?;
-                        Ok::<_, crate::utils::errors::Error>(stmts)
-                    }));
-                    match eval_result {
-                        Ok(Ok(stmts)) => {
-                            evaluator.set_source_file(source);
-                            let mut ok = true;
-                            for stmt in stmts {
-                                if let Err(e) = evaluator.evaluate_statement(&stmt) {
-                                    push_error(output, &e);
-                                    ok = false;
-                                    break;
-                                }
-                            }
-                            if ok {
-                                attached.push(path.clone());
-                                output
-                                    .push(OutputLine::Info(format!("attached {}", path.display())));
-                            }
+                    let tokens = match Tokenizer::lex(source.clone()) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            push_error(output, &e);
+                            return;
                         }
-                        Ok(Err(e)) => push_error(output, &e),
-                        Err(_) => output.push(OutputLine::Error("attach: aborted".into())),
+                    };
+                    let stmts = match Parser::parse(tokens, source.clone()) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            push_error(output, &e);
+                            return;
+                        }
+                    };
+                    evaluator.set_source_file(source);
+                    let mut ok = true;
+                    for stmt in &stmts {
+                        if let Err(e) = evaluator.evaluate_statement(stmt) {
+                            push_error(output, &e);
+                            ok = false;
+                            break;
+                        }
+                    }
+                    if ok {
+                        attached.push(path.clone());
+                        output.push(OutputLine::Info(format!("attached {}", path.display())));
                     }
                 }
                 Err(e) => output.push(OutputLine::Error(format!("attach failed: {}", e))),
             }
         }
-
         ":detach" => {
             if parts.len() < 2 || parts[1].trim().is_empty() {
                 output.push(OutputLine::Error(":detach requires a filename".into()));

--- a/src/repl/command_handler.rs
+++ b/src/repl/command_handler.rs
@@ -115,7 +115,7 @@ pub fn handle_command(
             let content: String = output
                 .iter()
                 .filter_map(|l| match l {
-                    OutputLine::Input(s) if !s.trim_start().starts_with(':') => Some(s.clone()),
+                    OutputLine::ValidInput(s) => Some(s.clone()),
                     _ => None,
                 })
                 .collect::<Vec<_>>()

--- a/src/repl/command_handler.rs
+++ b/src/repl/command_handler.rs
@@ -1,0 +1,211 @@
+use std::{fs, panic, path::PathBuf};
+
+use ratatui::style::{Color, Modifier, Style};
+
+use crate::{
+    interpreter::evaluator::Evaluator,
+    lexer::tokenizer::Tokenizer,
+    parser::parser_logic::Parser,
+    repl::{lines_types::OutputLine, stdlib_helper::stdlib_entries, utils::push_error},
+    utils::source::SourceFile,
+};
+
+pub fn handle_command(
+    cmd: &str,
+    output: &mut Vec<OutputLine>,
+    evaluator: &mut Evaluator,
+    attached: &mut Vec<PathBuf>,
+) {
+    let parts: Vec<&str> = cmd.splitn(2, ' ').collect();
+    match parts[0] {
+        ":help" => {
+            let cmd = Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD);
+            let arg = Style::default()
+                .fg(Color::LightBlue)
+                .add_modifier(Modifier::ITALIC);
+            let sep = Style::default().fg(Color::DarkGray);
+            let desc = Style::default().fg(Color::White);
+
+            output.push(OutputLine::Styled(vec![(
+                "Commands".to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            )]));
+            let entries: &[(&str, Option<&str>, &str)] = &[
+                (":help", None, "show this"),
+                (":stdlib", None, "list stdlib modules"),
+                (":stdlib", Some(" <mod>"), "list module functions"),
+                (":save", Some(" <file>"), "save session to file"),
+                (":load", Some(" <file>"), "load and print file"),
+                (":attach", Some(" <file>"), "import file into env"),
+                (":detach", Some(" <file>"), "remove attached file"),
+                (":exit", None, "quit  (ctrl+c also works)"),
+            ];
+            for (command, argument, description) in entries {
+                let mut parts = vec![("  ".to_string(), sep), (command.to_string(), cmd)];
+                if let Some(a) = argument {
+                    parts.push((a.to_string(), arg));
+                }
+                // pad to column 24
+                let used = 2 + command.len() + argument.map(|a| a.len()).unwrap_or(0);
+                let pad = " ".repeat(24_usize.saturating_sub(used));
+                parts.push((pad, sep));
+                parts.push(("— ".to_string(), sep));
+                parts.push((description.to_string(), desc));
+                output.push(OutputLine::Styled(parts));
+            }
+        }
+        ":stdlib" => {
+            let header = Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED);
+            let modname = Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD);
+            let sig = Style::default()
+                .fg(Color::LightBlue)
+                .add_modifier(Modifier::ITALIC);
+            let sep = Style::default().fg(Color::DarkGray);
+            let desc = Style::default().fg(Color::White);
+
+            if parts.len() == 1 {
+                output.push(OutputLine::Styled(vec![(
+                    "stdlib modules".to_string(),
+                    header,
+                )]));
+                for entry in stdlib_entries() {
+                    output.push(OutputLine::Styled(vec![
+                        ("  std".to_string(), sep),
+                        ("::".to_string(), sep),
+                        (entry.name.to_string(), modname),
+                    ]));
+                }
+            } else {
+                let mod_name = parts[1].trim();
+                let entries = stdlib_entries();
+                if let Some(entry) = entries.iter().find(|e| e.name == mod_name) {
+                    output.push(OutputLine::Styled(vec![
+                        ("std".to_string(), sep),
+                        ("::".to_string(), sep),
+                        (entry.name.to_string(), modname),
+                    ]));
+                    for (signature, description) in entry.functions {
+                        let pad = " ".repeat(32_usize.saturating_sub(signature.len()));
+                        output.push(OutputLine::Styled(vec![
+                            ("  ".to_string(), sep),
+                            (signature.to_string(), sig),
+                            (pad, sep),
+                            (description.to_string(), desc),
+                        ]));
+                    }
+                } else {
+                    output.push(OutputLine::Error(format!("unknown module: {}", mod_name)));
+                }
+            }
+        }
+        ":save" => {
+            if parts.len() < 2 || parts[1].trim().is_empty() {
+                output.push(OutputLine::Error(":save requires a filename".into()));
+                return;
+            }
+            let path = parts[1].trim();
+            let content: String = output
+                .iter()
+                .filter_map(|l| match l {
+                    OutputLine::Input(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            match fs::write(path, content) {
+                Ok(_) => output.push(OutputLine::Info(format!("saved to {}", path))),
+                Err(e) => output.push(OutputLine::Error(format!("save failed: {}", e))),
+            }
+        }
+
+        ":load" => {
+            if parts.len() < 2 || parts[1].trim().is_empty() {
+                output.push(OutputLine::Error(":load requires a filename".into()));
+                return;
+            }
+            let path = parts[1].trim();
+            match fs::read_to_string(path) {
+                Ok(content) => {
+                    output.push(OutputLine::Info(format!("--- {} ---", path)));
+                    for line in content.lines() {
+                        output.push(OutputLine::Info(line.to_string()));
+                    }
+                }
+                Err(e) => output.push(OutputLine::Error(format!("load failed: {}", e))),
+            }
+        }
+
+        ":attach" => {
+            if parts.len() < 2 || parts[1].trim().is_empty() {
+                output.push(OutputLine::Error(":attach requires a filename".into()));
+                return;
+            }
+            let path = PathBuf::from(parts[1].trim());
+            match fs::read_to_string(&path) {
+                Ok(content) => {
+                    let source =
+                        SourceFile::new(path.to_str().unwrap_or("<file>"), content.clone());
+                    let eval_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        let tokens = Tokenizer::lex(source.clone())?;
+                        let stmts = Parser::parse(tokens, source.clone())?;
+                        Ok::<_, crate::utils::errors::Error>(stmts)
+                    }));
+                    match eval_result {
+                        Ok(Ok(stmts)) => {
+                            evaluator.set_source_file(source);
+                            let mut ok = true;
+                            for stmt in stmts {
+                                if let Err(e) = evaluator.evaluate_statement(&stmt) {
+                                    push_error(output, &e);
+                                    ok = false;
+                                    break;
+                                }
+                            }
+                            if ok {
+                                attached.push(path.clone());
+                                output
+                                    .push(OutputLine::Info(format!("attached {}", path.display())));
+                            }
+                        }
+                        Ok(Err(e)) => push_error(output, &e),
+                        Err(_) => output.push(OutputLine::Error("attach: aborted".into())),
+                    }
+                }
+                Err(e) => output.push(OutputLine::Error(format!("attach failed: {}", e))),
+            }
+        }
+
+        ":detach" => {
+            if parts.len() < 2 || parts[1].trim().is_empty() {
+                output.push(OutputLine::Error(":detach requires a filename".into()));
+                return;
+            }
+            let path = PathBuf::from(parts[1].trim());
+            if let Some(pos) = attached.iter().position(|p| p == &path) {
+                attached.remove(pos);
+                output.push(OutputLine::Info(format!("detached {}", path.display())));
+                output.push(OutputLine::Info(
+                    "note: variables from that file remain in env until restart".into(),
+                ));
+            } else {
+                output.push(OutputLine::Error(format!(
+                    "{} is not attached",
+                    path.display()
+                )));
+            }
+        }
+
+        _ => {
+            output.push(OutputLine::Error(format!("unknown command: {}", parts[0])));
+            output.push(OutputLine::Info("type :help for commands".into()));
+        }
+    }
+}

--- a/src/repl/depth_checker.rs
+++ b/src/repl/depth_checker.rs
@@ -1,0 +1,35 @@
+use crate::{
+    lexer::{tokenizer::Tokenizer, tokentypes::TokenType},
+    utils::source::SourceFile,
+};
+
+pub fn is_complete(input: &str) -> bool {
+    let source = SourceFile::new("<check>", input.to_string());
+    let tokens = match Tokenizer::lex(source) {
+        Ok(t) => t,
+        Err(_) => return true,
+    };
+    let mut brace_depth: i32 = 0;
+    let mut paren_depth: i32 = 0;
+    let mut bracket_depth: i32 = 0;
+    for tok in &tokens {
+        match tok.token {
+            TokenType::LeftBrace => brace_depth += 1,
+            TokenType::RightBrace => brace_depth -= 1,
+            TokenType::LeftParen => paren_depth += 1,
+            TokenType::RightParen => paren_depth -= 1,
+            TokenType::LeftBracket => bracket_depth += 1,
+            TokenType::RightBracket => bracket_depth -= 1,
+            _ => {}
+        }
+    }
+
+    if paren_depth > 0 || bracket_depth > 0 {
+        return false;
+    }
+
+    if brace_depth > 0 {
+        return input.trim_end().ends_with('{');
+    }
+    true
+}

--- a/src/repl/input_eval.rs
+++ b/src/repl/input_eval.rs
@@ -1,5 +1,3 @@
-use std::panic;
-
 use crate::{
     interpreter::evaluator::Evaluator,
     lexer::tokenizer::Tokenizer,
@@ -30,34 +28,31 @@ pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<Outpu
     evaluator.set_source_file(source);
     evaluator.output_buffer = Some(String::new());
 
-    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        for statement in &statements {
-            if let crate::ast::statements::StatementKind::Expression(expr) = &statement.kind {
-                match evaluator.evaluate(expr) {
-                    Ok(val) => {
-                        if !matches!(val, crate::interpreter::values::Value::Null) {
-                            // use Styled so value output gets syntax colors
-                            let val_str = format!("{}", val);
-                            let spans = highlight(&val_str);
-                            output.push(OutputLine::Styled(
-                                spans
-                                    .into_iter()
-                                    .map(|sp| (sp.content.into_owned(), sp.style))
-                                    .collect(),
-                            ));
-                        }
-                    }
-                    Err(e) => {
-                        output.push(OutputLine::Error(format!("error: {}", e.message())));
-                        return;
+    for statement in &statements {
+        if let crate::ast::statements::StatementKind::Expression(expr) = &statement.kind {
+            match evaluator.evaluate(expr) {
+                Ok(val) => {
+                    if !matches!(val, crate::interpreter::values::Value::Null) {
+                        let val_str = format!("{}", val);
+                        let spans = highlight(&val_str);
+                        output.push(OutputLine::Styled(
+                            spans
+                                .into_iter()
+                                .map(|sp| (sp.content.into_owned(), sp.style))
+                                .collect(),
+                        ));
                     }
                 }
-            } else if let Err(e) = evaluator.evaluate_statement(statement) {
-                output.push(OutputLine::Error(format!("error: {}", e.message())));
-                return;
+                Err(e) => {
+                    output.push(OutputLine::Error(format!("error: {}", e.message())));
+                    break;
+                }
             }
+        } else if let Err(e) = evaluator.evaluate_statement(statement) {
+            output.push(OutputLine::Error(format!("error: {}", e.message())));
+            break;
         }
-    }));
+    }
 
     if let Some(captured) = evaluator.output_buffer.take() {
         for line in captured.split('\n') {
@@ -65,9 +60,5 @@ pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<Outpu
                 output.push(OutputLine::Result(line.to_string()));
             }
         }
-    }
-
-    if result.is_err() {
-        output.push(OutputLine::Error("runtime error: aborted".into()));
     }
 }

--- a/src/repl/input_eval.rs
+++ b/src/repl/input_eval.rs
@@ -6,14 +6,14 @@ use crate::{
     utils::source::SourceFile,
 };
 
-pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<OutputLine>) {
+pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<OutputLine>) -> bool {
     let source = SourceFile::new("<repl>", input.to_string());
 
     let tokens = match Tokenizer::lex(source.clone()) {
         Ok(t) => t,
         Err(e) => {
             output.push(OutputLine::Error(format!("error: {}", e.message())));
-            return;
+            return false;
         }
     };
 
@@ -21,12 +21,14 @@ pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<Outpu
         Ok(s) => s,
         Err(e) => {
             output.push(OutputLine::Error(format!("error: {}", e.message())));
-            return;
+            return false;
         }
     };
 
     evaluator.set_source_file(source);
     evaluator.output_buffer = Some(String::new());
+
+    let mut success = true;
 
     for statement in &statements {
         if let crate::ast::statements::StatementKind::Expression(expr) = &statement.kind {
@@ -45,11 +47,13 @@ pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<Outpu
                 }
                 Err(e) => {
                     output.push(OutputLine::Error(format!("error: {}", e.message())));
+                    success = false;
                     break;
                 }
             }
         } else if let Err(e) = evaluator.evaluate_statement(statement) {
             output.push(OutputLine::Error(format!("error: {}", e.message())));
+            success = false;
             break;
         }
     }
@@ -61,4 +65,6 @@ pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<Outpu
             }
         }
     }
+
+    success
 }

--- a/src/repl/input_eval.rs
+++ b/src/repl/input_eval.rs
@@ -1,0 +1,73 @@
+use std::panic;
+
+use crate::{
+    interpreter::evaluator::Evaluator,
+    lexer::tokenizer::Tokenizer,
+    parser::parser_logic::Parser,
+    repl::{lines_types::OutputLine, syntax_highlighting::highlight},
+    utils::source::SourceFile,
+};
+
+pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<OutputLine>) {
+    let source = SourceFile::new("<repl>", input.to_string());
+
+    let tokens = match Tokenizer::lex(source.clone()) {
+        Ok(t) => t,
+        Err(e) => {
+            output.push(OutputLine::Error(format!("error: {}", e.message())));
+            return;
+        }
+    };
+
+    let statements = match Parser::parse(tokens, source.clone()) {
+        Ok(s) => s,
+        Err(e) => {
+            output.push(OutputLine::Error(format!("error: {}", e.message())));
+            return;
+        }
+    };
+
+    evaluator.set_source_file(source);
+    evaluator.output_buffer = Some(String::new());
+
+    let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        for statement in &statements {
+            if let crate::ast::statements::StatementKind::Expression(expr) = &statement.kind {
+                match evaluator.evaluate(expr) {
+                    Ok(val) => {
+                        if !matches!(val, crate::interpreter::values::Value::Null) {
+                            // use Styled so value output gets syntax colors
+                            let val_str = format!("{}", val);
+                            let spans = highlight(&val_str);
+                            output.push(OutputLine::Styled(
+                                spans
+                                    .into_iter()
+                                    .map(|sp| (sp.content.into_owned(), sp.style))
+                                    .collect(),
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        output.push(OutputLine::Error(format!("error: {}", e.message())));
+                        return;
+                    }
+                }
+            } else if let Err(e) = evaluator.evaluate_statement(statement) {
+                output.push(OutputLine::Error(format!("error: {}", e.message())));
+                return;
+            }
+        }
+    }));
+
+    if let Some(captured) = evaluator.output_buffer.take() {
+        for line in captured.split('\n') {
+            if !line.is_empty() {
+                output.push(OutputLine::Result(line.to_string()));
+            }
+        }
+    }
+
+    if result.is_err() {
+        output.push(OutputLine::Error("runtime error: aborted".into()));
+    }
+}

--- a/src/repl/lines_types.rs
+++ b/src/repl/lines_types.rs
@@ -1,0 +1,10 @@
+use ratatui::style::Style;
+
+pub enum OutputLine {
+    Input(String),
+    Result(String),
+    Error(String),
+    Info(String),
+    Styled(Vec<(String, Style)>),
+    Separator,
+}

--- a/src/repl/lines_types.rs
+++ b/src/repl/lines_types.rs
@@ -2,6 +2,7 @@ use ratatui::style::Style;
 
 pub enum OutputLine {
     Input(String),
+    ValidInput(String),
     Result(String),
     Error(String),
     Info(String),

--- a/src/repl/logic_loop.rs
+++ b/src/repl/logic_loop.rs
@@ -187,20 +187,16 @@ pub fn run_repl(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
                 }
 
                 // backspace
-                (_, KeyCode::Backspace) => {
-                    if cursor_pos > 0 {
-                        let byte_pos = char_to_byte(&input_buf, cursor_pos - 1);
-                        input_buf.remove(byte_pos);
-                        cursor_pos -= 1;
-                    }
+                (_, KeyCode::Backspace) if cursor_pos > 0 => {
+                    let byte_pos = char_to_byte(&input_buf, cursor_pos - 1);
+                    input_buf.remove(byte_pos);
+                    cursor_pos -= 1;
                 }
 
                 // delete
-                (_, KeyCode::Delete) => {
-                    if cursor_pos < input_buf.chars().count() {
-                        let byte_pos = char_to_byte(&input_buf, cursor_pos);
-                        input_buf.remove(byte_pos);
-                    }
+                (_, KeyCode::Delete) if cursor_pos < input_buf.chars().count() => {
+                    let byte_pos = char_to_byte(&input_buf, cursor_pos);
+                    input_buf.remove(byte_pos);
                 }
 
                 // word jump (ctrl+left / ctrl+right)
@@ -229,16 +225,12 @@ pub fn run_repl(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
                 }
 
                 // cursor movement
-                (_, KeyCode::Left) => {
-                    if cursor_pos > 0 {
-                        cursor_pos -= 1;
-                    }
+                (_, KeyCode::Left) if cursor_pos > 0 => {
+                    cursor_pos = cursor_pos.saturating_sub(1);
                 }
 
-                (_, KeyCode::Right) => {
-                    if cursor_pos < input_buf.chars().count() {
-                        cursor_pos += 1;
-                    }
+                (_, KeyCode::Right) if cursor_pos < input_buf.chars().count() => {
+                    cursor_pos += 1;
                 }
 
                 (_, KeyCode::Home) => cursor_pos = 0,

--- a/src/repl/logic_loop.rs
+++ b/src/repl/logic_loop.rs
@@ -178,7 +178,11 @@ pub fn run_repl(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
                         if !full.trim().is_empty() {
                             history.push(full.trim().to_string());
                         }
-                        eval_input(full.trim(), &mut evaluator, &mut output);
+
+                        let success = eval_input(full.trim(), &mut evaluator, &mut output);
+                        if success {
+                            output.push(OutputLine::ValidInput(full.trim().to_string()));
+                        }
                     }
                 }
 

--- a/src/repl/logic_loop.rs
+++ b/src/repl/logic_loop.rs
@@ -1,0 +1,306 @@
+use super::{
+    command_handler::handle_command, depth_checker::is_complete, input_eval::eval_input,
+    lines_types::OutputLine, output_render::render_output, syntax_highlighting::highlight,
+    utils::char_to_byte,
+};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use ratatui::{
+    DefaultTerminal,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use std::path::PathBuf;
+
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn run_repl(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+    let mut evaluator = Evaluator::default().with_stdlib();
+    let mut output: Vec<OutputLine> = vec![
+        OutputLine::Info(format!(
+            "rl-lang v{} — type :help for commands",
+            env!("CARGO_PKG_VERSION")
+        )),
+        OutputLine::Separator,
+    ];
+
+    let mut input_buf = String::new(); // current line being typed
+    let mut accumulated = String::new(); // multiline accumulator
+    let mut cursor_pos: usize = 0; // cursor position in chars
+    let mut history: Vec<String> = Vec::new();
+    let mut history_idx: Option<usize> = None;
+    let mut attached: Vec<PathBuf> = Vec::new();
+    let mut scroll_offset: usize = 0;
+
+    loop {
+        // draw
+        let is_continuation = !accumulated.is_empty();
+        let prompt = if is_continuation { ".. " } else { ">> " };
+
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(3), Constraint::Length(3)])
+                .split(area);
+
+            // output area
+            let out_lines = render_output(&output);
+            let total = out_lines.len();
+            let visible = chunks[0].height.saturating_sub(2) as usize;
+            let max_scroll = total.saturating_sub(visible);
+            // scroll_offset=0 means bottom and larger values scroll up
+            let scroll = max_scroll.saturating_sub(scroll_offset) as u16;
+
+            let output_widget = Paragraph::new(out_lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::DarkGray))
+                        .title(Span::styled(
+                            " rl ",
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD),
+                        )),
+                )
+                .wrap(Wrap { trim: false })
+                .scroll((scroll, 0));
+            frame.render_widget(output_widget, chunks[0]);
+
+            // input area
+            let prompt_color = if is_continuation {
+                Color::Yellow
+            } else {
+                Color::Cyan
+            };
+            let mut input_spans = vec![Span::styled(
+                prompt,
+                Style::default()
+                    .fg(prompt_color)
+                    .add_modifier(Modifier::BOLD),
+            )];
+
+            if input_buf.is_empty() {
+                // blinking style cursor on empty input
+                input_spans.push(Span::styled("│", Style::default().fg(Color::DarkGray)));
+            } else {
+                // split at char boundary safe for any unicode
+                let before: String = input_buf.chars().take(cursor_pos).collect();
+                let mut after_chars = input_buf.chars().skip(cursor_pos);
+
+                let mut hl = highlight(&before);
+                input_spans.append(&mut hl);
+
+                match after_chars.next() {
+                    None => {
+                        // cursor past end of text
+                        input_spans.push(Span::styled(
+                            " ",
+                            Style::default().bg(Color::Cyan).fg(Color::Black),
+                        ));
+                    }
+                    Some(c) => {
+                        let cursor_str = c.to_string();
+                        let rest: String = after_chars.collect();
+                        input_spans.push(Span::styled(
+                            cursor_str,
+                            Style::default().bg(Color::Cyan).fg(Color::Black),
+                        ));
+                        let mut hl2 = highlight(&rest);
+                        input_spans.append(&mut hl2);
+                    }
+                }
+            }
+
+            let input_widget = Paragraph::new(Line::from(input_spans)).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            );
+            frame.render_widget(input_widget, chunks[1]);
+        })?;
+
+        // events
+        if let Event::Key(key) = event::read()? {
+            match (key.modifiers, key.code) {
+                // exit
+                (KeyModifiers::CONTROL, KeyCode::Char('c')) => break,
+
+                // submit
+                (_, KeyCode::Enter) => {
+                    let line = input_buf.clone();
+                    input_buf.clear();
+                    cursor_pos = 0;
+                    history_idx = None;
+                    scroll_offset = 0;
+
+                    if line.trim().is_empty() && accumulated.is_empty() {
+                        continue;
+                    }
+
+                    // commands only at top level (not inside a multiline block)
+                    if accumulated.is_empty() && line.trim().starts_with(':') {
+                        if line.trim() == ":exit" {
+                            break;
+                        }
+                        output.push(OutputLine::Input(line.clone()));
+                        handle_command(line.trim(), &mut output, &mut evaluator, &mut attached);
+                        if !line.trim().is_empty() {
+                            history.push(line);
+                        }
+                        continue;
+                    }
+
+                    // record which prompt was shown for this line before we push to accumulated
+                    let is_first_line = accumulated.is_empty();
+
+                    if !accumulated.is_empty() {
+                        accumulated.push('\n');
+                    }
+                    accumulated.push_str(&line);
+
+                    // first line: render_output adds ">> " prefix automatically via Input variant
+                    // continuation lines: prepend ".. " inside the string so it shows correctly
+                    if is_first_line {
+                        output.push(OutputLine::Input(line.clone()));
+                    } else {
+                        output.push(OutputLine::Input(format!(".. {}", line)));
+                    }
+
+                    if is_complete(&accumulated)
+                        && (accumulated.lines().count() > 1
+                            || !accumulated.trim_end().ends_with('{'))
+                    {
+                        let full = accumulated.clone();
+                        accumulated.clear();
+                        if !full.trim().is_empty() {
+                            history.push(full.trim().to_string());
+                        }
+                        eval_input(full.trim(), &mut evaluator, &mut output);
+                    }
+                }
+
+                // backspace
+                (_, KeyCode::Backspace) => {
+                    if cursor_pos > 0 {
+                        let byte_pos = char_to_byte(&input_buf, cursor_pos - 1);
+                        input_buf.remove(byte_pos);
+                        cursor_pos -= 1;
+                    }
+                }
+
+                // delete
+                (_, KeyCode::Delete) => {
+                    if cursor_pos < input_buf.chars().count() {
+                        let byte_pos = char_to_byte(&input_buf, cursor_pos);
+                        input_buf.remove(byte_pos);
+                    }
+                }
+
+                // word jump (ctrl+left / ctrl+right)
+                (KeyModifiers::CONTROL, KeyCode::Left) => {
+                    let chars: Vec<char> = input_buf.chars().collect();
+                    let mut i = cursor_pos;
+                    while i > 0 && chars[i - 1] == ' ' {
+                        i -= 1;
+                    }
+                    while i > 0 && chars[i - 1] != ' ' {
+                        i -= 1;
+                    }
+                    cursor_pos = i;
+                }
+                (KeyModifiers::CONTROL, KeyCode::Right) => {
+                    let chars: Vec<char> = input_buf.chars().collect();
+                    let len = chars.len();
+                    let mut i = cursor_pos;
+                    while i < len && chars[i] != ' ' {
+                        i += 1;
+                    }
+                    while i < len && chars[i] == ' ' {
+                        i += 1;
+                    }
+                    cursor_pos = i;
+                }
+
+                // cursor movement
+                (_, KeyCode::Left) => {
+                    if cursor_pos > 0 {
+                        cursor_pos -= 1;
+                    }
+                }
+
+                (_, KeyCode::Right) => {
+                    if cursor_pos < input_buf.chars().count() {
+                        cursor_pos += 1;
+                    }
+                }
+
+                (_, KeyCode::Home) => cursor_pos = 0,
+
+                (_, KeyCode::End) => cursor_pos = input_buf.chars().count(),
+
+                // scroll output (shift+up/down)
+                (KeyModifiers::SHIFT, KeyCode::Up) => {
+                    scroll_offset += 1;
+                }
+
+                (KeyModifiers::SHIFT, KeyCode::Down) => {
+                    scroll_offset = scroll_offset.saturating_sub(1);
+                }
+
+                // history up
+                (_, KeyCode::Up) => {
+                    if history.is_empty() {
+                        continue;
+                    }
+                    let new_idx = match history_idx {
+                        None => history.len() - 1,
+                        Some(0) => 0,
+                        Some(i) => i - 1,
+                    };
+                    history_idx = Some(new_idx);
+                    input_buf = history[new_idx].clone();
+                    cursor_pos = input_buf.chars().count();
+                }
+
+                // history down
+                (_, KeyCode::Down) => match history_idx {
+                    None => {}
+                    Some(i) if i + 1 >= history.len() => {
+                        history_idx = None;
+                        input_buf.clear();
+                        cursor_pos = 0;
+                    }
+                    Some(i) => {
+                        history_idx = Some(i + 1);
+                        input_buf = history[i + 1].clone();
+                        cursor_pos = input_buf.chars().count();
+                    }
+                },
+
+                // escape — cancel multiline accumulation
+                (_, KeyCode::Esc) => {
+                    if !accumulated.is_empty() {
+                        accumulated.clear();
+                        output.push(OutputLine::Info("cancelled".into()));
+                    }
+                    input_buf.clear();
+                    cursor_pos = 0;
+                }
+
+                // normal character input
+                (_, KeyCode::Char(c)) => {
+                    let byte_pos = char_to_byte(&input_buf, cursor_pos);
+                    input_buf.insert(byte_pos, c);
+                    cursor_pos += 1;
+                }
+
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,5 +1,3 @@
-use std::panic;
-
 mod command_handler;
 mod depth_checker;
 mod input_eval;
@@ -11,8 +9,6 @@ mod syntax_highlighting;
 mod utils;
 
 pub fn start_repl() {
-    panic::set_hook(Box::new(|_| {}));
-
     let mut terminal = ratatui::init();
     let result = logic_loop::run_repl(&mut terminal);
     ratatui::restore();

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,0 +1,23 @@
+use std::panic;
+
+mod command_handler;
+mod depth_checker;
+mod input_eval;
+mod lines_types;
+mod logic_loop;
+mod output_render;
+mod stdlib_helper;
+mod syntax_highlighting;
+mod utils;
+
+pub fn start_repl() {
+    panic::set_hook(Box::new(|_| {}));
+
+    let mut terminal = ratatui::init();
+    let result = logic_loop::run_repl(&mut terminal);
+    ratatui::restore();
+
+    if let Err(e) = result {
+        eprintln!("repl error: {}", e);
+    }
+}

--- a/src/repl/output_render.rs
+++ b/src/repl/output_render.rs
@@ -11,8 +11,8 @@ pub fn render_output(output: &[OutputLine]) -> Vec<Line<'static>> {
         .map(|line| match line {
             OutputLine::Input(s) => {
                 // strips ".. "
-                let (prefix, code) = if s.starts_with(".. ") {
-                    (".. ", &s[3..])
+                let (prefix, code) = if let Some(stripped) = s.strip_prefix(".. ") {
+                    (".. ", stripped)
                 } else {
                     (">> ", s.as_str())
                 };
@@ -26,8 +26,8 @@ pub fn render_output(output: &[OutputLine]) -> Vec<Line<'static>> {
                 Line::from(spans)
             }
             OutputLine::ValidInput(s) => {
-                let (prefix, code) = if s.starts_with(".. ") {
-                    (".. ", &s[3..])
+                let (prefix, code) = if let Some(stripped) = s.strip_prefix(".. ") {
+                    (".. ", stripped)
                 } else {
                     (">> ", s.as_str())
                 };

--- a/src/repl/output_render.rs
+++ b/src/repl/output_render.rs
@@ -1,0 +1,67 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+use crate::repl::{lines_types::OutputLine, syntax_highlighting::highlight};
+
+pub fn render_output(output: &[OutputLine]) -> Vec<Line<'static>> {
+    output
+        .iter()
+        .map(|line| match line {
+            OutputLine::Input(s) => {
+                // strips ".. "
+                let (prefix, code) = if s.starts_with(".. ") {
+                    (".. ", &s[3..])
+                } else {
+                    (">> ", s.as_str())
+                };
+                let mut spans = vec![Span::styled(
+                    prefix,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )];
+                spans.extend(highlight(code));
+                Line::from(spans)
+            }
+            OutputLine::Result(s) => {
+                // try to highlight if it is correct
+                let spans = highlight(s);
+                // highlight returns red on lex failure
+                let is_code = spans.iter().any(|sp| {
+                    sp.style
+                        .fg
+                        .map(|c| c != Color::Red && c != Color::White)
+                        .unwrap_or(false)
+                });
+                if is_code {
+                    Line::from(spans)
+                } else {
+                    Line::from(Span::styled(s.clone(), Style::default().fg(Color::Green)))
+                }
+            }
+            OutputLine::Error(s) => Line::from(vec![
+                Span::styled(
+                    "✗ ",
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(s.clone(), Style::default().fg(Color::Red)),
+            ]),
+            OutputLine::Info(s) => Line::from(Span::styled(
+                s.clone(),
+                Style::default().fg(Color::DarkGray),
+            )),
+            OutputLine::Separator => Line::from(Span::styled(
+                "─".repeat(40),
+                Style::default().fg(Color::DarkGray),
+            )),
+            OutputLine::Styled(parts) => Line::from(
+                parts
+                    .iter()
+                    .map(|(text, style)| Span::styled(text.clone(), *style))
+                    .collect::<Vec<_>>(),
+            ),
+        })
+        .collect()
+}

--- a/src/repl/output_render.rs
+++ b/src/repl/output_render.rs
@@ -25,6 +25,21 @@ pub fn render_output(output: &[OutputLine]) -> Vec<Line<'static>> {
                 spans.extend(highlight(code));
                 Line::from(spans)
             }
+            OutputLine::ValidInput(s) => {
+                let (prefix, code) = if s.starts_with(".. ") {
+                    (".. ", &s[3..])
+                } else {
+                    (">> ", s.as_str())
+                };
+                let mut spans = vec![Span::styled(
+                    prefix,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )];
+                spans.extend(highlight(code));
+                Line::from(spans)
+            }
             OutputLine::Result(s) => {
                 // try to highlight if it is correct
                 let spans = highlight(s);

--- a/src/repl/stdlib_helper.rs
+++ b/src/repl/stdlib_helper.rs
@@ -1,0 +1,39 @@
+pub struct StdEntry {
+    pub name: &'static str,
+    pub functions: &'static [(&'static str, &'static str)],
+}
+
+pub fn stdlib_entries() -> Vec<StdEntry> {
+    vec![
+        StdEntry {
+            name: "math",
+            functions: &[
+                ("pow(x, n)", "x raised to the power n"),
+                ("abs(x)", "absolute value"),
+                ("sqrt(x)", "square root"),
+                ("floor(x)", "round down"),
+                ("ceil(x)", "round up"),
+                ("round(x)", "round to nearest"),
+                ("min(a, b)", "minimum of two values"),
+                ("max(a, b)", "maximum of two values"),
+                ("log(x, base)", "logarithm"),
+                ("clamp(x, lo, hi)", "clamp x between lo and hi"),
+            ],
+        },
+        StdEntry {
+            name: "display",
+            functions: &[
+                ("print(x)", "print without newline"),
+                ("println(x)", "print with newline"),
+                ("len(x)", "length of string or array"),
+            ],
+        },
+        StdEntry {
+            name: "io",
+            functions: &[
+                ("input()", "read a line from stdin"),
+                ("input(prompt)", "prints prompt and read a line from stdin"),
+            ],
+        },
+    ]
+}

--- a/src/repl/syntax_highlighting.rs
+++ b/src/repl/syntax_highlighting.rs
@@ -1,0 +1,158 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::Span,
+};
+
+use crate::{
+    lexer::{tokenizer::Tokenizer, tokentypes::TokenType},
+    utils::source::SourceFile,
+};
+
+fn token_color(tt: &TokenType) -> Style {
+    match tt {
+        // control flow — cyan bold
+        TokenType::If
+        | TokenType::Else
+        | TokenType::While
+        | TokenType::For
+        | TokenType::Break
+        | TokenType::Continue
+        | TokenType::Return => Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+
+        // declarations cyan italic
+        TokenType::Dec | TokenType::Const | TokenType::Fn | TokenType::Array => Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::ITALIC),
+
+        // import keywords cyan dim
+        TokenType::Get | TokenType::From => {
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM)
+        }
+
+        // types light blue italic
+        TokenType::Int
+        | TokenType::Float
+        | TokenType::Bool
+        | TokenType::String
+        | TokenType::Char => Style::default()
+            .fg(Color::LightBlue)
+            .add_modifier(Modifier::ITALIC),
+
+        // logic operators yellow
+        TokenType::Or | TokenType::And => Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+
+        // number literals magenta
+        TokenType::NumberLiteral(_) | TokenType::FloatLiteral(_) => {
+            Style::default().fg(Color::Magenta)
+        }
+
+        // string literals yellow
+        TokenType::StringLiteral(_) => Style::default().fg(Color::Yellow),
+
+        // char literals light yellow
+        TokenType::CharacterLiteral(_) => Style::default().fg(Color::LightYellow),
+
+        // bool literals magenta italic
+        TokenType::BoolLiteral(_) => Style::default()
+            .fg(Color::Magenta)
+            .add_modifier(Modifier::ITALIC),
+
+        // null dark gray italic
+        TokenType::Null => Style::default()
+            .fg(Color::DarkGray)
+            .add_modifier(Modifier::ITALIC),
+
+        // arrow white dim (->)
+        TokenType::Arrow => Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::DIM),
+
+        // operators white
+        TokenType::Plus
+        | TokenType::Minus
+        | TokenType::Star
+        | TokenType::Slash
+        | TokenType::Bang
+        | TokenType::PlusEqual
+        | TokenType::MinusEqual
+        | TokenType::StarEqual
+        | TokenType::SlashEqual => Style::default().fg(Color::White),
+
+        // comparison operators light cyan
+        TokenType::Compare
+        | TokenType::BangEqual
+        | TokenType::Greater
+        | TokenType::GreaterEqual
+        | TokenType::Less
+        | TokenType::LessEqual => Style::default().fg(Color::LightCyan),
+
+        // assignment white
+        TokenType::Assign => Style::default().fg(Color::White),
+
+        // punctuation dark gray
+        TokenType::Comma
+        | TokenType::Semicolon
+        | TokenType::Colon
+        | TokenType::ColonColon
+        | TokenType::Dot
+        | TokenType::DotDot
+        | TokenType::Hash
+        | TokenType::BangHash => Style::default().fg(Color::DarkGray),
+
+        // braces/parens/brackets dark gray
+        TokenType::LeftBrace
+        | TokenType::RightBrace
+        | TokenType::LeftParen
+        | TokenType::RightParen
+        | TokenType::LeftBracket
+        | TokenType::RightBracket => Style::default().fg(Color::DarkGray),
+
+        // identifiers white
+        TokenType::Identifier(_) => Style::default().fg(Color::White),
+
+        _ => Style::default().fg(Color::White),
+    }
+}
+
+pub fn highlight(input: &str) -> Vec<Span<'static>> {
+    let source = SourceFile::new("<hl>", input.to_string());
+    let tokens = match Tokenizer::lex(source) {
+        Ok(t) => t,
+        Err(_) => {
+            return vec![Span::styled(
+                input.to_string(),
+                Style::default().fg(Color::Red),
+            )];
+        }
+    };
+
+    let mut spans = Vec::new();
+    let mut last = 0usize;
+    let chars: Vec<char> = input.chars().collect();
+
+    for tok in &tokens {
+        let start = tok.span.start;
+        let end = tok.span.end;
+
+        if start > last {
+            let gap: String = chars[last..start].iter().collect();
+            spans.push(Span::raw(gap));
+        }
+
+        let text: String = chars[start..end].iter().collect();
+        let style = token_color(&tok.token); // ← Style now, not Color
+        spans.push(Span::styled(text, style));
+        last = end;
+    }
+
+    if last < chars.len() {
+        let tail: String = chars[last..].iter().collect();
+        spans.push(Span::raw(tail));
+    }
+
+    spans
+}

--- a/src/repl/utils.rs
+++ b/src/repl/utils.rs
@@ -1,0 +1,12 @@
+use crate::repl::lines_types::OutputLine;
+
+pub fn push_error(output: &mut Vec<OutputLine>, e: &crate::utils::errors::Error) {
+    output.push(OutputLine::Error(format!("error: {}", e.message())));
+}
+
+pub fn char_to_byte(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(b, _)| b)
+        .unwrap_or(s.len())
+}

--- a/src/repl_terminal.rs
+++ b/src/repl_terminal.rs
@@ -8,7 +8,7 @@ use crate::{
     utils::source::SourceFile,
 };
 
-pub fn repl() {
+pub fn start_repl() {
     panic::set_hook(Box::new(|_| {}));
 
     let mut evaluator = Evaluator::default().with_stdlib();

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -5,16 +5,10 @@ use ariadne::{Color, Label, Report, ReportKind, Source};
 use crate::utils::source::SourceFile;
 use crate::utils::span::Span;
 
-/// represents an Interpreter error with optional line number and error category
-pub struct Error {
-    /// readable message
-    message: String,
-    /// line number of error in source file (legacy; superseded by `primary.0` when present)
-    line: Option<usize>,
-    /// the category and optional context of the error
-    reason: Option<ErrorReason>,
+/// heavy optional fields, heap-allocated so `Error` stays small on the stack
+struct ErrorDetail {
     /// primary span (anchor of the ariadne report) and its label text
-    primary: Option<(Span, String)>,
+    primary: (Span, String),
     /// secondary spans with labels
     labels: Vec<(Span, String)>,
     /// source string for rendering; supplied by the subsystem that built the error
@@ -23,6 +17,18 @@ pub struct Error {
     source_name: Option<String>,
     /// optional help/hint line shown after the snippet (e.g. "did you mean foo?")
     help: Option<String>,
+}
+
+/// represents an Interpreter error with optional line number and error category
+pub struct Error {
+    /// readable message
+    message: String,
+    /// line number of error in source file (legacy; superseded by `detail.primary.0` when present)
+    line: Option<usize>,
+    /// the category and optional context of the error
+    reason: Option<ErrorReason>,
+    /// boxed span-aware detail; `None` for legacy errors that have no span
+    detail: Option<Box<ErrorDetail>>,
 }
 
 /// provides an error category with optional error context
@@ -62,11 +68,7 @@ impl Error {
             message,
             line,
             reason,
-            primary: None,
-            labels: Vec::new(),
-            source: None,
-            source_name: None,
-            help: None,
+            detail: None,
         }
     }
 
@@ -80,50 +82,62 @@ impl Error {
             message: message.clone(),
             line: None,
             reason: Some(ErrorReason::init(kind, None)),
-            primary: Some((span, message)),
-            labels: Vec::new(),
-            source: None,
-            source_name: None,
-            help: None,
+            detail: Some(Box::new(ErrorDetail {
+                primary: (span, message),
+                labels: Vec::new(),
+                source: None,
+                source_name: None,
+                help: None,
+            })),
         }
     }
 
     /// override the primary label text (defaults to the error message).
     pub fn with_primary_label(mut self, label: impl Into<String>) -> Self {
-        if let Some((sp, _)) = self.primary {
-            self.primary = Some((sp, label.into()));
+        if let Some(d) = &mut self.detail {
+            d.primary.1 = label.into();
         }
         self
     }
 
     /// add a secondary label to the report.
     pub fn with_label(mut self, span: Span, label: impl Into<String>) -> Self {
-        self.labels.push((span, label.into()));
+        if let Some(d) = &mut self.detail {
+            d.labels.push((span, label.into()));
+        }
         self
     }
 
     /// attach the source string so ariadne can render snippets.
     pub fn with_source(mut self, source: Arc<String>) -> Self {
-        self.source = Some(source);
+        if let Some(d) = &mut self.detail {
+            d.source = Some(source);
+        }
         self
     }
 
     /// attach a human-readable source name (e.g. file path).
     pub fn with_source_name(mut self, name: impl Into<String>) -> Self {
-        self.source_name = Some(name.into());
+        if let Some(d) = &mut self.detail {
+            d.source_name = Some(name.into());
+        }
         self
     }
 
     /// attach a help/hint line shown beneath the snippet (e.g. "did you mean foo?").
     pub fn with_help(mut self, help: impl Into<String>) -> Self {
-        self.help = Some(help.into());
+        if let Some(d) = &mut self.detail {
+            d.help = Some(help.into());
+        }
         self
     }
 
     /// attach both the source text and name from a [`SourceFile`].
     pub fn with_source_file(mut self, file: &SourceFile) -> Self {
-        self.source = Some(Arc::clone(&file.text));
-        self.source_name = Some(file.name.to_string());
+        if let Some(d) = &mut self.detail {
+            d.source = Some(Arc::clone(&file.text));
+            d.source_name = Some(file.name.to_string());
+        }
         self
     }
 
@@ -139,8 +153,11 @@ impl Error {
     /// renders the error to stderr without terminating. used by call sites that already
     /// own their control flow (e.g. anything returning `Result`).
     pub fn report_to_stderr(&self) {
-        if let (Some(src), Some((sp, primary_label))) = (&self.source, &self.primary) {
-            let name: &str = self.source_name.as_deref().unwrap_or("<source>");
+        if let Some(d) = &self.detail
+            && let Some(src) = &d.source
+        {
+            let name: &str = d.source_name.as_deref().unwrap_or("<source>");
+            let (sp, primary_label) = &d.primary;
             let mut builder = Report::build(ReportKind::Error, (name, sp.start..sp.end))
                 .with_message(&self.message)
                 .with_label(
@@ -148,20 +165,21 @@ impl Error {
                         .with_message(primary_label)
                         .with_color(Color::Red),
                 );
-            for (lsp, label) in &self.labels {
+            for (lsp, label) in &d.labels {
                 builder = builder.with_label(
                     Label::new((name, lsp.start..lsp.end))
                         .with_message(label)
                         .with_color(Color::Yellow),
                 );
             }
-            if let Some(help) = &self.help {
+            if let Some(help) = &d.help {
                 builder = builder.with_help(help);
             }
             let _ = builder.finish().eprint((name, Source::from(src.as_str())));
-        } else {
-            self.fallback_text();
+            return;
         }
+
+        self.fallback_text();
     }
 
     /// legacy text rendering kept verbatim from the original implementation.

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -56,6 +56,7 @@ impl Error {
     /// legacy constructor: builds an error with just a message, optional line, and reason.
     /// Used by call sites that haven't been migrated to span-based errors yet.
     pub fn init(message: String, line: Option<usize>, reason: Option<ErrorReason>) -> Self {
+        #[cfg(feature = "debug")]
         log::debug!("Error: {}", message);
         Self {
             message,
@@ -73,6 +74,7 @@ impl Error {
     /// the `span` becomes the primary anchor of the report.
     pub fn at(kind: Reason, message: impl Into<String>, span: Span) -> Self {
         let message = message.into();
+        #[cfg(feature = "debug")]
         log::debug!("Error: {}", message);
         Self {
             message: message.clone(),
@@ -207,5 +209,11 @@ impl ErrorReason {
             Reason::Runtime => "Runtime Error",
         }
         .to_string()
+    }
+}
+
+impl Error {
+    pub fn message(&self) -> &str {
+        &self.message
     }
 }


### PR DESCRIPTION
## rl-lang v0.1.0

First public release of rl-lang  a statically typed, general-purpose scripting language implemented in Rust.

### What's included

Language
- Static typing with type inference
- Variables, constants, arrays
- Functions with typed parameters and return types
- First-class functions and closures
- Control flow: if/else, while, for, for-range, foreach
- Break, continue, return
- CONST immutability
- Stdlib imports via get x from std::module or get std::module::x

Standard Library
- std::math — arithmetic, trig, constants, and more
- std::display — print, println, len
- std::io — input

Tooling
- Ratatui TUI REPL with syntax highlighting, history, multiline input
- REPL commands: :help, :stdlib, :save, :load, :attach, :detach
- Ariadne error reporting with source spans and hints

Binaries
| File | Platform | Features |
|------|----------|----------|
| rl | Linux x86-64 | default |
| rl_debug | Linux x86-64 | debug logging |
| rl.exe | Windows x86-64 | default |
| rl_debug.exe | Windows x86-64 | debug logging |

### What's next (v0.2.0)
- VM bytecode backend