### PR TITLE
Feat/std path

### DIFF
--- a/src/docs/entries/mod.rs
+++ b/src/docs/entries/mod.rs
@@ -12,6 +12,7 @@ pub fn stdlib_entries() -> Vec<&'static StdEntry> {
         &stdlib::arrays::ARRAY,
         &stdlib::str::STR,
         &stdlib::types::TYPES,
+        &stdlib::path::PATH,
     ]
 }
 

--- a/src/docs/entries/stdlib/mod.rs
+++ b/src/docs/entries/stdlib/mod.rs
@@ -3,5 +3,6 @@ pub mod constants;
 pub mod display;
 pub mod io;
 pub mod math;
+pub mod path;
 pub mod str;
 pub mod types;

--- a/src/docs/entries/stdlib/path.rs
+++ b/src/docs/entries/stdlib/path.rs
@@ -1,0 +1,87 @@
+use crate::docs::entry::{FnEntry, StdEntry};
+
+pub static PATH: StdEntry = StdEntry {
+    name: "path",
+    description: "functions for working with filesystem paths",
+    functions: FUNCTIONS,
+};
+
+static FUNCTIONS: &[&FnEntry] = &[
+    &PATH_EXISTS,
+    &PATH_EXTENSION,
+    &PATH_FILENAME,
+    &PATH_IS_DIR,
+    &PATH_IS_FILE,
+    &PATH_JOIN,
+    &PATH_PARENT,
+    &PATH_POP,
+    &PATH_PUSH,
+    &PATH_SET_EXTENSION,
+    &PATH_STEM,
+];
+
+static PATH_EXISTS: FnEntry = FnEntry {
+    signature: "path_exists(path)",
+    description: "returns true if the path exists on the filesystem",
+    example: "get std::path::path_exists\n\npath_exists(\"./Cargo.toml\") // true",
+};
+
+static PATH_EXTENSION: FnEntry = FnEntry {
+    signature: "path_extension(path)",
+    description: "returns the file extension of the path",
+    example: "get std::path::path_extension\n\npath_extension(\"main.rl\") // \"rl\"",
+};
+
+static PATH_FILENAME: FnEntry = FnEntry {
+    signature: "path_filename(path)",
+    description: "returns the final component of the path",
+    example: "get std::path::path_filename\n\npath_filename(\"/usr/bin/rl\") // \"rl\"",
+};
+
+static PATH_IS_DIR: FnEntry = FnEntry {
+    signature: "path_is_dir(path)",
+    description: "returns true if the path is a directory",
+    example: "get std::path::path_is_dir\n\npath_is_dir(\"./src\") // true",
+};
+
+static PATH_IS_FILE: FnEntry = FnEntry {
+    signature: "path_is_file(path)",
+    description: "returns true if the path is a file",
+    example: "get std::path::path_is_file\n\npath_is_file(\"./Cargo.toml\") // true",
+};
+
+static PATH_JOIN: FnEntry = FnEntry {
+    signature: "path_join(path, other)",
+    description: "joins two paths together",
+    example: "get std::path::path_join\n\npath_join(\"src\", \"main.rl\") // \"src/main.rl\"",
+};
+
+static PATH_PARENT: FnEntry = FnEntry {
+    signature: "path_parent(path)",
+    description: "returns the parent directory of the path",
+    example: "get std::path::path_parent\n\npath_parent(\"/usr/bin/rl\") // \"/usr/bin\"",
+};
+
+static PATH_POP: FnEntry = FnEntry {
+    signature: "path_pop(path)",
+    description: "removes the last component of the path and returns the result",
+    example: "get std::path::path_pop\n\npath_pop(\"/usr/bin/rl\") // \"/usr/bin\"",
+};
+
+static PATH_PUSH: FnEntry = FnEntry {
+    signature: "path_push(path, target)",
+    description: "appends a component to the path and returns the result",
+    example: "get std::path::path_push\n\npath_push(\"/usr/bin\", \"rl\") // \"/usr/bin/rl\"",
+};
+
+static PATH_SET_EXTENSION: FnEntry = FnEntry {
+    signature: "path_set_extension(path, extension)",
+    description: "sets or replaces the extension of the path and returns the result",
+    example: "get std::path::path_set_extension\n\npath_set_extension(\"main.rl\", \"txt\") // \"main.txt\"",
+};
+
+static PATH_STEM: FnEntry = FnEntry {
+    signature: "path_stem(path)",
+    description: "returns the filename without its extension",
+    example: "get std::path::path_stem\n\npath_stem(\"main.rl\") // \"main\"",
+};

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -93,7 +93,8 @@ impl Evaluator {
                 .with_module(stdlib::io::module())
                 .with_module(stdlib::string::module())
                 .with_module(stdlib::types::module())
-                .with_module(stdlib::array::module()),
+                .with_module(stdlib::array::module())
+                .with_module(stdlib::path::module()),
         )
     }
 
