### PR TITLE
add path parsing logic

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -46,7 +46,7 @@ pub enum ExpressionKind {
 
     MethodCall {
         caller: Box<Expression>,
-        method: String,
+        method: Vec<String>,
         args: Vec<Expression>,
     },
     Index {

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -288,11 +288,7 @@ impl Evaluator {
                 for arg in args {
                     evaluated_args.push(self.evaluate(arg)?);
                 }
-                self.call_path(
-                    std::slice::from_ref(method),
-                    evaluated_args,
-                    expression.span,
-                )?
+                self.call_path(method, evaluated_args, expression.span)?
             }
             ExpressionKind::Lambda {
                 params,

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -459,11 +459,24 @@ impl Parser {
                 if !self.match_type(&[TokenType::Identifier(String::new())]) {
                     return Err(self.err("expected method name after '.'", self.peek_span()));
                 }
-                let method = if let TokenType::Identifier(name) = self.previous() {
+                let first = if let TokenType::Identifier(name) = self.previous() {
                     name
                 } else {
                     return Err(self.err("expected method name after '.'", self.peek_span()));
                 };
+
+                // construct the path
+                let mut method = vec![first];
+                while self.match_type(&[TokenType::ColonColon]) {
+                    if !self.match_type(&[TokenType::Identifier(String::new())]) {
+                        return Err(
+                            self.err("expected identifier name after '::'", self.peek_span())
+                        );
+                    }
+                    if let TokenType::Identifier(seg) = self.previous() {
+                        method.push(seg);
+                    }
+                }
 
                 // expect (args)
                 if !self.match_type(&[TokenType::LeftParen]) {


### PR DESCRIPTION
## What does this PR do?
fix 
```rl
dec string x = "123"
x.std::types::to_int().std::io::println()
```
not being working correctly
(now it works)