### PR TITLE
Feat/std io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RL is a statically-typed interpreted language with a clean syntax, a TUI REPL, a
 ## Quick look
 
 ```rl
-get println, len from std::display
+get println, len from std::io
 get pow, mod, factorial, fibonacci, is_prime from std::math
 get PI from std::math::consts
 

--- a/benches/v0_1_0.rs
+++ b/benches/v0_1_0.rs
@@ -46,7 +46,7 @@ const SRC_FN_FN_PARAM: &str = "fn x (fn x, int y) {return x(y)}";
 const SRC_DEC_FN_LAMBDA: &str = "dec fn x = fn(int x) {return x}";
 
 const SRC_PROGRAM_MATH_PRINT: &str = "\
-get println from std::display
+get println from std::io
 get pow from std::math
 get std::math::consts::PI
 
@@ -56,7 +56,7 @@ dec float x = pow(pi, pi)
 println(x, y)";
 
 const SRC_PROGRAM_GEOMETRY: &str = "\
-get println from std::display
+get println from std::io
 get sin, cos, hypot, is_prime, log2, factorial from std::math
 get PI, TAU, PHI from std::math::consts
 
@@ -82,7 +82,7 @@ dec bool big = lg > TAU()
 println(hyp, is_right, prime, big)";
 
 const SRC_PROGRAM_FN_ARRAY: &str = "\
-get println from std::display
+get println from std::io
 get is_prime, factorial, fibonacci from std::math
 
 dec int n = 10

--- a/examples/my-test-structure/main.rl
+++ b/examples/my-test-structure/main.rl
@@ -1,4 +1,4 @@
-get println from std::display
+get println from std::io
 
 fn main() {
     println("hello world")

--- a/src/docs/entries/stdlib/display.rs
+++ b/src/docs/entries/stdlib/display.rs
@@ -6,28 +6,10 @@ pub static DISPLAY: StdEntry = StdEntry {
     functions: FUNCTIONS,
 };
 
-static FUNCTIONS: &[&FnEntry] = &[&PRINT, &PRINTLN, &LEN, &EPRINT];
-
-static PRINT: FnEntry = FnEntry {
-    signature: "print(x)",
-    description: "print without newline",
-    example: "get std::display::print\n\nprint(\"hello\")",
-};
-
-static PRINTLN: FnEntry = FnEntry {
-    signature: "println(x)",
-    description: "print with newline",
-    example: "get std::display::println\n\nprintln(\"hello\")",
-};
+static FUNCTIONS: &[&FnEntry] = &[&LEN];
 
 static LEN: FnEntry = FnEntry {
     signature: "len(x)",
     description: "length of string or array",
     example: "get std::display::len\n\nlen(\"hello\") // 5",
-};
-
-static EPRINT: FnEntry = FnEntry {
-    signature: "eprint(string)",
-    description: "halts evaluation with an error containing the given message",
-    example: "get std::display::eprint\n\neprint(\"something went wrong\") // ✗ error: something went wrong",
 };

--- a/src/docs/entries/stdlib/io.rs
+++ b/src/docs/entries/stdlib/io.rs
@@ -6,7 +6,14 @@ pub static IO: StdEntry = StdEntry {
     functions: FUNCTIONS,
 };
 
-static FUNCTIONS: &[&FnEntry] = &[&READ, &READ_PROMPT];
+static FUNCTIONS: &[&FnEntry] = &[
+    &READ,
+    &READ_PROMPT,
+    &READ_INT,
+    &READ_INT_PROMPT,
+    &READ_FLOAT,
+    &READ_FLOAT_PROMPT,
+];
 
 static READ: FnEntry = FnEntry {
     signature: "read()",
@@ -18,4 +25,28 @@ static READ_PROMPT: FnEntry = FnEntry {
     signature: "read(prompt)",
     description: "prints prompt and reads a line from stdin",
     example: "get std::io::read\n\ndec str name = read(\"enter your name: \")",
+};
+
+static READ_INT: FnEntry = FnEntry {
+    signature: "read_int()",
+    description: "read a line from stdin then parses to integer",
+    example: "get std::io::read_int\n\ndec int age = read()",
+};
+
+static READ_INT_PROMPT: FnEntry = FnEntry {
+    signature: "read_int(prompt)",
+    description: "prints prompt and reads a line from stdin then parses to integer",
+    example: "get std::io::read_int\n\ndec int age = read_float(\"enter your age: \")",
+};
+
+static READ_FLOAT: FnEntry = FnEntry {
+    signature: "read_float()",
+    description: "read a line from stdin then parses to float",
+    example: "get std::io::read_float\n\ndec float pi = read_float()",
+};
+
+static READ_FLOAT_PROMPT: FnEntry = FnEntry {
+    signature: "read_float(prompt)",
+    description: "prints prompt and reads a line from stdin then parses to float",
+    example: "get std::io::read_float\n\ndec float pi = read_float(\"enter your pi: \")",
 };

--- a/src/docs/entries/stdlib/io.rs
+++ b/src/docs/entries/stdlib/io.rs
@@ -6,16 +6,16 @@ pub static IO: StdEntry = StdEntry {
     functions: FUNCTIONS,
 };
 
-static FUNCTIONS: &[&FnEntry] = &[&INPUT, &INPUT_PROMPT];
+static FUNCTIONS: &[&FnEntry] = &[&READ, &READ_PROMPT];
 
-static INPUT: FnEntry = FnEntry {
-    signature: "input()",
+static READ: FnEntry = FnEntry {
+    signature: "read()",
     description: "read a line from stdin",
-    example: "get std::io::input\n\ndec str name = input()",
+    example: "get std::io::read\n\ndec str name = read()",
 };
 
-static INPUT_PROMPT: FnEntry = FnEntry {
-    signature: "input(prompt)",
+static READ_PROMPT: FnEntry = FnEntry {
+    signature: "read(prompt)",
     description: "prints prompt and reads a line from stdin",
-    example: "get std::io::input\n\ndec str name = input(\"enter your name: \")",
+    example: "get std::io::read\n\ndec str name = read(\"enter your name: \")",
 };

--- a/src/docs/entries/stdlib/io.rs
+++ b/src/docs/entries/stdlib/io.rs
@@ -13,6 +13,11 @@ static FUNCTIONS: &[&FnEntry] = &[
     &READ_INT_PROMPT,
     &READ_FLOAT,
     &READ_FLOAT_PROMPT,
+    &APPEND_FILE,
+    &DELETE_FILE,
+    &READ_FILE,
+    &READ_LINES,
+    &WRITE_FILE,
 ];
 
 static READ: FnEntry = FnEntry {
@@ -49,4 +54,34 @@ static READ_FLOAT_PROMPT: FnEntry = FnEntry {
     signature: "read_float(prompt)",
     description: "prints prompt and reads a line from stdin then parses to float",
     example: "get std::io::read_float\n\ndec float pi = read_float(\"enter your pi: \")",
+};
+
+static APPEND_FILE: FnEntry = FnEntry {
+    signature: "append_file(path, content)",
+    description: "",
+    example: "get std::io::append_file\n\nappend_file(\"info.txt\", \"name: Mohamed\")",
+};
+
+static DELETE_FILE: FnEntry = FnEntry {
+    signature: "delete_file(path)",
+    description: "",
+    example: "get std::io::delete_file\n\ndelete_file(\"info.txt\")",
+};
+
+static READ_FILE: FnEntry = FnEntry {
+    signature: "read_file(path)",
+    description: "",
+    example: "get std::io::read_file\n\ndec string data = read_file(\"backup_info.txt\")",
+};
+
+static READ_LINES: FnEntry = FnEntry {
+    signature: "read_lines(path)",
+    description: "",
+    example: "get std::io::read_lines\n\ndec arr[string] data = read_lines(\"index.html\")",
+};
+
+static WRITE_FILE: FnEntry = FnEntry {
+    signature: "write_file(path, contents)",
+    description: "",
+    example: "get std::io::write_file\n\nwrite_file(\"index.html\", \"<p>hello \\\"Mohamed\\\"</p>\")",
 };

--- a/src/docs/entries/stdlib/io.rs
+++ b/src/docs/entries/stdlib/io.rs
@@ -58,30 +58,30 @@ static READ_FLOAT_PROMPT: FnEntry = FnEntry {
 
 static APPEND_FILE: FnEntry = FnEntry {
     signature: "append_file(path, content)",
-    description: "",
+    description: "appends content to a file creating it if it does not exist",
     example: "get std::io::append_file\n\nappend_file(\"info.txt\", \"name: Mohamed\")",
 };
 
 static DELETE_FILE: FnEntry = FnEntry {
     signature: "delete_file(path)",
-    description: "",
+    description: "deletes a file at the given path",
     example: "get std::io::delete_file\n\ndelete_file(\"info.txt\")",
 };
 
 static READ_FILE: FnEntry = FnEntry {
     signature: "read_file(path)",
-    description: "",
+    description: "reads the entire contents of a file as a string",
     example: "get std::io::read_file\n\ndec string data = read_file(\"backup_info.txt\")",
 };
 
 static READ_LINES: FnEntry = FnEntry {
     signature: "read_lines(path)",
-    description: "",
+    description: "reads a file and returns its lines as an array of strings",
     example: "get std::io::read_lines\n\ndec arr[string] data = read_lines(\"index.html\")",
 };
 
 static WRITE_FILE: FnEntry = FnEntry {
     signature: "write_file(path, contents)",
-    description: "",
+    description: "writes content to a file overwriting it if it already exists",
     example: "get std::io::write_file\n\nwrite_file(\"index.html\", \"<p>hello \\\"Mohamed\\\"</p>\")",
 };

--- a/src/docs/entries/stdlib/io.rs
+++ b/src/docs/entries/stdlib/io.rs
@@ -18,6 +18,9 @@ static FUNCTIONS: &[&FnEntry] = &[
     &READ_FILE,
     &READ_LINES,
     &WRITE_FILE,
+    &PRINT,
+    &PRINTLN,
+    &EPRINT,
 ];
 
 static READ: FnEntry = FnEntry {
@@ -84,4 +87,22 @@ static WRITE_FILE: FnEntry = FnEntry {
     signature: "write_file(path, contents)",
     description: "writes content to a file overwriting it if it already exists",
     example: "get std::io::write_file\n\nwrite_file(\"index.html\", \"<p>hello \\\"Mohamed\\\"</p>\")",
+};
+
+static PRINT: FnEntry = FnEntry {
+    signature: "print(x)",
+    description: "print without newline",
+    example: "get std::io::print\n\nprint(\"hello\")",
+};
+
+static PRINTLN: FnEntry = FnEntry {
+    signature: "println(x)",
+    description: "print with newline",
+    example: "get std::io:println\n\nprintln(\"hello\")",
+};
+
+static EPRINT: FnEntry = FnEntry {
+    signature: "eprint(string)",
+    description: "halts evaluation with an error containing the given message",
+    example: "get std::io::eprint\n\neprint(\"something went wrong\") // x error: something went wrong",
 };

--- a/src/interpreter/stdlib/display/mod.rs
+++ b/src/interpreter/stdlib/display/mod.rs
@@ -1,16 +1,9 @@
-pub mod eprint;
 pub mod len;
-pub mod print;
-pub mod println;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["print", "println", "len", "eprint"];
+pub const KEYWORDS: &[&str] = &["len"];
 
 pub fn module() -> Module {
-    Module::new("display")
-        .with_raw_function("print", print::std_print)
-        .with_raw_function("println", println::std_println)
-        .with_function("len", len::std_len)
-        .with_function("eprint", eprint::std_eprint)
+    Module::new("display").with_function("len", len::std_len)
 }

--- a/src/interpreter/stdlib/io/append_file.rs
+++ b/src/interpreter/stdlib/io/append_file.rs
@@ -1,0 +1,30 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::{Error, ErrorReason, Reason},
+};
+
+use std::{fs::OpenOptions, io::Write};
+
+pub fn std_append_file(_: &mut Evaluator, file: String, content: String) -> Result<Value, Error> {
+    let mut file_data = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&file)
+        .map_err(|e| {
+            Error::init(
+                format!("append_file(): failed to open \"{}\": {}", file, e),
+                None,
+                Some(ErrorReason::init(Reason::Runtime, None)),
+            )
+        })?;
+
+    file_data.write_all(content.as_bytes()).map_err(|e| {
+        Error::init(
+            format!("append_file(): failed to append \"{}\": {}", file, e),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )
+    })?;
+
+    Ok(Value::Null)
+}

--- a/src/interpreter/stdlib/io/delete_file.rs
+++ b/src/interpreter/stdlib/io/delete_file.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::{Error, ErrorReason, Reason},
+};
+
+pub fn std_delete_file(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+    std::fs::remove_file(&file).map_err(|e| {
+        Error::init(
+            format!("read_file(): failed to read \"{}\": {}", file, e),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )
+    })?;
+    Ok(Value::Null)
+}

--- a/src/interpreter/stdlib/io/eprint.rs
+++ b/src/interpreter/stdlib/io/eprint.rs
@@ -1,0 +1,7 @@
+use crate::interpreter::evaluator::Evaluator;
+use crate::interpreter::values::Value;
+use crate::utils::errors::Error;
+
+pub fn std_eprint(_: &mut Evaluator, string: String) -> Result<Value, Error> {
+    Err(Error::init(string, None, None))
+}

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -50,3 +50,77 @@ pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
         )),
     }
 }
+
+// reads input then parses to integer if possible otherwise error
+pub fn std_read_int(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    let len = args.len();
+    let mut args = args.into_iter();
+
+    let value = match len {
+        0 => input(None),
+        1 => input(args.next()),
+        n => Err(Error::init(
+            format!("read_int() expects 0 or 1 argument(s), got {}", n),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )),
+    }?;
+
+    match value {
+        Value::String(s) => s.parse::<i64>().map(Value::Integer).map_err(|_| {
+            Error::init(
+                format!("read_int(): \"{}\" is not a valid integer", s),
+                None,
+                Some(ErrorReason::init(Reason::Runtime, None)),
+            )
+        }),
+        // those unreachable btw
+        Value::Integer(i) => Ok(Value::Integer(i)),
+        Value::Float(f) => Ok(Value::Integer(f as i64)),
+        other => Err(Error::init(
+            format!(
+                "read_int(): found unsupported type from input, got {}",
+                other.type_name()
+            ),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )),
+    }
+}
+
+// reads the input then parses the string into float if possible or error
+pub fn std_read_float(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    let len = args.len();
+    let mut args = args.into_iter();
+
+    let value = match len {
+        0 => input(None),
+        1 => input(args.next()),
+        n => Err(Error::init(
+            format!("read_float() expects 0 or 1 argument(s), got {}", n),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )),
+    }?;
+
+    match value {
+        Value::String(s) => s.parse::<f64>().map(Value::Float).map_err(|_| {
+            Error::init(
+                format!("read_float(): \"{}\" is not a valid float", s),
+                None,
+                Some(ErrorReason::init(Reason::Runtime, None)),
+            )
+        }),
+        // those are un----reachable!! might change read_line() or remove them
+        Value::Integer(i) => Ok(Value::Float(i as f64)),
+        Value::Float(f) => Ok(Value::Float(f)),
+        other => Err(Error::init(
+            format!(
+                "read_float(): found unsupported type from input, got {}",
+                other.type_name()
+            ),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )),
+    }
+}

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use std::io::{self, Write};
 
-pub fn std_input(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
     match args.len() {
         0 => read_line(),
         1 => {
@@ -22,7 +22,7 @@ pub fn std_input(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
             read_line()
         }
         n => Err(Error::init(
-            format!("input() expects 0 or 1 argument(s), got {}", n),
+            format!("read() expects 0 or 1 argument(s), got {}", n),
             None,
             Some(ErrorReason::init(Reason::Runtime, None)),
         )),
@@ -33,7 +33,7 @@ fn read_line() -> Result<Value, Error> {
     let mut input = String::new();
     io::stdin().read_line(&mut input).map_err(|e| {
         Error::init(
-            format!("input(): failed to read line: {}", e),
+            format!("read(): failed to read line: {}", e),
             None,
             Some(ErrorReason::init(Reason::Runtime, None)),
         )

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -4,11 +4,11 @@ use crate::{
 };
 use std::io::{self, Write};
 
-pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
-    match args.len() {
-        0 => read_line(),
-        1 => {
-            let prompt = match args.into_iter().next().unwrap_or(Value::Null) {
+fn input(prompt: Option<Value>) -> Result<Value, Error> {
+    match prompt {
+        None => read_line(),
+        Some(p) => {
+            let prompt = match p {
                 Value::Integer(i) => i.to_string(),
                 Value::Float(f) => f.to_string(),
                 Value::String(s) => s,
@@ -21,11 +21,6 @@ pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
             io::stdout().flush().ok();
             read_line()
         }
-        n => Err(Error::init(
-            format!("read() expects 0 or 1 argument(s), got {}", n),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
-        )),
     }
 }
 
@@ -39,4 +34,19 @@ fn read_line() -> Result<Value, Error> {
         )
     })?;
     Ok(Value::String(input.trim().to_string()))
+}
+
+pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    let len = args.len();
+    let mut args = args.into_iter();
+
+    match len {
+        0 => input(None),
+        1 => input(args.next()),
+        n => Err(Error::init(
+            format!("read() expects 0 or 1 argument(s), got {}", n),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )),
+    }
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,6 +1,9 @@
 mod append_file;
 mod delete_file;
+mod eprint;
 mod input;
+mod print;
+mod println;
 mod read_file;
 mod read_lines;
 mod write_file;
@@ -16,6 +19,9 @@ pub const KEYWORDS: &[&str] = &[
     "delete_file",
     "write_file",
     "append_file",
+    "print",
+    "println",
+    "eprint",
 ];
 
 pub fn module() -> Module {
@@ -28,4 +34,7 @@ pub fn module() -> Module {
         .with_function("delete_file", delete_file::std_delete_file)
         .with_function("write_file", write_file::std_write_file)
         .with_function("append_file", append_file::std_append_file)
+        .with_raw_function("print", print::std_print)
+        .with_raw_function("println", println::std_println)
+        .with_function("eprint", eprint::std_eprint)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,12 +1,14 @@
-pub mod input;
+mod input;
+mod read_file;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float"];
+pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float", "read_file"];
 
 pub fn module() -> Module {
     Module::new("io")
         .with_raw_function("read", input::std_read)
         .with_raw_function("read_int", input::std_read_int)
         .with_raw_function("read_float", input::std_read_float)
+        .with_function("read_file", read_file::std_read_file)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,9 +1,10 @@
 mod input;
 mod read_file;
+mod read_lines;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float", "read_file"];
+pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float", "read_file", "read_lines"];
 
 pub fn module() -> Module {
     Module::new("io")
@@ -11,4 +12,5 @@ pub fn module() -> Module {
         .with_raw_function("read_int", input::std_read_int)
         .with_raw_function("read_float", input::std_read_float)
         .with_function("read_file", read_file::std_read_file)
+        .with_function("read_lines", read_lines::std_read_lines)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,3 +1,4 @@
+mod append_file;
 mod delete_file;
 mod input;
 mod read_file;
@@ -14,6 +15,7 @@ pub const KEYWORDS: &[&str] = &[
     "read_lines",
     "delete_file",
     "write_file",
+    "append_file",
 ];
 
 pub fn module() -> Module {
@@ -25,4 +27,5 @@ pub fn module() -> Module {
         .with_function("read_lines", read_lines::std_read_lines)
         .with_function("delete_file", delete_file::std_delete_file)
         .with_function("write_file", write_file::std_write_file)
+        .with_function("append_file", append_file::std_append_file)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,10 +1,18 @@
+mod delete_file;
 mod input;
 mod read_file;
 mod read_lines;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float", "read_file", "read_lines"];
+pub const KEYWORDS: &[&str] = &[
+    "read",
+    "read_int",
+    "read_float",
+    "read_file",
+    "read_lines",
+    "delete_file",
+];
 
 pub fn module() -> Module {
     Module::new("io")
@@ -13,4 +21,5 @@ pub fn module() -> Module {
         .with_raw_function("read_float", input::std_read_float)
         .with_function("read_file", read_file::std_read_file)
         .with_function("read_lines", read_lines::std_read_lines)
+        .with_function("delete_file", delete_file::std_delete_file)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -2,8 +2,11 @@ pub mod input;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["read"];
+pub const KEYWORDS: &[&str] = &["read", "read_int", "read_float"];
 
 pub fn module() -> Module {
-    Module::new("io").with_raw_function("input", input::std_read)
+    Module::new("io")
+        .with_raw_function("read", input::std_read)
+        .with_raw_function("read_int", input::std_read_int)
+        .with_raw_function("read_float", input::std_read_float)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -2,8 +2,8 @@ pub mod input;
 
 use crate::interpreter::native::Module;
 
-pub const KEYWORDS: &[&str] = &["input"];
+pub const KEYWORDS: &[&str] = &["read"];
 
 pub fn module() -> Module {
-    Module::new("io").with_raw_function("input", input::std_input)
+    Module::new("io").with_raw_function("input", input::std_read)
 }

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -2,6 +2,7 @@ mod delete_file;
 mod input;
 mod read_file;
 mod read_lines;
+mod write_file;
 
 use crate::interpreter::native::Module;
 
@@ -12,6 +13,7 @@ pub const KEYWORDS: &[&str] = &[
     "read_file",
     "read_lines",
     "delete_file",
+    "write_file",
 ];
 
 pub fn module() -> Module {
@@ -22,4 +24,5 @@ pub fn module() -> Module {
         .with_function("read_file", read_file::std_read_file)
         .with_function("read_lines", read_lines::std_read_lines)
         .with_function("delete_file", delete_file::std_delete_file)
+        .with_function("write_file", write_file::std_write_file)
 }

--- a/src/interpreter/stdlib/io/plan.md
+++ b/src/interpreter/stdlib/io/plan.md
@@ -1,12 +1,6 @@
 # io
-- ~`eprint(msg)`~
-- ~`eprintln(msg)`~
-- `read_int()`
-- `read_float()`
-- `read_file(path)`
 - `write_file(path, content)`
 - `append_file(path, content)`
-- `file_exists(path)`
 - `delete_file(path)`
 - `read_lines(path)`
-- `read_bytes(path)`
+- `read_bytes(path)` too expensive to implement with current setup will implement after adding byte type

--- a/src/interpreter/stdlib/io/plan.md
+++ b/src/interpreter/stdlib/io/plan.md
@@ -1,6 +1,3 @@
 # io
-- `write_file(path, content)`
-- `append_file(path, content)`
-- `delete_file(path)`
-- `read_lines(path)`
+
 - `read_bytes(path)` too expensive to implement with current setup will implement after adding byte type

--- a/src/interpreter/stdlib/io/print.rs
+++ b/src/interpreter/stdlib/io/print.rs
@@ -1,0 +1,14 @@
+use crate::interpreter::evaluator::Evaluator;
+use crate::interpreter::values::Value;
+use crate::utils::errors::Error;
+
+pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    let text = args.iter().map(|s| s.to_string()).collect::<String>();
+
+    if let Some(buffer) = &mut evaluator.output_buffer {
+        buffer.push_str(&text);
+    } else {
+        print!("{}", text);
+    }
+    Ok(Value::Null)
+}

--- a/src/interpreter/stdlib/io/println.rs
+++ b/src/interpreter/stdlib/io/println.rs
@@ -1,0 +1,15 @@
+use crate::interpreter::evaluator::Evaluator;
+use crate::interpreter::values::Value;
+use crate::utils::errors::Error;
+
+pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+    let text = args.iter().map(|s| s.to_string()).collect::<String>();
+
+    if let Some(buffer) = &mut evaluator.output_buffer {
+        buffer.push_str(&text);
+        buffer.push('\n');
+    } else {
+        println!("{}", text);
+    }
+    Ok(Value::Null)
+}

--- a/src/interpreter/stdlib/io/read_file.rs
+++ b/src/interpreter/stdlib/io/read_file.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::{Error, ErrorReason, Reason},
+};
+
+pub fn std_read_file(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+    let data = std::fs::read_to_string(&file).map_err(|e| {
+        Error::init(
+            format!("read_file(): failed to read \"{}\": {}", file, e),
+            None,
+            Some(ErrorReason::init(Reason::Runtime, None)),
+        )
+    })?;
+    Ok(Value::String(data))
+}

--- a/src/interpreter/stdlib/io/read_lines.rs
+++ b/src/interpreter/stdlib/io/read_lines.rs
@@ -1,0 +1,25 @@
+use crate::{
+    ast::statements::TypeAnnotation,
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::errors::{Error, ErrorReason, Reason},
+};
+
+pub fn std_read_lines(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+    let data = std::fs::read_to_string(&file)
+        .map_err(|e| {
+            Error::init(
+                format!("read_lines(): failed to read \"{}\": {}", file, e),
+                None,
+                Some(ErrorReason::init(Reason::Runtime, None)),
+            )
+        })?
+        .lines()
+        .map(String::from)
+        .map(Value::String)
+        .collect::<Vec<Value>>();
+
+    Ok(Value::Values {
+        items_type: TypeAnnotation::String,
+        items: data,
+    })
+}

--- a/src/interpreter/stdlib/io/write_file.rs
+++ b/src/interpreter/stdlib/io/write_file.rs
@@ -3,10 +3,10 @@ use crate::{
     utils::errors::{Error, ErrorReason, Reason},
 };
 
-pub fn std_delete_file(_: &mut Evaluator, file: String) -> Result<Value, Error> {
-    std::fs::remove_file(&file).map_err(|e| {
+pub fn std_write_file(_: &mut Evaluator, file: String, content: String) -> Result<Value, Error> {
+    std::fs::write(&file, content).map_err(|e| {
         Error::init(
-            format!("delete_file(): failed to read \"{}\": {}", file, e),
+            format!("write_file(): failed to write \"{}\": {}", file, e),
             None,
             Some(ErrorReason::init(Reason::Runtime, None)),
         )

--- a/src/tooling/new.rs
+++ b/src/tooling/new.rs
@@ -19,7 +19,7 @@ entry = "src/main.rl"
         name,
         env!("CARGO_PKG_VERSION"),
     );
-    let main = r#"get println from std::display
+    let main = r#"get println from std::io
 fn main() {
     println("hello world")
 }

--- a/syntax.rl
+++ b/syntax.rl
@@ -8,7 +8,8 @@
 // ------------------------------------------------------------
 // 1. imports
 // ------------------------------------------------------------
-get println, len from std::display
+get len from std::display
+get println from std::io
 get sin, cos, tan, pow, mod, is_prime, factorial, fibonacci from std::math
 get PI, TAU, PHI, E from std::math::consts
 

--- a/tests/parser/programs.rs
+++ b/tests/parser/programs.rs
@@ -186,14 +186,14 @@ println(hyp, is_right, prime, big)",
                 names: vec!["println".to_string()],
                 path: vec!["std".to_string(), "io".to_string()],
             },
-            Span::new(0, 29),
+            Span::new(0, 24),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(29, 30),
+                Span::new(24, 25),
             )),
-            Span::new(29, 30),
+            Span::new(24, 25),
         ),
         Statement::new(
             StatementKind::Import {
@@ -207,35 +207,35 @@ println(hyp, is_right, prime, big)",
                 ],
                 path: vec!["std".to_string(), "math".to_string()],
             },
-            Span::new(30, 91),
+            Span::new(25, 86),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(91, 92),
+                Span::new(86, 87),
             )),
-            Span::new(91, 92),
+            Span::new(86, 87),
         ),
         Statement::new(
             StatementKind::Import {
                 names: vec!["PI".to_string(), "TAU".to_string(), "PHI".to_string()],
                 path: vec!["std".to_string(), "math".to_string(), "consts".to_string()],
             },
-            Span::new(92, 131),
+            Span::new(87, 126),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(131, 132),
+                Span::new(126, 127),
             )),
-            Span::new(131, 132),
+            Span::new(126, 127),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(132, 133),
+                Span::new(127, 128),
             )),
-            Span::new(132, 133),
+            Span::new(127, 128),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -246,17 +246,17 @@ println(hyp, is_right, prime, big)",
                         path: vec!["PI".to_string()],
                         args: vec![],
                     },
-                    Span::new(151, 155),
+                    Span::new(146, 150),
                 ),
             },
-            Span::new(133, 155),
+            Span::new(128, 150),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(155, 156),
+                Span::new(150, 151),
             )),
-            Span::new(155, 156),
+            Span::new(150, 151),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
@@ -266,7 +266,7 @@ println(hyp, is_right, prime, big)",
                         ExpressionKind::Binary {
                             left: Box::new(Expression::new(
                                 ExpressionKind::Identifier("angle".to_string()),
-                                Span::new(156, 161),
+                                Span::new(151, 156),
                             )),
                             operator: TokenType::Star,
                             right: Box::new(Expression::new(
@@ -274,29 +274,29 @@ println(hyp, is_right, prime, big)",
                                     path: vec!["PHI".to_string()],
                                     args: vec![],
                                 },
-                                Span::new(165, 170),
+                                Span::new(160, 165),
                             )),
                         },
-                        Span::new(156, 170),
+                        Span::new(151, 165),
                     )),
                 },
-                Span::new(156, 170),
+                Span::new(151, 165),
             )),
-            Span::new(156, 170),
+            Span::new(151, 165),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(170, 171),
+                Span::new(165, 166),
             )),
-            Span::new(170, 171),
+            Span::new(165, 166),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(171, 172),
+                Span::new(166, 167),
             )),
-            Span::new(171, 172),
+            Span::new(166, 167),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -307,20 +307,20 @@ println(hyp, is_right, prime, big)",
                         path: vec!["sin".to_string()],
                         args: vec![Expression::new(
                             ExpressionKind::Identifier("angle".to_string()),
-                            Span::new(192, 197),
+                            Span::new(187, 192),
                         )],
                     },
-                    Span::new(188, 198),
+                    Span::new(183, 193),
                 ),
             },
-            Span::new(172, 198),
+            Span::new(167, 193),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(198, 199),
+                Span::new(193, 194),
             )),
-            Span::new(198, 199),
+            Span::new(193, 194),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -331,20 +331,20 @@ println(hyp, is_right, prime, big)",
                         path: vec!["cos".to_string()],
                         args: vec![Expression::new(
                             ExpressionKind::Identifier("angle".to_string()),
-                            Span::new(219, 224),
+                            Span::new(214, 219),
                         )],
                     },
-                    Span::new(215, 225),
+                    Span::new(210, 220),
                 ),
             },
-            Span::new(199, 225),
+            Span::new(194, 220),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(225, 226),
+                Span::new(220, 221),
             )),
-            Span::new(225, 226),
+            Span::new(220, 221),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -356,32 +356,32 @@ println(hyp, is_right, prime, big)",
                         args: vec![
                             Expression::new(
                                 ExpressionKind::Identifier("opp".to_string()),
-                                Span::new(248, 251),
+                                Span::new(243, 246),
                             ),
                             Expression::new(
                                 ExpressionKind::Identifier("adj".to_string()),
-                                Span::new(253, 256),
+                                Span::new(248, 251),
                             ),
                         ],
                     },
-                    Span::new(242, 257),
+                    Span::new(237, 252),
                 ),
             },
-            Span::new(226, 257),
+            Span::new(221, 252),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(257, 258),
+                Span::new(252, 253),
             )),
-            Span::new(257, 258),
+            Span::new(252, 253),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(258, 259),
+                Span::new(253, 254),
             )),
-            Span::new(258, 259),
+            Span::new(253, 254),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -391,25 +391,25 @@ println(hyp, is_right, prime, big)",
                     ExpressionKind::Binary {
                         left: Box::new(Expression::new(
                             ExpressionKind::Identifier("hyp".to_string()),
-                            Span::new(279, 282),
+                            Span::new(274, 277),
                         )),
                         operator: TokenType::Compare,
                         right: Box::new(Expression::new(
                             ExpressionKind::Float(1.0),
-                            Span::new(286, 289),
+                            Span::new(281, 284),
                         )),
                     },
-                    Span::new(279, 289),
+                    Span::new(274, 284),
                 ),
             },
-            Span::new(259, 289),
+            Span::new(254, 284),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(289, 290),
+                Span::new(284, 285),
             )),
-            Span::new(289, 290),
+            Span::new(284, 285),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -420,42 +420,42 @@ println(hyp, is_right, prime, big)",
                         operator: TokenType::Bang,
                         operand: Box::new(Expression::new(
                             ExpressionKind::Identifier("is_right".to_string()),
-                            Span::new(312, 320),
+                            Span::new(307, 315),
                         )),
                     },
-                    Span::new(311, 320),
+                    Span::new(306, 315),
                 ),
             },
-            Span::new(290, 320),
+            Span::new(285, 315),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(320, 321),
+                Span::new(315, 316),
             )),
-            Span::new(320, 321),
+            Span::new(315, 316),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(321, 322),
+                Span::new(316, 317),
             )),
-            Span::new(321, 322),
+            Span::new(316, 317),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
                 name: "n".to_string(),
                 type_annotation: TypeAnnotation::Int,
-                value: Expression::new(ExpressionKind::Integer(7), Span::new(334, 335)),
+                value: Expression::new(ExpressionKind::Integer(7), Span::new(329, 330)),
             },
-            Span::new(322, 335),
+            Span::new(317, 330),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(335, 336),
+                Span::new(330, 331),
             )),
-            Span::new(335, 336),
+            Span::new(330, 331),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -466,20 +466,20 @@ println(hyp, is_right, prime, big)",
                         path: vec!["is_prime".to_string()],
                         args: vec![Expression::new(
                             ExpressionKind::Identifier("n".to_string()),
-                            Span::new(362, 363),
+                            Span::new(357, 358),
                         )],
                     },
-                    Span::new(353, 364),
+                    Span::new(348, 359),
                 ),
             },
-            Span::new(336, 364),
+            Span::new(331, 359),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(364, 365),
+                Span::new(359, 360),
             )),
-            Span::new(364, 365),
+            Span::new(359, 360),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -490,20 +490,20 @@ println(hyp, is_right, prime, big)",
                         path: vec!["factorial".to_string()],
                         args: vec![Expression::new(
                             ExpressionKind::Identifier("n".to_string()),
-                            Span::new(392, 393),
+                            Span::new(387, 388),
                         )],
                     },
-                    Span::new(382, 394),
+                    Span::new(377, 389),
                 ),
             },
-            Span::new(365, 394),
+            Span::new(360, 389),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(394, 395),
+                Span::new(389, 390),
             )),
-            Span::new(394, 395),
+            Span::new(389, 390),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -514,27 +514,27 @@ println(hyp, is_right, prime, big)",
                         path: vec!["log2".to_string()],
                         args: vec![Expression::new(
                             ExpressionKind::Identifier("fact".to_string()),
-                            Span::new(415, 419),
+                            Span::new(410, 414),
                         )],
                     },
-                    Span::new(410, 420),
+                    Span::new(405, 415),
                 ),
             },
-            Span::new(395, 420),
+            Span::new(390, 415),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(420, 421),
+                Span::new(415, 416),
             )),
-            Span::new(420, 421),
+            Span::new(415, 416),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(421, 422),
+                Span::new(416, 417),
             )),
-            Span::new(421, 422),
+            Span::new(416, 417),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
@@ -544,34 +544,34 @@ println(hyp, is_right, prime, big)",
                         ExpressionKind::Binary {
                             left: Box::new(Expression::new(
                                 ExpressionKind::Identifier("lg".to_string()),
-                                Span::new(422, 424),
+                                Span::new(417, 419),
                             )),
                             operator: TokenType::Minus,
                             right: Box::new(Expression::new(
                                 ExpressionKind::Float(1.0),
-                                Span::new(428, 431),
+                                Span::new(423, 426),
                             )),
                         },
-                        Span::new(422, 431),
+                        Span::new(417, 426),
                     )),
                 },
-                Span::new(422, 431),
+                Span::new(417, 426),
             )),
-            Span::new(422, 431),
+            Span::new(417, 426),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(431, 432),
+                Span::new(426, 427),
             )),
-            Span::new(431, 432),
+            Span::new(426, 427),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(432, 433),
+                Span::new(427, 428),
             )),
-            Span::new(432, 433),
+            Span::new(427, 428),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -581,7 +581,7 @@ println(hyp, is_right, prime, big)",
                     ExpressionKind::Binary {
                         left: Box::new(Expression::new(
                             ExpressionKind::Identifier("lg".to_string()),
-                            Span::new(448, 450),
+                            Span::new(443, 445),
                         )),
                         operator: TokenType::Greater,
                         right: Box::new(Expression::new(
@@ -589,27 +589,27 @@ println(hyp, is_right, prime, big)",
                                 path: vec!["TAU".to_string()],
                                 args: vec![],
                             },
-                            Span::new(453, 458),
+                            Span::new(448, 453),
                         )),
                     },
-                    Span::new(448, 458),
+                    Span::new(443, 453),
                 ),
             },
-            Span::new(433, 458),
+            Span::new(428, 453),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(458, 459),
+                Span::new(453, 454),
             )),
-            Span::new(458, 459),
+            Span::new(453, 454),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(459, 460),
+                Span::new(454, 455),
             )),
-            Span::new(459, 460),
+            Span::new(454, 455),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
@@ -618,25 +618,25 @@ println(hyp, is_right, prime, big)",
                     args: vec![
                         Expression::new(
                             ExpressionKind::Identifier("hyp".to_string()),
-                            Span::new(468, 471),
+                            Span::new(463, 466),
                         ),
                         Expression::new(
                             ExpressionKind::Identifier("is_right".to_string()),
-                            Span::new(473, 481),
+                            Span::new(468, 476),
                         ),
                         Expression::new(
                             ExpressionKind::Identifier("prime".to_string()),
-                            Span::new(483, 488),
+                            Span::new(478, 483),
                         ),
                         Expression::new(
                             ExpressionKind::Identifier("big".to_string()),
-                            Span::new(490, 493),
+                            Span::new(485, 488),
                         ),
                     ],
                 },
-                Span::new(460, 494),
+                Span::new(455, 489),
             )),
-            Span::new(460, 494),
+            Span::new(455, 489),
         ),
     ];
     assert_eq!(statements, expected);
@@ -668,243 +668,243 @@ for [int i = 0, i < 2, i += 1] {
 }",
     );
     let expected = vec![
-        Statement::new(
-            StatementKind::Import {
-                names: vec!["println".to_string()],
-                path: vec!["std".to_string(), "io".to_string()],
-            },
-            Span::new(0, 29),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(29, 30))),
-            Span::new(29, 30),
-        ),
-        Statement::new(
-            StatementKind::Import {
-                names: vec!["is_prime".to_string(), "factorial".to_string(), "fibonacci".to_string()],
-                path: vec!["std".to_string(), "math".to_string()],
-            },
-            Span::new(30, 79),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(79, 80))),
-            Span::new(79, 80),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(80, 81))),
-            Span::new(80, 81),
-        ),
-        Statement::new(
-            StatementKind::VariableDeclaration {
-                name: "n".to_string(),
-                type_annotation: TypeAnnotation::Int,
-                value: Expression::new(ExpressionKind::Integer(10), Span::new(93, 95)),
-            },
-            Span::new(81, 95),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(95, 96))),
-            Span::new(95, 96),
-        ),
-        Statement::new(
-            StatementKind::Array {
-                name: "ops".to_string(),
-                type_annotation: TypeAnnotation::Fn,
-                value: vec![
-                    Expression::new(ExpressionKind::Identifier("factorial".to_string()), Span::new(115, 124)),
-                    Expression::new(ExpressionKind::Identifier("fibonacci".to_string()), Span::new(126, 135)),
-                ],
-            },
-            Span::new(96, 136),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(136, 137))),
-            Span::new(136, 137),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(137, 138))),
-            Span::new(137, 138),
-        ),
-        Statement::new(
-            StatementKind::VariableDeclaration {
-                name: "i".to_string(),
-                type_annotation: TypeAnnotation::Int,
-                value: Expression::new(ExpressionKind::Integer(0), Span::new(150, 151)),
-            },
-            Span::new(138, 151),
-        ),
-        Statement::new(
-            StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(151, 152))),
-            Span::new(151, 152),
-        ),
-        Statement::new(
-            StatementKind::For {
-                initializer: Box::new(Statement::new(
-                    StatementKind::VariableDeclaration {
-                        name: "i".to_string(),
-                        type_annotation: TypeAnnotation::Int,
-                        value: Expression::new(ExpressionKind::Integer(0), Span::new(165, 166)),
-                    },
-                    Span::new(157, 166),
-                )),
-                condition: Expression::new(
-                    ExpressionKind::Binary {
-                        left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(168, 169))),
-                        operator: TokenType::Less,
-                        right: Box::new(Expression::new(ExpressionKind::Integer(2), Span::new(172, 173))),
-                    },
-                    Span::new(168, 173),
-                ),
-                increment: Expression::new(
-                    ExpressionKind::Assign {
-                        name: "i".to_string(),
-                        value: Box::new(Expression::new(
-                            ExpressionKind::Binary {
-                                left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(175, 176))),
-                                operator: TokenType::Plus,
-                                right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(180, 181))),
-                            },
-                            Span::new(175, 181),
-                        )),
-                    },
-                    Span::new(175, 181),
-                ),
-                body: vec![
-                    Statement::new(
+            Statement::new(
+                StatementKind::Import {
+                    names: vec!["println".to_string()],
+                    path: vec!["std".to_string(), "io".to_string()],
+                },
+                Span::new(0, 24),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(24, 25))),
+                Span::new(24, 25),
+            ),
+            Statement::new(
+                StatementKind::Import {
+                    names: vec!["is_prime".to_string(), "factorial".to_string(), "fibonacci".to_string()],
+                    path: vec!["std".to_string(), "math".to_string()],
+                },
+                Span::new(25, 74),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(74, 75))),
+                Span::new(74, 75),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(75, 76))),
+                Span::new(75, 76),
+            ),
+            Statement::new(
+                StatementKind::VariableDeclaration {
+                    name: "n".to_string(),
+                    type_annotation: TypeAnnotation::Int,
+                    value: Expression::new(ExpressionKind::Integer(10), Span::new(88, 90)),
+                },
+                Span::new(76, 90),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(90, 91))),
+                Span::new(90, 91),
+            ),
+            Statement::new(
+                StatementKind::Array {
+                    name: "ops".to_string(),
+                    type_annotation: TypeAnnotation::Fn,
+                    value: vec![
+                        Expression::new(ExpressionKind::Identifier("factorial".to_string()), Span::new(110, 119)),
+                        Expression::new(ExpressionKind::Identifier("fibonacci".to_string()), Span::new(121, 130)),
+                    ],
+                },
+                Span::new(91, 131),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(131, 132))),
+                Span::new(131, 132),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(132, 133))),
+                Span::new(132, 133),
+            ),
+            Statement::new(
+                StatementKind::VariableDeclaration {
+                    name: "i".to_string(),
+                    type_annotation: TypeAnnotation::Int,
+                    value: Expression::new(ExpressionKind::Integer(0), Span::new(145, 146)),
+                },
+                Span::new(133, 146),
+            ),
+            Statement::new(
+                StatementKind::Expression(Expression::new(ExpressionKind::Integer(0), Span::new(146, 147))),
+                Span::new(146, 147),
+            ),
+            Statement::new(
+                StatementKind::For {
+                    initializer: Box::new(Statement::new(
                         StatementKind::VariableDeclaration {
-                            name: "op".to_string(),
-                            type_annotation: TypeAnnotation::Fn,
-                            value: Expression::new(
-                                ExpressionKind::Index {
-                                    target: Box::new(Expression::new(ExpressionKind::Identifier("ops".to_string()), Span::new(201, 204))),
-                                    index: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(205, 206))),
-                                },
-                                Span::new(201, 207),
-                            ),
-                        },
-                        Span::new(189, 207),
-                    ),
-                    Statement::new(
-                        StatementKind::VariableDeclaration {
-                            name: "j".to_string(),
+                            name: "i".to_string(),
                             type_annotation: TypeAnnotation::Int,
-                            value: Expression::new(ExpressionKind::Integer(1), Span::new(224, 225)),
+                            value: Expression::new(ExpressionKind::Integer(0), Span::new(160, 161)),
                         },
-                        Span::new(212, 225),
-                    ),
-                    Statement::new(
-                        StatementKind::While {
-                            condition: Expression::new(
-                                ExpressionKind::Grouping(Box::new(Expression::new(
-                                    ExpressionKind::Binary {
-                                        left: Box::new(Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(237, 238))),
-                                        operator: TokenType::Less,
-                                        right: Box::new(Expression::new(ExpressionKind::Identifier("n".to_string()), Span::new(241, 242))),
-                                    },
-                                    Span::new(237, 242),
-                                ))),
-                                Span::new(236, 243),
-                            ),
-                            body: vec![
-                                Statement::new(
-                                    StatementKind::VariableDeclaration {
-                                        name: "result".to_string(),
-                                        type_annotation: TypeAnnotation::Int,
-                                        value: Expression::new(
-                                            ExpressionKind::Call {
-                                                path: vec!["op".to_string()],
-                                                args: vec![Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(274, 275))],
-                                            },
-                                            Span::new(271, 276),
-                                        ),
-                                    },
-                                    Span::new(254, 276),
-                                ),
-                                Statement::new(
-                                    StatementKind::Conditional {
-                                        if_branch: Box::new(Statement::new(
-                                            StatementKind::ConditionalBranch {
-                                                condition: Some(Expression::new(
-                                                    ExpressionKind::Grouping(Box::new(Expression::new(
-                                                        ExpressionKind::Call {
-                                                            path: vec!["is_prime".to_string()],
-                                                            args: vec![Expression::new(ExpressionKind::Identifier("result".to_string()), Span::new(298, 304))],
-                                                        },
-                                                        Span::new(289, 305),
-                                                    ))),
-                                                    Span::new(288, 306),
-                                                )),
-                                                body: vec![
-                                                    Statement::new(
-                                                        StatementKind::Expression(Expression::new(
-                                                            ExpressionKind::Call {
-                                                                path: vec!["println".to_string()],
-                                                                args: vec![Expression::new(ExpressionKind::Identifier("result".to_string()), Span::new(329, 335))],
-                                                            },
-                                                            Span::new(321, 336),
-                                                        )),
-                                                        Span::new(321, 336),
-                                                    ),
-                                                    Statement::new(
-                                                        StatementKind::Expression(Expression::new(
-                                                            ExpressionKind::Assign {
-                                                                name: "j".to_string(),
-                                                                value: Box::new(Expression::new(
-                                                                    ExpressionKind::Binary {
-                                                                        left: Box::new(Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(349, 350))),
-                                                                        operator: TokenType::Plus,
-                                                                        right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(354, 355))),
-                                                                    },
-                                                                    Span::new(349, 355),
-                                                                )),
-                                                            },
-                                                            Span::new(349, 355),
-                                                        )),
-                                                        Span::new(349, 355),
-                                                    ),
-                                                ],
-                                            },
-                                            Span::new(285, 365),
-                                        )),
-                                        elseif_branch: Some(vec![]),
-                                        else_branch: Some(Box::new(Statement::new(
-                                            StatementKind::ConditionalBranch {
-                                                condition: None,
-                                                body: vec![Statement::new(
-                                                    StatementKind::Break,
-                                                    Span::new(385, 390),
-                                                )],
-                                            },
-                                            Span::new(366, 400),
-                                        ))),
-                                    },
-                                    Span::new(285, 400),
-                                ),
-                            ],
+                        Span::new(152, 161),
+                    )),
+                    condition: Expression::new(
+                        ExpressionKind::Binary {
+                            left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(163, 164))),
+                            operator: TokenType::Less,
+                            right: Box::new(Expression::new(ExpressionKind::Integer(2), Span::new(167, 168))),
                         },
-                        Span::new(230, 406),
+                        Span::new(163, 168),
                     ),
-                    Statement::new(
-                        StatementKind::Expression(Expression::new(
-                            ExpressionKind::Assign {
-                                name: "i".to_string(),
-                                value: Box::new(Expression::new(
-                                    ExpressionKind::Binary {
-                                        left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(411, 412))),
-                                        operator: TokenType::Plus,
-                                        right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(416, 417))),
+                    increment: Expression::new(
+                        ExpressionKind::Assign {
+                            name: "i".to_string(),
+                            value: Box::new(Expression::new(
+                                ExpressionKind::Binary {
+                                    left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(170, 171))),
+                                    operator: TokenType::Plus,
+                                    right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(175, 176))),
+                                },
+                                Span::new(170, 176),
+                            )),
+                        },
+                        Span::new(170, 176),
+                    ),
+                    body: vec![
+                        Statement::new(
+                            StatementKind::VariableDeclaration {
+                                name: "op".to_string(),
+                                type_annotation: TypeAnnotation::Fn,
+                                value: Expression::new(
+                                    ExpressionKind::Index {
+                                        target: Box::new(Expression::new(ExpressionKind::Identifier("ops".to_string()), Span::new(196, 199))),
+                                        index: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(200, 201))),
                                     },
-                                    Span::new(411, 417),
-                                )),
+                                    Span::new(196, 202),
+                                ),
                             },
-                            Span::new(411, 417),
-                        )),
-                        Span::new(411, 417),
-                    ),
-                ],
-            },
-            Span::new(152, 419),
-        ),
-    ];
+                            Span::new(184, 202),
+                        ),
+                        Statement::new(
+                            StatementKind::VariableDeclaration {
+                                name: "j".to_string(),
+                                type_annotation: TypeAnnotation::Int,
+                                value: Expression::new(ExpressionKind::Integer(1), Span::new(219, 220)),
+                            },
+                            Span::new(207, 220),
+                        ),
+                        Statement::new(
+                            StatementKind::While {
+                                condition: Expression::new(
+                                    ExpressionKind::Grouping(Box::new(Expression::new(
+                                        ExpressionKind::Binary {
+                                            left: Box::new(Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(232, 233))),
+                                            operator: TokenType::Less,
+                                            right: Box::new(Expression::new(ExpressionKind::Identifier("n".to_string()), Span::new(236, 237))),
+                                        },
+                                        Span::new(232, 237),
+                                    ))),
+                                    Span::new(231, 238),
+                                ),
+                                body: vec![
+                                    Statement::new(
+                                        StatementKind::VariableDeclaration {
+                                            name: "result".to_string(),
+                                            type_annotation: TypeAnnotation::Int,
+                                            value: Expression::new(
+                                                ExpressionKind::Call {
+                                                    path: vec!["op".to_string()],
+                                                    args: vec![Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(269, 270))],
+                                                },
+                                                Span::new(266, 271),
+                                            ),
+                                        },
+                                        Span::new(249, 271),
+                                    ),
+                                    Statement::new(
+                                        StatementKind::Conditional {
+                                            if_branch: Box::new(Statement::new(
+                                                StatementKind::ConditionalBranch {
+                                                    condition: Some(Expression::new(
+                                                        ExpressionKind::Grouping(Box::new(Expression::new(
+                                                            ExpressionKind::Call {
+                                                                path: vec!["is_prime".to_string()],
+                                                                args: vec![Expression::new(ExpressionKind::Identifier("result".to_string()), Span::new(293, 299))],
+                                                            },
+                                                            Span::new(284, 300),
+                                                        ))),
+                                                        Span::new(283, 301),
+                                                    )),
+                                                    body: vec![
+                                                        Statement::new(
+                                                            StatementKind::Expression(Expression::new(
+                                                                ExpressionKind::Call {
+                                                                    path: vec!["println".to_string()],
+                                                                    args: vec![Expression::new(ExpressionKind::Identifier("result".to_string()), Span::new(324, 330))],
+                                                                },
+                                                                Span::new(316, 331),
+                                                            )),
+                                                            Span::new(316, 331),
+                                                        ),
+                                                        Statement::new(
+                                                            StatementKind::Expression(Expression::new(
+                                                                ExpressionKind::Assign {
+                                                                    name: "j".to_string(),
+                                                                    value: Box::new(Expression::new(
+                                                                        ExpressionKind::Binary {
+                                                                            left: Box::new(Expression::new(ExpressionKind::Identifier("j".to_string()), Span::new(344, 345))),
+                                                                            operator: TokenType::Plus,
+                                                                            right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(349, 350))),
+                                                                        },
+                                                                        Span::new(344, 350),
+                                                                    )),
+                                                                },
+                                                                Span::new(344, 350),
+                                                            )),
+                                                            Span::new(344, 350),
+                                                        ),
+                                                    ],
+                                                },
+                                                Span::new(280, 360),
+                                            )),
+                                            elseif_branch: Some(vec![]),
+                                            else_branch: Some(Box::new(Statement::new(
+                                                StatementKind::ConditionalBranch {
+                                                    condition: None,
+                                                    body: vec![Statement::new(
+                                                        StatementKind::Break,
+                                                        Span::new(380, 385),
+                                                    )],
+                                                },
+                                                Span::new(361, 395),
+                                            ))),
+                                        },
+                                        Span::new(280, 395),
+                                    ),
+                                ],
+                            },
+                            Span::new(225, 401),
+                        ),
+                        Statement::new(
+                            StatementKind::Expression(Expression::new(
+                                ExpressionKind::Assign {
+                                    name: "i".to_string(),
+                                    value: Box::new(Expression::new(
+                                        ExpressionKind::Binary {
+                                            left: Box::new(Expression::new(ExpressionKind::Identifier("i".to_string()), Span::new(406, 407))),
+                                            operator: TokenType::Plus,
+                                            right: Box::new(Expression::new(ExpressionKind::Integer(1), Span::new(411, 412))),
+                                        },
+                                        Span::new(406, 412),
+                                    )),
+                                },
+                                Span::new(406, 412),
+                            )),
+                            Span::new(406, 412),
+                        ),
+                    ],
+                },
+                Span::new(147, 414),
+            ),
+        ];
     assert_eq!(statements, expected);
 }

--- a/tests/parser/programs.rs
+++ b/tests/parser/programs.rs
@@ -12,7 +12,7 @@ use crate::common;
 #[test]
 fn integration_math_print() {
     let statements = common::parse(
-        "get println from std::display
+        "get println from std::io
 get pow from std::math
 get std::math::consts::PI
 
@@ -155,7 +155,7 @@ println(x, y)",
 #[test]
 fn integration_geometry() {
     let statements = common::parse(
-        "get println from std::display
+        "get println from std::io
 get sin, cos, hypot, is_prime, log2, factorial from std::math
 get PI, TAU, PHI from std::math::consts
 
@@ -645,7 +645,7 @@ println(hyp, is_right, prime, big)",
 #[test]
 fn integration_fn_array() {
     let statements = common::parse(
-        "get println from std::display
+        "get println from std::io
 get is_prime, factorial, fibonacci from std::math
 
 dec int n = 10

--- a/tests/parser/programs.rs
+++ b/tests/parser/programs.rs
@@ -25,7 +25,7 @@ println(x, y)",
         Statement::new(
             StatementKind::Import {
                 names: vec!["println".to_string()],
-                path: vec!["std".to_string(), "display".to_string()],
+                path: vec!["std".to_string(), "io".to_string()],
             },
             Span::new(0, 29),
         ),
@@ -184,7 +184,7 @@ println(hyp, is_right, prime, big)",
         Statement::new(
             StatementKind::Import {
                 names: vec!["println".to_string()],
-                path: vec!["std".to_string(), "display".to_string()],
+                path: vec!["std".to_string(), "io".to_string()],
             },
             Span::new(0, 29),
         ),
@@ -671,7 +671,7 @@ for [int i = 0, i < 2, i += 1] {
         Statement::new(
             StatementKind::Import {
                 names: vec!["println".to_string()],
-                path: vec!["std".to_string(), "display".to_string()],
+                path: vec!["std".to_string(), "io".to_string()],
             },
             Span::new(0, 29),
         ),

--- a/tests/parser/programs.rs
+++ b/tests/parser/programs.rs
@@ -27,49 +27,49 @@ println(x, y)",
                 names: vec!["println".to_string()],
                 path: vec!["std".to_string(), "io".to_string()],
             },
-            Span::new(0, 29),
+            Span::new(0, 24),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(29, 30),
+                Span::new(24, 25),
             )),
-            Span::new(29, 30),
+            Span::new(24, 25),
         ),
         Statement::new(
             StatementKind::Import {
                 names: vec!["pow".to_string()],
                 path: vec!["std".to_string(), "math".to_string()],
             },
-            Span::new(30, 52),
+            Span::new(25, 47),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(52, 53),
+                Span::new(47, 48),
             )),
-            Span::new(52, 53),
+            Span::new(47, 48),
         ),
         Statement::new(
             StatementKind::Import {
                 names: vec!["PI".to_string()],
                 path: vec!["std".to_string(), "math".to_string(), "consts".to_string()],
             },
-            Span::new(53, 78),
+            Span::new(48, 73),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(78, 79),
+                Span::new(73, 74),
             )),
-            Span::new(78, 79),
+            Span::new(73, 74),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(79, 80),
+                Span::new(74, 75),
             )),
-            Span::new(79, 80),
+            Span::new(74, 75),
         ),
         Statement::new(
             StatementKind::ConstantDeclaration {
@@ -80,17 +80,17 @@ println(x, y)",
                         path: vec!["PI".to_string()],
                         args: vec![],
                     },
-                    Span::new(97, 101),
+                    Span::new(92, 96),
                 ),
             },
-            Span::new(80, 101),
+            Span::new(75, 96),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(101, 102),
+                Span::new(96, 97),
             )),
-            Span::new(101, 102),
+            Span::new(96, 97),
         ),
         Statement::new(
             StatementKind::VariableDeclaration {
@@ -102,32 +102,32 @@ println(x, y)",
                         args: vec![
                             Expression::new(
                                 ExpressionKind::Identifier("pi".to_string()),
-                                Span::new(120, 122),
+                                Span::new(115, 117),
                             ),
                             Expression::new(
                                 ExpressionKind::Identifier("pi".to_string()),
-                                Span::new(124, 126),
+                                Span::new(119, 121),
                             ),
                         ],
                     },
-                    Span::new(116, 127),
+                    Span::new(111, 122),
                 ),
             },
-            Span::new(102, 127),
+            Span::new(97, 122),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(127, 128),
+                Span::new(122, 123),
             )),
-            Span::new(127, 128),
+            Span::new(122, 123),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
                 ExpressionKind::Integer(0),
-                Span::new(128, 129),
+                Span::new(123, 124),
             )),
-            Span::new(128, 129),
+            Span::new(123, 124),
         ),
         Statement::new(
             StatementKind::Expression(Expression::new(
@@ -136,17 +136,17 @@ println(x, y)",
                     args: vec![
                         Expression::new(
                             ExpressionKind::Identifier("x".to_string()),
-                            Span::new(137, 138),
+                            Span::new(132, 133),
                         ),
                         Expression::new(
                             ExpressionKind::Identifier("y".to_string()),
-                            Span::new(140, 141),
+                            Span::new(135, 136),
                         ),
                     ],
                 },
-                Span::new(129, 142),
+                Span::new(124, 137),
             )),
-            Span::new(129, 142),
+            Span::new(124, 137),
         ),
     ];
     assert_eq!(statements, expected);


### PR DESCRIPTION
## What does this PR do?

Update the `io` stdlib module, plus its docs entry (`FnEntry`/`StdEntry`) following the existing stdlib documentation pattern.

### functions

- `read_int()` -> reads a line from stdin then parses to integer
- `read_int(prompt)` -> prints prompt and reads a line from stdin then parses to integer
- `read_float()` -> reads a line from stdin then parses to float
- `read_float(prompt)` -> prints prompt and reads a line from stdin then parses to float
- `append_file(path, content)` -> appends content to a file, creating it if it does not exist
- `delete_file(path)` -> deletes a file at the given path
- `read_file(path)` -> reads the entire contents of a file as a string
- `read_lines(path)` -> reads a file and returns its lines as an array of strings
- `write_file(path, contents)` -> writes content to a file, overwriting it if it already exists
- `input()` has been renamed to `read()`
- `println()` `print()` and `eprint()` moved from `std::display` to `std::io`