@@ -470,6 +471,7 @@ impl Evaluator {
                 .chain(stdlib::string::KEYWORDS)
                 .chain(stdlib::types::KEYWORDS)
                 .chain(stdlib::array::KEYWORDS)
+                .chain(stdlib::path::KEYWORDS)
                 .copied();
             if let Some(suggestion) = closest_match(last, candidates) {
                 err = err.with_help(format!("did you mean `{}`?", suggestion));

--- a/src/interpreter/stdlib/mod.rs
+++ b/src/interpreter/stdlib/mod.rs
@@ -2,5 +2,6 @@ pub mod array;
 pub mod display;
 pub mod io;
 pub mod math;
+pub mod path;
 pub mod string;
 pub mod types;

--- a/src/interpreter/stdlib/path/mod.rs
+++ b/src/interpreter/stdlib/path/mod.rs
@@ -1,0 +1,27 @@
+mod path_absolute;
+mod path_extension;
+mod path_filename;
+mod path_join;
+mod path_parent;
+mod path_stem;
+
+use crate::interpreter::native::Module;
+
+pub const KEYWORDS: &[&str] = &[
+    "path_absolute",
+    "path_extension",
+    "path_filename",
+    "path_join",
+    "path_parent",
+    "path_stem",
+];
+
+pub fn module() -> Module {
+    Module::new("path")
+        .with_function("path_absolute", path_absolute::std_path_absolute)
+        .with_function("path_extension", path_extension::std_path_extension)
+        .with_function("path_filename", path_filename::std_path_filename)
+        .with_function("path_join", path_join::std_path_join)
+        .with_function("path_parent", path_parent::std_path_parent)
+        .with_function("path_stem", path_stem::std_path_stem)
+}

--- a/src/interpreter/stdlib/path/mod.rs
+++ b/src/interpreter/stdlib/path/mod.rs
@@ -1,27 +1,45 @@
-mod path_absolute;
+mod path_exists;
 mod path_extension;
 mod path_filename;
+mod path_is_dir;
+mod path_is_file;
 mod path_join;
 mod path_parent;
+mod path_pop;
+mod path_push;
+mod path_set_extension;
 mod path_stem;
 
 use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
-    "path_absolute",
+    "path_exists",
     "path_extension",
     "path_filename",
+    "path_is_dir",
+    "path_is_file",
     "path_join",
     "path_parent",
+    "path_pop",
+    "path_push",
+    "path_set_extension",
     "path_stem",
 ];
 
 pub fn module() -> Module {
     Module::new("path")
-        .with_function("path_absolute", path_absolute::std_path_absolute)
+        .with_function("path_exists", path_exists::std_path_exists)
         .with_function("path_extension", path_extension::std_path_extension)
         .with_function("path_filename", path_filename::std_path_filename)
+        .with_function("path_is_dir", path_is_dir::std_path_is_dir)
+        .with_function("path_is_file", path_is_file::std_path_is_file)
         .with_function("path_join", path_join::std_path_join)
         .with_function("path_parent", path_parent::std_path_parent)
+        .with_function("path_pop", path_pop::std_path_pop)
+        .with_function("path_push", path_push::std_path_push)
+        .with_function(
+            "path_set_extension",
+            path_set_extension::std_path_set_extension,
+        )
         .with_function("path_stem", path_stem::std_path_stem)
 }

--- a/src/interpreter/stdlib/path/path_exists.rs
+++ b/src/interpreter/stdlib/path/path_exists.rs
@@ -5,7 +5,7 @@ use crate::{
 
 pub fn std_path_exists(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
     match path {
-        Value::String(s) => Ok(Value::Bool(std::path::Path::new(s).exists())),
+        Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).exists())),
         other => Err(Error::init(
             format!("path_exists() expects a string, got {}", other.type_name()),
             None,

--- a/src/interpreter/stdlib/path/path_exists.rs
+++ b/src/interpreter/stdlib/path/path_exists.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_exists(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::Bool(std::path::Path::new(s).exists())),
+        other => Err(Error::init(
+            format!("path_exists() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_extension.rs
+++ b/src/interpreter/stdlib/path/path_extension.rs
@@ -1,0 +1,20 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_extension(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::String(
+            std::path::Path::new(s).extension().to_string(),
+        )),
+        other => Err(Error::init(
+            format!(
+                "path_extension() expects a string, got {}",
+                other.type_name()
+            ),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_extension.rs
+++ b/src/interpreter/stdlib/path/path_extension.rs
@@ -6,7 +6,11 @@ use crate::{
 pub fn std_path_extension(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
-            std::path::Path::new(s).extension().to_string(),
+            std::path::Path::new(&s)
+                .extension()
+                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .to_string_lossy()
+                .to_string(),
         )),
         other => Err(Error::init(
             format!(

--- a/src/interpreter/stdlib/path/path_filename.rs
+++ b/src/interpreter/stdlib/path/path_filename.rs
@@ -1,0 +1,20 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_filename(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::String(
+            std::path::Path::new(s).file_name().to_string(),
+        )),
+        other => Err(Error::init(
+            format!(
+                "path_filename() expects a string, got {}",
+                other.type_name()
+            ),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_filename.rs
+++ b/src/interpreter/stdlib/path/path_filename.rs
@@ -6,7 +6,11 @@ use crate::{
 pub fn std_path_filename(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
-            std::path::Path::new(s).file_name().to_string(),
+            std::path::Path::new(&s)
+                .file_name()
+                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .to_string_lossy()
+                .to_string(),
         )),
         other => Err(Error::init(
             format!(

--- a/src/interpreter/stdlib/path/path_is_dir.rs
+++ b/src/interpreter/stdlib/path/path_is_dir.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_is_dir(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).is_dir())),
+        other => Err(Error::init(
+            format!("path_is_dir() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_is_file.rs
+++ b/src/interpreter/stdlib/path/path_is_file.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_is_file(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).is_file())),
+        other => Err(Error::init(
+            format!("path_is_file() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_join.rs
+++ b/src/interpreter/stdlib/path/path_join.rs
@@ -1,0 +1,20 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_join(_: &mut Evaluator, path: Value, target: String) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::String(
+            std::path::PathBuf::from(&s)
+                .join(&target)
+                .to_string_lossy()
+                .to_string(),
+        )),
+        other => Err(Error::init(
+            format!("path_join() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_parent.rs
+++ b/src/interpreter/stdlib/path/path_parent.rs
@@ -1,0 +1,21 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_parent(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::String(
+            std::path::Path::new(&s)
+                .parent()
+                .ok_or_else(|| Error::init("path was not found".to_string(), None, None))?
+                .to_string_lossy()
+                .to_string(),
+        )),
+        other => Err(Error::init(
+            format!("path_parent() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_pop.rs
+++ b/src/interpreter/stdlib/path/path_pop.rs
@@ -1,0 +1,19 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_pop(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => {
+            let mut buf = std::path::PathBuf::from(&s);
+            buf.pop();
+            Ok(Value::String(buf.to_string_lossy().to_string()))
+        }
+        other => Err(Error::init(
+            format!("path_push() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_push.rs
+++ b/src/interpreter/stdlib/path/path_push.rs
@@ -1,0 +1,19 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_push(_: &mut Evaluator, path: Value, target: String) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => {
+            let mut buf = std::path::PathBuf::from(&s);
+            buf.push(&target);
+            Ok(Value::String(buf.to_string_lossy().to_string()))
+        }
+        other => Err(Error::init(
+            format!("path_push() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_set_extension.rs
+++ b/src/interpreter/stdlib/path/path_set_extension.rs
@@ -1,0 +1,26 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_set_extension(
+    _: &mut Evaluator,
+    path: Value,
+    target: String,
+) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => {
+            let mut buf = std::path::PathBuf::from(&s);
+            buf.set_extension(&target);
+            Ok(Value::String(buf.to_string_lossy().to_string()))
+        }
+        other => Err(Error::init(
+            format!(
+                "path_set_extension() expects a string, got {}",
+                other.type_name()
+            ),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/path_stem.rs
+++ b/src/interpreter/stdlib/path/path_stem.rs
@@ -1,0 +1,21 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::Error,
+};
+
+pub fn std_path_stem(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+    match path {
+        Value::String(s) => Ok(Value::String(
+            std::path::Path::new(&s)
+                .file_stem()
+                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .to_string_lossy()
+                .to_string(),
+        )),
+        other => Err(Error::init(
+            format!("path_stem() expects a string, got {}", other.type_name()),
+            None,
+            None,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/path/plan.md
+++ b/src/interpreter/stdlib/path/plan.md
@@ -1,7 +1,0 @@
-# path
-- `path_join(a, b)`
-- `path_parent(p)`
-- `path_filename(p)`
-- `path_extension(p)`
-- `path_stem(p)`
-- `path_absolute(p)`


### PR DESCRIPTION
## What does this PR do?

Adds a new `path` stdlib module for working with filesystem paths, plus its docs entry (`FnEntry`/`StdEntry`) following the existing stdlib documentation pattern.

### functions

- `path_exists(path)` -> returns `true` if the path exists on the filesystem
- `path_extension(path)` -> returns the file extension of the path
- `path_filename(path)` -> returns the final component of the path
- `path_is_dir(path)` -> returns `true` if the path is a directory
- `path_is_file(path)` -> returns `true` if the path is a file
- `path_join(path, other)` -> joins two paths together
- `path_parent(path)` -> returns the parent directory of the path
- `path_pop(path)` -> removes the last component of the path and returns the result
- `path_push(path, target)` -> appends a component to the path and returns the result
- `path_set_extension(path, extension)` -> sets or replaces the extension of the path and returns the result
- `path_stem(path)` -> returns the filename without its extension

### Testing

manually exercised all 11 functions against real paths (`Cargo.toml`, `src/`) and confirmed output matches the documented examples.

but! it still needs test units...