### PR TITLE
Refactor/error handling

### DIFF
--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -382,7 +382,10 @@ impl Evaluator {
             let f = Arc::clone(f);
             return match f(self, args, span) {
                 Ok(v) => Ok(v),
-                Err(e) if e.span().is_some() => Err(e),
+                Err(e) if e.span().is_some() => Err(match &self.source_file {
+                    Some(file) => e.with_source_file(file),
+                    None => e,
+                }),
                 Err(e) => Err(self.err(e.message(), span)),
             };
         }

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -380,7 +380,11 @@ impl Evaluator {
     ) -> Result<Value, Error> {
         if let Some(f) = self.root_module.resolve(path) {
             let f = Arc::clone(f);
-            return f(self, args);
+            return match f(self, args, span) {
+                Ok(v) => Ok(v),
+                Err(e) if e.span().is_some() => Err(e),
+                Err(e) => Err(self.err(e.message(), span)),
+            };
         }
 
         // detect user defined functions

--- a/src/interpreter/native.rs
+++ b/src/interpreter/native.rs
@@ -373,3 +373,91 @@ impl_into_native_fn!(
     (A9, a9),
     (A10, a10)
 );
+
+pub struct Spanned<T>(std::marker::PhantomData<T>);
+
+macro_rules! impl_into_native_fn_spanned {
+    ($count:literal, $(($ty:ident, $var:ident)),+) => {
+        impl<F, R, $($ty),+> IntoNativeFn<(Spanned<($($ty,)+)>,)> for F
+        where
+            F: Fn(&mut Evaluator, $($ty),+, Span) -> Result<R, Error> + Send + Sync + 'static,
+            R: IntoValue,
+            $($ty: FromValue),+
+        {
+            fn into_native(self) -> NativeFn {
+                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>, span: Span| -> Result<Value, Error> {
+                    if args.len() != $count {
+                        return Err(rt.err(
+                            format!("expected {} argument(s), got {}", $count, args.len()),
+                            span,
+                        ));
+                    }
+                    let mut iter = args.into_iter();
+                    $(let $var = <$ty>::from_value(iter.next().unwrap(), span)?;)+
+                    Ok(self(rt, $($var),+, span)?.into_value())
+                })
+            }
+        }
+    };
+}
+
+impl_into_native_fn_spanned!(1, (A1, a1));
+impl_into_native_fn_spanned!(2, (A1, a1), (A2, a2));
+impl_into_native_fn_spanned!(3, (A1, a1), (A2, a2), (A3, a3));
+impl_into_native_fn_spanned!(4, (A1, a1), (A2, a2), (A3, a3), (A4, a4));
+impl_into_native_fn_spanned!(5, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5));
+impl_into_native_fn_spanned!(
+    6,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6)
+);
+impl_into_native_fn_spanned!(
+    7,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7)
+);
+impl_into_native_fn_spanned!(
+    8,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8)
+);
+impl_into_native_fn_spanned!(
+    9,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9)
+);
+impl_into_native_fn_spanned!(
+    10,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9),
+    (A10, a10)
+);

--- a/src/interpreter/native.rs
+++ b/src/interpreter/native.rs
@@ -1,13 +1,12 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use crate::ast::statements::TypeAnnotation;
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
-use crate::utils::errors::{Error, ErrorReason, Reason};
-
-pub type NativeFn = Arc<dyn Fn(&mut Evaluator, Vec<Value>) -> Result<Value, Error> + Send + Sync>;
-
+use crate::utils::errors::{Error, Reason};
+use crate::utils::span::Span;
+use std::collections::HashMap;
+use std::sync::Arc;
+pub type NativeFn =
+    Arc<dyn Fn(&mut Evaluator, Vec<Value>, Span) -> Result<Value, Error> + Send + Sync>;
 pub struct Module {
     pub name: String,
     pub functions: HashMap<String, NativeFn>,
@@ -33,7 +32,7 @@ impl Module {
 
     pub fn with_raw_function<F>(mut self, name: impl Into<String>, f: F) -> Self
     where
-        F: Fn(&mut Evaluator, Vec<Value>) -> Result<Value, Error> + Send + Sync + 'static,
+        F: Fn(&mut Evaluator, Vec<Value>, Span) -> Result<Value, Error> + Send + Sync + 'static,
     {
         self.functions.insert(name.into(), Arc::new(f));
         self
@@ -97,88 +96,91 @@ impl<T: ValueType> ValueType for Vec<T> {
 }
 
 pub trait FromValue: Sized {
-    fn from_value(v: Value) -> Result<Self, Error>;
+    fn from_value(v: Value, span: Span) -> Result<Self, Error>;
 }
 
 impl FromValue for Value {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, _span: Span) -> Result<Self, Error> {
         Ok(v)
     }
 }
 
 impl FromValue for i64 {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Integer(i) => Ok(i),
-            other => Err(Error::init(
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected integer, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
 }
 
 impl FromValue for f64 {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Float(f) => Ok(f),
-            other => Err(Error::init(
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected float, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
 }
 
 impl FromValue for String {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::String(s) => Ok(s),
-            other => Err(Error::init(
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected string, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
 }
 
 impl FromValue for bool {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Bool(b) => Ok(b),
-            other => Err(Error::init(
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected bool, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
 }
 
 impl FromValue for char {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Char(c) => Ok(c),
-            other => Err(Error::init(
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected char, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
 }
 
 impl<T: FromValue> FromValue for Vec<T> {
-    fn from_value(v: Value) -> Result<Self, Error> {
+    fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
-            Value::Values { items, .. } => items.into_iter().map(T::from_value).collect(),
-            other => Err(Error::init(
+            Value::Values { items, .. } => items
+                .into_iter()
+                .map(|item| T::from_value(item, span))
+                .collect(),
+            other => Err(Error::at(
+                Reason::Runtime,
                 format!("expected array, got {}", other.type_name()),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         }
     }
@@ -250,12 +252,12 @@ where
 {
     fn into_native(self) -> NativeFn {
         Arc::new(
-            move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
+            move |rt: &mut Evaluator, args: Vec<Value>, span: Span| -> Result<Value, Error> {
                 if !args.is_empty() {
-                    return Err(Error::init(
+                    return Err(Error::at(
+                        Reason::Runtime,
                         format!("expected 0 argument(s), got {}", args.len()),
-                        None,
-                        Some(ErrorReason::init(Reason::Runtime, None)),
+                        span,
                     ));
                 }
                 Ok(self(rt).into_value())
@@ -275,15 +277,15 @@ macro_rules! impl_into_native_fn {
             $($ty: FromValue),+
         {
             fn into_native(self) -> NativeFn {
-                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
+                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>, span: Span| -> Result<Value, Error> {
                     if args.len() != $count {
-                        return Err(Error::init(
+                        return Err(Error::at(
+                            Reason::Runtime,
                             format!("expected {} argument(s), got {}", $count, args.len()),
-                            None, Some(ErrorReason::init(Reason::Runtime, None)),
-                        ));
+                            span, ));
                     }
                     let mut iter = args.into_iter();
-                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    $(let $var = <$ty>::from_value(iter.next().unwrap(), span)?;)+
                     Ok(self(rt, $($var),+).into_value())
                 })
             }
@@ -296,15 +298,15 @@ macro_rules! impl_into_native_fn {
             $($ty: FromValue),+
         {
             fn into_native(self) -> NativeFn {
-                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>| -> Result<Value, Error> {
+                Arc::new(move |rt: &mut Evaluator, args: Vec<Value>, span: Span| -> Result<Value, Error> {
                     if args.len() != $count {
-                        return Err(Error::init(
+                        return Err(Error::at(
+                            Reason::Runtime,
                             format!("expected {} argument(s), got {}", $count, args.len()),
-                            None, Some(ErrorReason::init(Reason::Runtime, None)),
-                        ));
+                            span, ));
                     }
                     let mut iter = args.into_iter();
-                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    $(let $var = <$ty>::from_value(iter.next().unwrap(), span)?;)+
                     Ok(self(rt, $($var),+)?.into_value())
                 })
             }

--- a/src/interpreter/stdlib/array/arr_all.rs
+++ b/src/interpreter/stdlib/array/arr_all.rs
@@ -32,22 +32,25 @@ pub fn std_arr_all(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool)) {
-            return Err(Error::init(
-                format!(
-                    "arr_all() expected function or lambda with Bool return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Bool))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_all() expected function or lambda with Bool return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 
     for item in items.clone() {
         let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
-        if let Value::Bool(false) = mapped_item { return Ok(Value::Bool(false)) }
+        if let Value::Bool(false) = mapped_item {
+            return Ok(Value::Bool(false));
+        }
     }
 
     Ok(Value::Bool(true))

--- a/src/interpreter/stdlib/array/arr_all.rs
+++ b/src/interpreter/stdlib/array/arr_all.rs
@@ -5,49 +5,45 @@ use crate::{
 };
 
 pub fn std_arr_all(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (_, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!("arr_all() accepts only arrays found {}", other.type_name()).to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_all() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Bool))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_all() expected function or lambda with Bool return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
-
     for item in items.clone() {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Bool(false) = mapped_item {
             return Ok(Value::Bool(false));
         }

--- a/src/interpreter/stdlib/array/arr_any.rs
+++ b/src/interpreter/stdlib/array/arr_any.rs
@@ -5,49 +5,45 @@ use crate::{
 };
 
 pub fn std_arr_any(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (_, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!("arr_any() accepts only arrays found {}", other.type_name()).to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_any() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Bool))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_any() expected function or lambda with Bool return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
-
     for item in items.clone() {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Bool(true) = mapped_item {
             return Ok(Value::Bool(true));
         }

--- a/src/interpreter/stdlib/array/arr_any.rs
+++ b/src/interpreter/stdlib/array/arr_any.rs
@@ -32,22 +32,25 @@ pub fn std_arr_any(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool)) {
-            return Err(Error::init(
-                format!(
-                    "arr_any() expected function or lambda with Bool return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Bool))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_any() expected function or lambda with Bool return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 
     for item in items.clone() {
         let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
-        if let Value::Bool(true) = mapped_item { return Ok(Value::Bool(true)) }
+        if let Value::Bool(true) = mapped_item {
+            return Ok(Value::Bool(true));
+        }
     }
 
     Ok(Value::Bool(false))

--- a/src/interpreter/stdlib/array/arr_concat.rs
+++ b/src/interpreter/stdlib/array/arr_concat.rs
@@ -1,9 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_concat(_: &mut Evaluator, array1: Value, array2: Value) -> Result<Value, Error> {
+pub fn std_arr_concat(
+    eval: &mut Evaluator,
+    array1: Value,
+    array2: Value,
+    span: Span,
+) -> Result<Value, Error> {
     match (array1, array2) {
         (
             Value::Values {
@@ -16,13 +21,12 @@ pub fn std_arr_concat(_: &mut Evaluator, array1: Value, array2: Value) -> Result
             },
         ) => {
             if it_1 != it_2 {
-                return Err(Error::init(
+                return Err(eval.err(
                     format!(
                         "type mismatch: array type {:?}, cannot concat {:?}",
                         it_1, it_2
                     ),
-                    None,
-                    None,
+                    span,
                 ));
             }
             let mut v = i1;
@@ -32,10 +36,6 @@ pub fn std_arr_concat(_: &mut Evaluator, array1: Value, array2: Value) -> Result
                 items: v,
             })
         }
-        _ => Err(Error::init(
-            "arr_concat() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_concat() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_contains.rs
+++ b/src/interpreter/stdlib/array/arr_contains.rs
@@ -1,9 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_contains(_: &mut Evaluator, array: Value, value: Value) -> Result<bool, Error> {
+pub fn std_arr_contains(
+    eval: &mut Evaluator,
+    array: Value,
+    value: Value,
+    span: Span,
+) -> Result<bool, Error> {
     match array {
         Value::Values { items, .. } => {
             if items.contains(&value) {
@@ -11,10 +16,6 @@ pub fn std_arr_contains(_: &mut Evaluator, array: Value, value: Value) -> Result
             }
             Ok(false)
         }
-        _ => Err(Error::init(
-            "arr_contains() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_contains() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_count.rs
+++ b/src/interpreter/stdlib/array/arr_count.rs
@@ -1,15 +1,11 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_count(_: &mut Evaluator, array: Value) -> Result<i64, Error> {
+pub fn std_arr_count(eval: &mut Evaluator, array: Value, span: Span) -> Result<i64, Error> {
     match array {
         Value::Values { items, .. } => Ok(items.len() as i64),
-        _ => Err(Error::init(
-            "arr_is_empty() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_is_empty() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_filter.rs
+++ b/src/interpreter/stdlib/array/arr_filter.rs
@@ -36,16 +36,17 @@ pub fn std_arr_filter(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool)) {
-            return Err(Error::init(
-                format!(
-                    "arr_filter() expected function or lambda with Bool return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Bool))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_filter() expected function or lambda with Bool return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 
@@ -53,7 +54,9 @@ pub fn std_arr_filter(
 
     for item in items {
         let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
-        if let Value::Bool(true) = mapped_item { result.push(item) }
+        if let Value::Bool(true) = mapped_item {
+            result.push(item)
+        }
     }
 
     Ok(Value::Values {

--- a/src/interpreter/stdlib/array/arr_filter.rs
+++ b/src/interpreter/stdlib/array/arr_filter.rs
@@ -5,55 +5,51 @@ use crate::{
 };
 
 pub fn std_arr_filter(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (items_type, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_filter() accepts only arrays found {}",
                     other.type_name()
                 )
                 .to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_filter() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Bool))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_filter() expected function or lambda with Bool return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
-
-    let span = Span { start: 0, end: 0 };
 
     let mut result = Vec::with_capacity(items.len());
 
     for item in items {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Bool(true) = mapped_item {
             result.push(item)
         }

--- a/src/interpreter/stdlib/array/arr_find.rs
+++ b/src/interpreter/stdlib/array/arr_find.rs
@@ -32,22 +32,25 @@ pub fn std_arr_find(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool)) {
-            return Err(Error::init(
-                format!(
-                    "arr_find() expected function or lambda with Bool return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Bool))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_find() expected function or lambda with Bool return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 
     for item in items {
         let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
-        if let Value::Bool(true) = mapped_item { return Ok(item) }
+        if let Value::Bool(true) = mapped_item {
+            return Ok(item);
+        }
     }
 
     Ok(Value::Null)

--- a/src/interpreter/stdlib/array/arr_find.rs
+++ b/src/interpreter/stdlib/array/arr_find.rs
@@ -5,49 +5,45 @@ use crate::{
 };
 
 pub fn std_arr_find(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (_, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!("arr_find() accepts only arrays found {}", other.type_name()).to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_find() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Bool))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_find() expected function or lambda with Bool return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
-
     for item in items {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Bool(true) = mapped_item {
             return Ok(item);
         }

--- a/src/interpreter/stdlib/array/arr_find_index.rs
+++ b/src/interpreter/stdlib/array/arr_find_index.rs
@@ -36,22 +36,25 @@ pub fn std_arr_find_index(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool)) {
-            return Err(Error::init(
-                format!(
-                    "arr_find_index() expected function or lambda with Bool return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Bool))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_find_index() expected function or lambda with Bool return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 
     for (i, item) in items.iter().enumerate() {
         let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
-        if let Value::Bool(true) = mapped_item { return Ok(Value::Integer(i as i64)) }
+        if let Value::Bool(true) = mapped_item {
+            return Ok(Value::Integer(i as i64));
+        }
     }
 
     Ok(Value::Integer(-1_i64))

--- a/src/interpreter/stdlib/array/arr_find_index.rs
+++ b/src/interpreter/stdlib/array/arr_find_index.rs
@@ -5,53 +5,49 @@ use crate::{
 };
 
 pub fn std_arr_find_index(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (_, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_find_index() accepts only arrays found {}",
                     other.type_name()
                 )
                 .to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_find_index() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Bool))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_find_index() expected function or lambda with Bool return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
-
     for (i, item) in items.iter().enumerate() {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Bool(true) = mapped_item {
             return Ok(Value::Integer(i as i64));
         }

--- a/src/interpreter/stdlib/array/arr_first.rs
+++ b/src/interpreter/stdlib/array/arr_first.rs
@@ -1,22 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_first(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_first(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, .. } => match items.into_iter().next() {
             Some(v) => Ok(v),
-            None => Err(Error::init(
-                "arr_first() called on empty array".to_string(),
-                None,
-                None,
-            )),
+            None => Err(eval.err("arr_first() called on empty array".to_string(), span)),
         },
-        _ => Err(Error::init(
-            "arr_first() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_first() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_flat_map.rs
+++ b/src/interpreter/stdlib/array/arr_flat_map.rs
@@ -36,16 +36,17 @@ pub fn std_arr_flat_map(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Array(_))) {
-            return Err(Error::init(
-                format!(
-                    "arr_flat_map() expected function or lambda with Array return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Array(_)))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_flat_map() expected function or lambda with Array return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 

--- a/src/interpreter/stdlib/array/arr_flat_map.rs
+++ b/src/interpreter/stdlib/array/arr_flat_map.rs
@@ -5,55 +5,51 @@ use crate::{
 };
 
 pub fn std_arr_flat_map(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (items_type, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_flat_map() accepts only arrays found {}",
                     other.type_name()
                 )
                 .to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_flat_map() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Array(_)))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_flat_map() expected function or lambda with Array return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span,
         ));
     }
-
-    let span = Span { start: 0, end: 0 };
 
     let mut result = Vec::with_capacity(items.len());
 
     for item in items {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item.clone()], span)?;
         if let Value::Values { items, .. } = mapped_item {
             for item in items {
                 result.push(item)

--- a/src/interpreter/stdlib/array/arr_flatten.rs
+++ b/src/interpreter/stdlib/array/arr_flatten.rs
@@ -1,17 +1,13 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_flatten(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_flatten(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => {
             if items.is_empty() {
-                return Err(Error::init(
-                    "arr_flatten() called on empty array".to_string(),
-                    None,
-                    None,
-                ));
+                return Err(eval.err("arr_flatten() called on empty array".to_string(), span));
             }
 
             Ok(Value::Values {
@@ -28,10 +24,6 @@ pub fn std_arr_flatten(_: &mut Evaluator, array: Value) -> Result<Value, Error> 
                     .collect(),
             })
         }
-        _ => Err(Error::init(
-            "arr_flatten() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_flatten() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_for_each.rs
+++ b/src/interpreter/stdlib/array/arr_for_each.rs
@@ -5,53 +5,49 @@ use crate::{
 };
 
 pub fn std_arr_for_each(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (_, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_for_each() accepts only arrays found {}",
                     other.type_name()
                 )
                 .to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_for_each() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
     if let Value::Function { return_type, .. } = function.clone()
         && !matches!(return_type, Some(TypeAnnotation::Null))
     {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_for_each() expected function or lambda with no (or null) return type found {:?}",
                 return_type
             ),
-            None,
-            None,
+            span
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
-
     for item in items {
-        evaluator.call_value(function.clone(), vec![item.clone()], span)?;
+        eval.call_value(function.clone(), vec![item.clone()], span)?;
     }
 
     Ok(Value::Null)

--- a/src/interpreter/stdlib/array/arr_for_each.rs
+++ b/src/interpreter/stdlib/array/arr_for_each.rs
@@ -36,16 +36,17 @@ pub fn std_arr_for_each(
     }
 
     if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Null)) {
-            return Err(Error::init(
-                format!(
-                    "arr_for_each() expected function or lambda with no (or null) return type found {:?}",
-                    return_type
-                ),
-                None,
-                None,
-            ));
-        }
+        && !matches!(return_type, Some(TypeAnnotation::Null))
+    {
+        return Err(Error::init(
+            format!(
+                "arr_for_each() expected function or lambda with no (or null) return type found {:?}",
+                return_type
+            ),
+            None,
+            None,
+        ));
+    }
 
     let span = Span { start: 0, end: 0 };
 

--- a/src/interpreter/stdlib/array/arr_index_of.rs
+++ b/src/interpreter/stdlib/array/arr_index_of.rs
@@ -2,26 +2,23 @@ use std::ops::Index;
 
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_index_of(_: &mut Evaluator, array: Value, index: i64) -> Result<Value, Error> {
+pub fn std_arr_index_of(
+    eval: &mut Evaluator,
+    array: Value,
+    index: i64,
+    span: Span,
+) -> Result<Value, Error> {
     match array {
         Value::Values { items, .. } => {
             if index as usize >= items.len() {
-                return Err(Error::init(
-                    format!("index out of bounds: {}", index),
-                    None,
-                    None,
-                ));
+                return Err(eval.err(format!("index out of bounds: {}", index), span));
             }
             let item = items.index(index as usize);
             Ok(item.clone())
         }
-        _ => Err(Error::init(
-            "arr_is_empty() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_is_empty() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_insert.rs
+++ b/src/interpreter/stdlib/array/arr_insert.rs
@@ -1,34 +1,30 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_arr_insert(
-    _: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     value: Value,
     index: i64,
+    span: Span,
 ) -> Result<Value, Error> {
     match array {
         Value::Values { items_type, items } => {
             if index as usize >= items.len() {
-                return Err(Error::init(
-                    format!("index out of bounds: {}", index),
-                    None,
-                    None,
-                ));
+                return Err(eval.err(format!("index out of bounds: {}", index), span));
             }
 
             let val_type = Evaluator::infer_type(&value, false);
             if val_type != items_type && val_type != TypeAnnotation::Null {
-                return Err(Error::init(
+                return Err(eval.err(
                     format!(
                         "type mismatch: array expects {:?}, cannot push {:?}",
                         items_type, val_type
                     ),
-                    None,
-                    None,
+                    span,
                 ));
             }
             let mut v = items;
@@ -38,10 +34,9 @@ pub fn std_arr_insert(
                 items: v,
             })
         }
-        _ => Err(Error::init(
+        _ => Err(eval.err(
             "arr_insert() accepts only arrays and values".to_string(),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/array/arr_is_empty.rs
+++ b/src/interpreter/stdlib/array/arr_is_empty.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_is_empty(_: &mut Evaluator, array: Value) -> Result<bool, Error> {
+pub fn std_arr_is_empty(eval: &mut Evaluator, array: Value, span: Span) -> Result<bool, Error> {
     match array {
         Value::Values { items, .. } => {
             if items.is_empty() {
@@ -11,10 +11,6 @@ pub fn std_arr_is_empty(_: &mut Evaluator, array: Value) -> Result<bool, Error> 
             }
             Ok(false)
         }
-        _ => Err(Error::init(
-            "arr_is_empty() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_is_empty() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_last.rs
+++ b/src/interpreter/stdlib/array/arr_last.rs
@@ -1,22 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_last(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_last(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, .. } => match items.into_iter().last() {
             Some(v) => Ok(v),
-            None => Err(Error::init(
-                "arr_last() called on empty array".to_string(),
-                None,
-                None,
-            )),
+            None => Err(eval.err("arr_last() called on empty array".to_string(), span)),
         },
-        _ => Err(Error::init(
-            "arr_last() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_last() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_map.rs
+++ b/src/interpreter/stdlib/array/arr_map.rs
@@ -4,38 +4,35 @@ use crate::{
 };
 
 pub fn std_arr_map(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (items_type, items) = match array {
         Value::Values { items_type, items } => (items_type, items),
 
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!("arr_map() accepts only arrays found {}", other.type_name()).to_string(),
-                None,
-                None,
+                span,
             ));
         }
     };
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_map() expected function or lambda found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
-
-    let span = Span { start: 0, end: 0 };
 
     let mut result = Vec::with_capacity(items.len());
 
     for item in items {
-        let mapped_item = evaluator.call_value(function.clone(), vec![item], span)?;
+        let mapped_item = eval.call_value(function.clone(), vec![item], span)?;
         result.push(mapped_item);
     }
 

--- a/src/interpreter/stdlib/array/arr_max.rs
+++ b/src/interpreter/stdlib/array/arr_max.rs
@@ -1,10 +1,13 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_arr_max(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_max(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => match items_type {
             TypeAnnotation::Int => {
@@ -18,13 +21,7 @@ pub fn std_arr_max(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                         }
                     })
                     .max()
-                    .ok_or_else(|| {
-                        Error::init(
-                            "arr_max() called on empty array".to_string(),
-                            None,
-                            Some(ErrorReason::init(Reason::Runtime, None)),
-                        )
-                    })?;
+                    .ok_or_else(|| eval.err("arr_max() called on empty array".to_string(), span))?;
                 Ok(Value::Integer(max))
             }
             TypeAnnotation::Float => {
@@ -38,25 +35,14 @@ pub fn std_arr_max(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                         }
                     })
                     .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                    .ok_or_else(|| {
-                        Error::init(
-                            "arr_max() called on empty array".to_string(),
-                            None,
-                            Some(ErrorReason::init(Reason::Runtime, None)),
-                        )
-                    })?;
+                    .ok_or_else(|| eval.err("arr_max() called on empty array".to_string(), span))?;
                 Ok(Value::Float(max))
             }
-            _ => Err(Error::init(
+            _ => Err(eval.err(
                 "arr_max() accepts only int or float arrays".to_string(),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         },
-        _ => Err(Error::init(
-            "arr_max() accepts only arrays".to_string(),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
-        )),
+        _ => Err(eval.err("arr_max() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_max.rs
+++ b/src/interpreter/stdlib/array/arr_max.rs
@@ -1,10 +1,7 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_arr_max(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/array/arr_max.rs
+++ b/src/interpreter/stdlib/array/arr_max.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/array/arr_min.rs
+++ b/src/interpreter/stdlib/array/arr_min.rs
@@ -1,10 +1,13 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_arr_min(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_min(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => match items_type {
             TypeAnnotation::Int => {
@@ -18,13 +21,7 @@ pub fn std_arr_min(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                         }
                     })
                     .min()
-                    .ok_or_else(|| {
-                        Error::init(
-                            "arr_min() called on empty array".to_string(),
-                            None,
-                            Some(ErrorReason::init(Reason::Runtime, None)),
-                        )
-                    })?;
+                    .ok_or_else(|| eval.err("arr_min() called on empty array".to_string(), span))?;
                 Ok(Value::Integer(min))
             }
             TypeAnnotation::Float => {
@@ -38,25 +35,14 @@ pub fn std_arr_min(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                         }
                     })
                     .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-                    .ok_or_else(|| {
-                        Error::init(
-                            "arr_min() called on empty array".to_string(),
-                            None,
-                            Some(ErrorReason::init(Reason::Runtime, None)),
-                        )
-                    })?;
+                    .ok_or_else(|| eval.err("arr_min() called on empty array".to_string(), span))?;
                 Ok(Value::Float(min))
             }
-            _ => Err(Error::init(
+            _ => Err(eval.err(
                 "arr_min() accepts only int or float arrays".to_string(),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )),
         },
-        _ => Err(Error::init(
-            "arr_min() accepts only arrays".to_string(),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
-        )),
+        _ => Err(eval.err("arr_min() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_min.rs
+++ b/src/interpreter/stdlib/array/arr_min.rs
@@ -1,10 +1,7 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_arr_min(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/array/arr_min.rs
+++ b/src/interpreter/stdlib/array/arr_min.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/array/arr_pop.rs
+++ b/src/interpreter/stdlib/array/arr_pop.rs
@@ -1,28 +1,20 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_pop(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_pop(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values {
             items_type,
             mut items,
         } => {
             if items.is_empty() {
-                return Err(Error::init(
-                    "arr_pop() called on empty array".to_string(),
-                    None,
-                    None,
-                ));
+                return Err(eval.err("arr_pop() called on empty array".to_string(), span));
             }
             items.pop();
             Ok(Value::Values { items_type, items })
         }
-        _ => Err(Error::init(
-            "arr_pop() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_pop() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_product.rs
+++ b/src/interpreter/stdlib/array/arr_product.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_product(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_product(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => match items_type {
             TypeAnnotation::Int => {
@@ -33,16 +33,11 @@ pub fn std_arr_product(_: &mut Evaluator, array: Value) -> Result<Value, Error> 
                     .sum::<f64>();
                 Ok(Value::Float(product))
             }
-            _ => Err(Error::init(
+            _ => Err(eval.err(
                 "arr_product() accepts only int or float arrays".to_string(),
-                None,
-                None,
+                span,
             )),
         },
-        _ => Err(Error::init(
-            "arr_product() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_product() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_push.rs
+++ b/src/interpreter/stdlib/array/arr_push.rs
@@ -1,21 +1,25 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_push(_: &mut Evaluator, array: Value, value: Value) -> Result<Value, Error> {
+pub fn std_arr_push(
+    eval: &mut Evaluator,
+    array: Value,
+    value: Value,
+    span: Span,
+) -> Result<Value, Error> {
     match array {
         Value::Values { items_type, items } => {
             let val_type = Evaluator::infer_type(&value, false);
             if val_type != items_type && val_type != TypeAnnotation::Null {
-                return Err(Error::init(
+                return Err(eval.err(
                     format!(
                         "type mismatch: array expects {:?}, cannot push {:?}",
                         items_type, val_type
                     ),
-                    None,
-                    None,
+                    span,
                 ));
             }
             let mut v = items;
@@ -25,10 +29,6 @@ pub fn std_arr_push(_: &mut Evaluator, array: Value, value: Value) -> Result<Val
                 items: v,
             })
         }
-        _ => Err(Error::init(
-            "arr_push() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_push() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_reduce.rs
+++ b/src/interpreter/stdlib/array/arr_reduce.rs
@@ -4,41 +4,39 @@ use crate::{
 };
 
 pub fn std_arr_reduce(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
     initial: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let items = match array {
         Value::Values { items, .. } => items,
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_reduce() accepts only arrays, found {}",
                     other.type_name()
                 ),
-                None,
-                None,
+                span,
             ));
         }
     };
 
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_reduce() expected function or lambda, found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
 
-    let span = Span { start: 0, end: 0 };
     let mut result = initial;
 
     for item in items {
-        result = evaluator.call_value(function.clone(), vec![result, item], span)?;
+        result = eval.call_value(function.clone(), vec![result, item], span)?;
     }
 
     Ok(result)

--- a/src/interpreter/stdlib/array/arr_remove.rs
+++ b/src/interpreter/stdlib/array/arr_remove.rs
@@ -1,17 +1,18 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_remove(_: &mut Evaluator, array: Value, index: i64) -> Result<Value, Error> {
+pub fn std_arr_remove(
+    eval: &mut Evaluator,
+    array: Value,
+    index: i64,
+    span: Span,
+) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => {
             if index as usize >= items.len() {
-                return Err(Error::init(
-                    format!("index out of bounds: {}", index),
-                    None,
-                    None,
-                ));
+                return Err(eval.err(format!("index out of bounds: {}", index), span));
             }
             let mut v = items;
             v.remove(index as usize);
@@ -20,10 +21,6 @@ pub fn std_arr_remove(_: &mut Evaluator, array: Value, index: i64) -> Result<Val
                 items: v,
             })
         }
-        _ => Err(Error::init(
-            "arr_remove() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_remove() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_reverse.rs
+++ b/src/interpreter/stdlib/array/arr_reverse.rs
@@ -1,19 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_reverse(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_reverse(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items_type, items } => {
             let mut items = items;
             items.reverse();
             Ok(Value::Values { items_type, items })
         }
-        _ => Err(Error::init(
-            "arr_reverse() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_reverse() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_slice.rs
+++ b/src/interpreter/stdlib/array/arr_slice.rs
@@ -1,35 +1,34 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_arr_slice(
-    _: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     start: i64,
     end: i64,
+    span: Span,
 ) -> Result<Value, Error> {
     match array {
         Value::Values { items_type, items } => {
             let start = start as usize;
             let end = end as usize;
             if start > items.len() || end > items.len() {
-                return Err(Error::init(
+                return Err(eval.err(
                     format!(
                         "slice index out of bounds: {}..{} (len {})",
                         start,
                         end,
                         items.len()
                     ),
-                    None,
-                    None,
+                    span,
                 ));
             }
             if start > end {
-                return Err(Error::init(
+                return Err(eval.err(
                     format!("slice start {} is greater than end {}", start, end),
-                    None,
-                    None,
+                    span,
                 ));
             }
             Ok(Value::Values {
@@ -37,10 +36,6 @@ pub fn std_arr_slice(
                 items: items[start..end].to_vec(),
             })
         }
-        _ => Err(Error::init(
-            "arr_slice() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_slice() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_sort.rs
+++ b/src/interpreter/stdlib/array/arr_sort.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_sort(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_sort(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values {
             items_type,
@@ -30,16 +30,11 @@ pub fn std_arr_sort(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                 });
                 Ok(Value::Values { items_type, items })
             }
-            _ => Err(Error::init(
+            _ => Err(eval.err(
                 "arr_sort() accepts only int or float arrays".to_string(),
-                None,
-                None,
+                span,
             )),
         },
-        _ => Err(Error::init(
-            "arr_sort() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_sort() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_sort_by.rs
+++ b/src/interpreter/stdlib/array/arr_sort_by.rs
@@ -4,41 +4,38 @@ use crate::{
 };
 
 pub fn std_arr_sort_by(
-    evaluator: &mut Evaluator,
+    eval: &mut Evaluator,
     array: Value,
     function: Value,
+    span: Span,
 ) -> Result<Value, Error> {
     let (items_type, mut items) = match array {
         Value::Values { items_type, items } => (items_type, items),
         other => {
-            return Err(Error::init(
+            return Err(eval.err(
                 format!(
                     "arr_sort_by() accepts only arrays, found {}",
                     other.type_name()
                 ),
-                None,
-                None,
+                span,
             ));
         }
     };
 
     if !matches!(function, Value::Function { .. }) {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "arr_sort_by() expected function or lambda, found {}",
                 function.type_name()
             ),
-            None,
-            None,
+            span,
         ));
     }
-
-    let span = Span { start: 0, end: 0 };
 
     for i in 1..items.len() {
         let mut j = i;
         while j > 0 {
-            let result = evaluator.call_value(
+            let result = eval.call_value(
                 function.clone(),
                 vec![items[j - 1].clone(), items[j].clone()],
                 span,
@@ -51,13 +48,12 @@ pub fn std_arr_sort_by(
                 }
                 Value::Integer(_) => break,
                 other => {
-                    return Err(Error::init(
+                    return Err(eval.err(
                         format!(
                             "arr_sort_by() comparator must return int (-1, 0, 1), found {}",
                             other.type_name()
                         ),
-                        None,
-                        None,
+                        span,
                     ));
                 }
             }

--- a/src/interpreter/stdlib/array/arr_sum.rs
+++ b/src/interpreter/stdlib/array/arr_sum.rs
@@ -1,10 +1,10 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_sum(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_sum(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items, items_type } => match items_type {
             TypeAnnotation::Int => {
@@ -33,16 +33,11 @@ pub fn std_arr_sum(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                     .sum::<f64>();
                 Ok(Value::Float(sum))
             }
-            _ => Err(Error::init(
+            _ => Err(eval.err(
                 "arr_sum() accepts only int or float arrays".to_string(),
-                None,
-                None,
+                span,
             )),
         },
-        _ => Err(Error::init(
-            "arr_sum() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_sum() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/array/arr_unique.rs
+++ b/src/interpreter/stdlib/array/arr_unique.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_arr_unique(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
+pub fn std_arr_unique(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
     match array {
         Value::Values { items_type, items } => {
             let mut seen = Vec::new();
@@ -17,10 +17,6 @@ pub fn std_arr_unique(_: &mut Evaluator, array: Value) -> Result<Value, Error> {
                 items: seen,
             })
         }
-        _ => Err(Error::init(
-            "arr_unique() accepts only arrays".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("arr_unique() accepts only arrays".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/fs/copy_file.rs
+++ b/src/interpreter/stdlib/fs/copy_file.rs
@@ -1,17 +1,24 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_copy_file(_: &mut Evaluator, src: String, dst: String) -> Result<Value, Error> {
+pub fn std_copy_file(
+    eval: &mut Evaluator,
+    src: String,
+    dst: String,
+    span: Span,
+) -> Result<Value, Error> {
     let bytes = std::fs::copy(&src, &dst).map_err(|e| {
-        Error::init(
+        eval.err(
             format!(
                 "copy_file(): failed to copy \"{}\" to \"{}\": {}",
                 src, dst, e
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Integer(bytes as i64))

--- a/src/interpreter/stdlib/fs/copy_file.rs
+++ b/src/interpreter/stdlib/fs/copy_file.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/copy_file.rs
+++ b/src/interpreter/stdlib/fs/copy_file.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_copy_file(

--- a/src/interpreter/stdlib/fs/file_modified.rs
+++ b/src/interpreter/stdlib/fs/file_modified.rs
@@ -1,38 +1,38 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_file_modified(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_file_modified(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     let metadata = std::fs::metadata(&path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("file_modified(): failed to read \"{}\": {}", path, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
 
     let modified = metadata.modified().map_err(|e| {
-        Error::init(
+        eval.err(
             format!(
                 "file_modified(): could not get modification time for \"{}\": {}",
                 path, e
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
 
     let secs = modified
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|e| {
-            Error::init(
+            eval.err(
                 format!(
                     "file_modified(): modification time before epoch for \"{}\": {}",
                     path, e
                 ),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         })?
         .as_secs();

--- a/src/interpreter/stdlib/fs/file_modified.rs
+++ b/src/interpreter/stdlib/fs/file_modified.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_file_modified(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/file_modified.rs
+++ b/src/interpreter/stdlib/fs/file_modified.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/file_size.rs
+++ b/src/interpreter/stdlib/fs/file_size.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_file_size(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/file_size.rs
+++ b/src/interpreter/stdlib/fs/file_size.rs
@@ -1,15 +1,17 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_file_size(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_file_size(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     let size = std::fs::metadata(&path)
         .map_err(|e| {
-            Error::init(
+            eval.err(
                 format!("file_size(): failed to read \"{}\": {}", path, e),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         })?
         .len();

--- a/src/interpreter/stdlib/fs/file_size.rs
+++ b/src/interpreter/stdlib/fs/file_size.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/list_dir.rs
+++ b/src/interpreter/stdlib/fs/list_dir.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/list_dir.rs
+++ b/src/interpreter/stdlib/fs/list_dir.rs
@@ -1,10 +1,7 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_list_dir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/list_dir.rs
+++ b/src/interpreter/stdlib/fs/list_dir.rs
@@ -1,16 +1,18 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_list_dir(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_list_dir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     let data = std::fs::read_dir(&path)
         .map_err(|e| {
-            Error::init(
+            eval.err(
                 format!("list_dir(): failed to read \"{}\": {}", path, e),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         })?
         .filter_map(|i| i.ok())

--- a/src/interpreter/stdlib/fs/mkdir.rs
+++ b/src/interpreter/stdlib/fs/mkdir.rs
@@ -1,14 +1,16 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_mkdir(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_mkdir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     std::fs::create_dir(&path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("mkdir(): failed to create \"{}\": {}", path, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/fs/mkdir.rs
+++ b/src/interpreter/stdlib/fs/mkdir.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/mkdir.rs
+++ b/src/interpreter/stdlib/fs/mkdir.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_mkdir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/mkdir_all.rs
+++ b/src/interpreter/stdlib/fs/mkdir_all.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_mkdir_all(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/mkdir_all.rs
+++ b/src/interpreter/stdlib/fs/mkdir_all.rs
@@ -1,14 +1,16 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_mkdir_all(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_mkdir_all(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     std::fs::create_dir_all(&path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("mkdir_all(): failed to create \"{}\": {}", path, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/fs/mkdir_all.rs
+++ b/src/interpreter/stdlib/fs/mkdir_all.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/move_file.rs
+++ b/src/interpreter/stdlib/fs/move_file.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_move_file(

--- a/src/interpreter/stdlib/fs/move_file.rs
+++ b/src/interpreter/stdlib/fs/move_file.rs
@@ -1,17 +1,24 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_move_file(_: &mut Evaluator, src: String, dst: String) -> Result<Value, Error> {
+pub fn std_move_file(
+    eval: &mut Evaluator,
+    src: String,
+    dst: String,
+    span: Span,
+) -> Result<Value, Error> {
     std::fs::rename(&src, &dst).map_err(|e| {
-        Error::init(
+        eval.err(
             format!(
                 "move_file(): failed to move \"{}\" to \"{}\": {}",
                 src, dst, e
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/fs/move_file.rs
+++ b/src/interpreter/stdlib/fs/move_file.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/rename_file.rs
+++ b/src/interpreter/stdlib/fs/rename_file.rs
@@ -1,9 +1,17 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_rename_file(_: &mut Evaluator, path: String, new_name: String) -> Result<Value, Error> {
+pub fn std_rename_file(
+    eval: &mut Evaluator,
+    path: String,
+    new_name: String,
+    span: Span,
+) -> Result<Value, Error> {
     let old_path = std::path::Path::new(&path);
     let new_path = match old_path.parent() {
         Some(parent) => parent.join(&new_name),
@@ -11,15 +19,14 @@ pub fn std_rename_file(_: &mut Evaluator, path: String, new_name: String) -> Res
     };
 
     std::fs::rename(old_path, &new_path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!(
                 "rename_file(): failed to rename \"{}\" to \"{}\": {}",
                 path,
                 new_path.to_string_lossy(),
                 e
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
 

--- a/src/interpreter/stdlib/fs/rename_file.rs
+++ b/src/interpreter/stdlib/fs/rename_file.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/rename_file.rs
+++ b/src/interpreter/stdlib/fs/rename_file.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_rename_file(

--- a/src/interpreter/stdlib/fs/rmdir.rs
+++ b/src/interpreter/stdlib/fs/rmdir.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_rmdir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/rmdir.rs
+++ b/src/interpreter/stdlib/fs/rmdir.rs
@@ -1,14 +1,16 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_rmdir(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_rmdir(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     std::fs::remove_dir(&path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("rmdir(): failed to delete \"{}\": {}", path, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/fs/rmdir.rs
+++ b/src/interpreter/stdlib/fs/rmdir.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/rmdir_all.rs
+++ b/src/interpreter/stdlib/fs/rmdir_all.rs
@@ -1,7 +1,7 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{
-        errors::{Error, ErrorReason, Reason},
+        errors::Error,
         span::Span,
     },
 };

--- a/src/interpreter/stdlib/fs/rmdir_all.rs
+++ b/src/interpreter/stdlib/fs/rmdir_all.rs
@@ -1,9 +1,6 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::Error,
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_rmdir_all(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/fs/rmdir_all.rs
+++ b/src/interpreter/stdlib/fs/rmdir_all.rs
@@ -1,14 +1,16 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_rmdir_all(_: &mut Evaluator, path: String) -> Result<Value, Error> {
+pub fn std_rmdir_all(eval: &mut Evaluator, path: String, span: Span) -> Result<Value, Error> {
     std::fs::remove_dir_all(&path).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("rmdir_all(): failed to delete \"{}\": {}", path, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/fs/temp_dir.rs
+++ b/src/interpreter/stdlib/fs/temp_dir.rs
@@ -2,10 +2,10 @@ use std::env::temp_dir;
 
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_temp_dir(_: &mut Evaluator, _: Vec<Value>) -> Result<Value, Error> {
+pub fn std_temp_dir(_: &mut Evaluator, _: Vec<Value>, _: Span) -> Result<Value, Error> {
     let temp = temp_dir().to_string_lossy().to_string();
     Ok(Value::String(temp))
 }

--- a/src/interpreter/stdlib/io/append_file.rs
+++ b/src/interpreter/stdlib/io/append_file.rs
@@ -1,28 +1,30 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{errors::Error, span::Span},
 };
-
 use std::{fs::OpenOptions, io::Write};
 
-pub fn std_append_file(_: &mut Evaluator, file: String, content: String) -> Result<Value, Error> {
+pub fn std_append_file(
+    eval: &mut Evaluator,
+    file: String,
+    content: String,
+    span: Span,
+) -> Result<Value, Error> {
     let mut file_data = OpenOptions::new()
         .append(true)
         .create(true)
         .open(&file)
         .map_err(|e| {
-            Error::init(
+            eval.err(
                 format!("append_file(): failed to open \"{}\": {}", file, e),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         })?;
 
     file_data.write_all(content.as_bytes()).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("append_file(): failed to append \"{}\": {}", file, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
 

--- a/src/interpreter/stdlib/io/delete_file.rs
+++ b/src/interpreter/stdlib/io/delete_file.rs
@@ -1,14 +1,13 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_delete_file(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+pub fn std_delete_file(eval: &mut Evaluator, file: String, span: Span) -> Result<Value, Error> {
     std::fs::remove_file(&file).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("delete_file(): failed to read \"{}\": {}", file, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/io/eprint.rs
+++ b/src/interpreter/stdlib/io/eprint.rs
@@ -1,7 +1,8 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
+use crate::utils::span::Span;
 
-pub fn std_eprint(_: &mut Evaluator, string: String) -> Result<Value, Error> {
-    Err(Error::init(string, None, None))
+pub fn std_eprint(eval: &mut Evaluator, string: String, span: Span) -> Result<Value, Error> {
+    Err(eval.err(string, span))
 }

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -1,15 +1,12 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::{Error, ErrorReason, Reason},
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 use std::io::{self, Write};
 
-fn input(prompt: Option<Value>, span: Span) -> Result<Value, Error> {
+fn input(prompt: Option<Value>, eval: &mut Evaluator, span: Span) -> Result<Value, Error> {
     match prompt {
-        None => read_line(span),
+        None => read_line(eval, span),
         Some(p) => {
             let prompt = match p {
                 Value::Integer(i) => i.to_string(),
@@ -22,108 +19,97 @@ fn input(prompt: Option<Value>, span: Span) -> Result<Value, Error> {
             };
             print!("{}", prompt);
             io::stdout().flush().ok();
-            read_line(span)
+            read_line(eval, span)
         }
     }
 }
 
-fn read_line(span: Span) -> Result<Value, Error> {
+fn read_line(eval: &mut Evaluator, span: Span) -> Result<Value, Error> {
     let mut input = String::new();
-    io::stdin().read_line(&mut input).map_err(|e| {
-        Error::at(
-            Reason::Runtime,
-            format!("read(): failed to read line: {}", e),
-            span,
-        )
-    })?;
+    io::stdin()
+        .read_line(&mut input)
+        .map_err(|e| eval.err(format!("read(): failed to read line: {}", e), span))?;
     Ok(Value::String(input.trim().to_string()))
 }
 
-pub fn std_read(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+pub fn std_read(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     match len {
-        0 => input(None, span),
-        1 => input(args.next(), span),
-        n => Err(Error::init(
+        0 => input(None, eval, span),
+        1 => input(args.next(), eval, span),
+        n => Err(eval.err(
             format!("read() expects 0 or 1 argument(s), got {}", n),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )),
     }
 }
 
 // reads input then parses to integer if possible otherwise error
-pub fn std_read_int(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+pub fn std_read_int(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     let value = match len {
-        0 => input(None, span),
-        1 => input(args.next(), span),
-        n => Err(Error::init(
+        0 => input(None, eval, span),
+        1 => input(args.next(), eval, span),
+        n => Err(eval.err(
             format!("read_int() expects 0 or 1 argument(s), got {}", n),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )),
     }?;
 
     match value {
         Value::String(s) => s.parse::<i64>().map(Value::Integer).map_err(|_| {
-            Error::init(
+            eval.err(
                 format!("read_int(): \"{}\" is not a valid integer", s),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         }),
         // those unreachable btw
         Value::Integer(i) => Ok(Value::Integer(i)),
         Value::Float(f) => Ok(Value::Integer(f as i64)),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "read_int(): found unsupported type from input, got {}",
                 other.type_name()
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )),
     }
 }
 
 // reads the input then parses the string into float if possible or error
-pub fn std_read_float(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+pub fn std_read_float(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     let value = match len {
-        0 => input(None, span),
-        1 => input(args.next(), span),
-        n => Err(Error::init(
+        0 => input(None, eval, span),
+        1 => input(args.next(), eval, span),
+        n => Err(eval.err(
             format!("read_float() expects 0 or 1 argument(s), got {}", n),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )),
     }?;
 
     match value {
         Value::String(s) => s.parse::<f64>().map(Value::Float).map_err(|_| {
-            Error::init(
+            eval.err(
                 format!("read_float(): \"{}\" is not a valid float", s),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         }),
         // those are un----reachable!! might change read_line() or remove them
         Value::Integer(i) => Ok(Value::Float(i as f64)),
         Value::Float(f) => Ok(Value::Float(f)),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "read_float(): found unsupported type from input, got {}",
                 other.type_name()
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/io/input.rs
+++ b/src/interpreter/stdlib/io/input.rs
@@ -1,12 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, ErrorReason, Reason},
+        span::Span,
+    },
 };
 use std::io::{self, Write};
 
-fn input(prompt: Option<Value>) -> Result<Value, Error> {
+fn input(prompt: Option<Value>, span: Span) -> Result<Value, Error> {
     match prompt {
-        None => read_line(),
+        None => read_line(span),
         Some(p) => {
             let prompt = match p {
                 Value::Integer(i) => i.to_string(),
@@ -19,30 +22,30 @@ fn input(prompt: Option<Value>) -> Result<Value, Error> {
             };
             print!("{}", prompt);
             io::stdout().flush().ok();
-            read_line()
+            read_line(span)
         }
     }
 }
 
-fn read_line() -> Result<Value, Error> {
+fn read_line(span: Span) -> Result<Value, Error> {
     let mut input = String::new();
     io::stdin().read_line(&mut input).map_err(|e| {
-        Error::init(
+        Error::at(
+            Reason::Runtime,
             format!("read(): failed to read line: {}", e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::String(input.trim().to_string()))
 }
 
-pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_read(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     match len {
-        0 => input(None),
-        1 => input(args.next()),
+        0 => input(None, span),
+        1 => input(args.next(), span),
         n => Err(Error::init(
             format!("read() expects 0 or 1 argument(s), got {}", n),
             None,
@@ -52,13 +55,13 @@ pub fn std_read(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
 }
 
 // reads input then parses to integer if possible otherwise error
-pub fn std_read_int(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_read_int(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     let value = match len {
-        0 => input(None),
-        1 => input(args.next()),
+        0 => input(None, span),
+        1 => input(args.next(), span),
         n => Err(Error::init(
             format!("read_int() expects 0 or 1 argument(s), got {}", n),
             None,
@@ -89,13 +92,13 @@ pub fn std_read_int(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error>
 }
 
 // reads the input then parses the string into float if possible or error
-pub fn std_read_float(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_read_float(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     let len = args.len();
     let mut args = args.into_iter();
 
     let value = match len {
-        0 => input(None),
-        1 => input(args.next()),
+        0 => input(None, span),
+        1 => input(args.next(), span),
         n => Err(Error::init(
             format!("read_float() expects 0 or 1 argument(s), got {}", n),
             None,

--- a/src/interpreter/stdlib/io/print.rs
+++ b/src/interpreter/stdlib/io/print.rs
@@ -1,8 +1,9 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
+use crate::utils::span::Span;
 
-pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     let text = args.iter().map(|s| s.to_string()).collect::<String>();
 
     if let Some(buffer) = &mut evaluator.output_buffer {

--- a/src/interpreter/stdlib/io/print.rs
+++ b/src/interpreter/stdlib/io/print.rs
@@ -3,10 +3,10 @@ use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
 use crate::utils::span::Span;
 
-pub fn std_print(evaluator: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
+pub fn std_print(eval: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     let text = args.iter().map(|s| s.to_string()).collect::<String>();
 
-    if let Some(buffer) = &mut evaluator.output_buffer {
+    if let Some(buffer) = &mut eval.output_buffer {
         buffer.push_str(&text);
     } else {
         print!("{}", text);

--- a/src/interpreter/stdlib/io/println.rs
+++ b/src/interpreter/stdlib/io/println.rs
@@ -3,10 +3,10 @@ use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
 use crate::utils::span::Span;
 
-pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
+pub fn std_println(eval: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     let text = args.iter().map(|s| s.to_string()).collect::<String>();
 
-    if let Some(buffer) = &mut evaluator.output_buffer {
+    if let Some(buffer) = &mut eval.output_buffer {
         buffer.push_str(&text);
         buffer.push('\n');
     } else {

--- a/src/interpreter/stdlib/io/println.rs
+++ b/src/interpreter/stdlib/io/println.rs
@@ -1,8 +1,9 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
 use crate::utils::errors::Error;
+use crate::utils::span::Span;
 
-pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_println(evaluator: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     let text = args.iter().map(|s| s.to_string()).collect::<String>();
 
     if let Some(buffer) = &mut evaluator.output_buffer {

--- a/src/interpreter/stdlib/io/read_file.rs
+++ b/src/interpreter/stdlib/io/read_file.rs
@@ -1,14 +1,13 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_read_file(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+pub fn std_read_file(eval: &mut Evaluator, file: String, span: Span) -> Result<Value, Error> {
     let data = std::fs::read_to_string(&file).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("read_file(): failed to read \"{}\": {}", file, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::String(data))

--- a/src/interpreter/stdlib/io/read_lines.rs
+++ b/src/interpreter/stdlib/io/read_lines.rs
@@ -1,16 +1,15 @@
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_read_lines(_: &mut Evaluator, file: String) -> Result<Value, Error> {
+pub fn std_read_lines(eval: &mut Evaluator, file: String, span: Span) -> Result<Value, Error> {
     let data = std::fs::read_to_string(&file)
         .map_err(|e| {
-            Error::init(
+            eval.err(
                 format!("read_lines(): failed to read \"{}\": {}", file, e),
-                None,
-                Some(ErrorReason::init(Reason::Runtime, None)),
+                span,
             )
         })?
         .lines()

--- a/src/interpreter/stdlib/io/write_file.rs
+++ b/src/interpreter/stdlib/io/write_file.rs
@@ -1,14 +1,18 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_write_file(_: &mut Evaluator, file: String, content: String) -> Result<Value, Error> {
+pub fn std_write_file(
+    eval: &mut Evaluator,
+    file: String,
+    content: String,
+    span: Span,
+) -> Result<Value, Error> {
     std::fs::write(&file, content).map_err(|e| {
-        Error::init(
+        eval.err(
             format!("write_file(): failed to write \"{}\": {}", file, e),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         )
     })?;
     Ok(Value::Null)

--- a/src/interpreter/stdlib/len.rs
+++ b/src/interpreter/stdlib/len.rs
@@ -1,16 +1,18 @@
-use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{errors::Error, span::Span},
+};
 
-pub fn std_len(_: &mut Evaluator, v: Value) -> Result<i64, Error> {
+pub fn std_len(eval: &mut Evaluator, v: Value, span: Span) -> Result<i64, Error> {
     match v {
         Value::Values { items, .. } => Ok(items.len() as i64),
         Value::String(s) => Ok(s.len() as i64),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "len() expects an array or string, got {}",
                 other.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/abs.rs
+++ b/src/interpreter/stdlib/math/abs.rs
@@ -1,17 +1,16 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
 /// returns the absolute value of number
-pub fn std_abs(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_abs(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Integer(i.abs())),
         Value::Float(f) => Ok(Value::Float(f.abs())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("abs() expects a number, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/ceil.rs
+++ b/src/interpreter/stdlib/math/ceil.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_ceil(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_ceil(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Integer(i)),
         Value::Float(f) => Ok(Value::Float(f.ceil())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("ceil() expects a number, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/clamp.rs
+++ b/src/interpreter/stdlib/math/clamp.rs
@@ -1,9 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Result<Value, Error> {
+pub fn std_clamp(
+    eval: &mut Evaluator,
+    value: Value,
+    min: Value,
+    max: Value,
+    span: Span,
+) -> Result<Value, Error> {
     match (value, min, max) {
         (Value::Integer(value), Value::Integer(low), Value::Integer(high)) => {
             Ok(Value::Integer(value.clamp(low, high)))
@@ -11,15 +17,14 @@ pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Res
         (Value::Float(value), Value::Float(low), Value::Float(high)) => {
             Ok(Value::Float(value.clamp(low, high)))
         }
-        (value, min, max) => Err(Error::init(
+        (value, min, max) => Err(eval.err(
             format!(
                 "clamp() expects a number, got ({}, {}, {})",
                 value.type_name(),
                 min.type_name(),
                 max.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/floor.rs
+++ b/src/interpreter/stdlib/math/floor.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_floor(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_floor(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Integer(i)),
         Value::Float(f) => Ok(Value::Float(f.floor())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("floor() expects a number, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/log.rs
+++ b/src/interpreter/stdlib/math/log.rs
@@ -1,23 +1,22 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_log(_: &mut Evaluator, a: Value, base: Value) -> Result<Value, Error> {
+pub fn std_log(eval: &mut Evaluator, a: Value, base: Value, span: Span) -> Result<Value, Error> {
     match (a, base) {
         (Value::Integer(i), Value::Integer(base)) => Ok(Value::Float((i as f64).log(base as f64))),
         (Value::Float(f), Value::Float(base)) => Ok(Value::Float(f.log(base))),
         (Value::Float(f), Value::Integer(base)) => Ok(Value::Float(f.log(base as f64))),
         (Value::Integer(i), Value::Float(base)) => Ok(Value::Float((i as f64).log(base))),
 
-        (a, base) => Err(Error::init(
+        (a, base) => Err(eval.err(
             format!(
                 "log() expects a number, got ({}, {})",
                 a.type_name(),
                 base.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/log10.rs
+++ b/src/interpreter/stdlib/math/log10.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_log10(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_log10(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Float((i as f64).log10())),
         Value::Float(f) => Ok(Value::Float(f.log10())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("log10() expects a number, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/log2.rs
+++ b/src/interpreter/stdlib/math/log2.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_log2(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_log2(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Float((i as f64).log2())),
         Value::Float(f) => Ok(Value::Float(f.log2())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("log2() expects a number, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/max.rs
+++ b/src/interpreter/stdlib/math/max.rs
@@ -1,20 +1,19 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_max(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
+pub fn std_max(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.max(b))),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.max(b))),
-        (a, b) => Err(Error::init(
+        (a, b) => Err(eval.err(
             format!(
                 "max() expects a number, got ({}, {})",
                 a.type_name(),
                 b.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/min.rs
+++ b/src/interpreter/stdlib/math/min.rs
@@ -1,20 +1,19 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_min(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
+pub fn std_min(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.min(b))),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.min(b))),
-        (a, b) => Err(Error::init(
+        (a, b) => Err(eval.err(
             format!(
                 "min() expects a number, got ({}, {})",
                 a.type_name(),
                 b.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/modulo.rs
+++ b/src/interpreter/stdlib/math/modulo.rs
@@ -1,19 +1,21 @@
-use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{errors::Error, span::Span},
+};
 
-pub fn std_mod(_: &mut Evaluator, a: Value, b: Value) -> Result<Value, Error> {
+pub fn std_mod(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
     match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a % b)),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a % b)),
         (Value::Integer(a), Value::Float(b)) => Ok(Value::Float(a as f64 % b)),
         (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a % b as f64)),
-        (a, b) => Err(Error::init(
+        (a, b) => Err(eval.err(
             format!(
                 "mod() expects a number, got ({}, {})",
                 a.type_name(),
                 b.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/power.rs
+++ b/src/interpreter/stdlib/math/power.rs
@@ -1,15 +1,11 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::{
-        errors::{Error, Reason},
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_pow(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+pub fn std_pow(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     if args.len() != 2 {
-        return Err(Error::at(
-            Reason::Runtime,
+        return Err(eval.err(
             format!("pow() expects 2 arguments, got {}", args.len()),
             span,
         ));
@@ -26,10 +22,6 @@ pub fn std_pow(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value,
         (Value::Integer(a), Value::Float(b)) => Ok(Value::Float((a as f64).powf(b))),
         (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.powf(b))),
         (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a.powi(b as i32))),
-        _ => Err(Error::init(
-            "pow() expects numeric arguments".to_string(),
-            None,
-            None,
-        )),
+        _ => Err(eval.err("pow() expects numeric arguments".to_string(), span)),
     }
 }

--- a/src/interpreter/stdlib/math/power.rs
+++ b/src/interpreter/stdlib/math/power.rs
@@ -1,11 +1,17 @@
-use crate::{interpreter::evaluator::Evaluator, interpreter::values::Value, utils::errors::Error};
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{
+        errors::{Error, Reason},
+        span::Span,
+    },
+};
 
-pub fn std_pow(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_pow(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     if args.len() != 2 {
-        return Err(Error::init(
+        return Err(Error::at(
+            Reason::Runtime,
             format!("pow() expects 2 arguments, got {}", args.len()),
-            None,
-            None,
+            span,
         ));
     }
     let mut iter = args.into_iter();

--- a/src/interpreter/stdlib/math/round.rs
+++ b/src/interpreter/stdlib/math/round.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_round(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_round(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Integer(i)),
         Value::Float(f) => Ok(Value::Float(f.round())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("round() expects a number, got {}", other.type_name(),),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/math/sqrt.rs
+++ b/src/interpreter/stdlib/math/sqrt.rs
@@ -1,16 +1,15 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_sqrt(_: &mut Evaluator, a: Value) -> Result<Value, Error> {
+pub fn std_sqrt(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
     match a {
         Value::Integer(i) => Ok(Value::Float((i as f64).sqrt())),
         Value::Float(f) => Ok(Value::Float(f.sqrt())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("round() expects a number, got {}", other.type_name(),),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_exists.rs
+++ b/src/interpreter/stdlib/path/path_exists.rs
@@ -1,15 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_exists(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_exists(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).exists())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_exists() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_extension.rs
+++ b/src/interpreter/stdlib/path/path_extension.rs
@@ -1,24 +1,23 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_extension(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_extension(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
             std::path::Path::new(&s)
                 .extension()
-                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .ok_or_else(|| eval.err("file was not found".to_string(), span))?
                 .to_string_lossy()
                 .to_string(),
         )),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "path_extension() expects a string, got {}",
                 other.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_filename.rs
+++ b/src/interpreter/stdlib/path/path_filename.rs
@@ -1,24 +1,23 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_filename(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_filename(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
             std::path::Path::new(&s)
                 .file_name()
-                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .ok_or_else(|| eval.err("file was not found".to_string(), span))?
                 .to_string_lossy()
                 .to_string(),
         )),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "path_filename() expects a string, got {}",
                 other.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_is_dir.rs
+++ b/src/interpreter/stdlib/path/path_is_dir.rs
@@ -1,15 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_is_dir(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_is_dir(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).is_dir())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_is_dir() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_is_file.rs
+++ b/src/interpreter/stdlib/path/path_is_file.rs
@@ -1,15 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_is_file(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_is_file(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::Bool(std::path::Path::new(&s).is_file())),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_is_file() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_join.rs
+++ b/src/interpreter/stdlib/path/path_join.rs
@@ -1,9 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_join(_: &mut Evaluator, path: Value, target: String) -> Result<Value, Error> {
+pub fn std_path_join(
+    eval: &mut Evaluator,
+    path: Value,
+    target: String,
+    span: Span,
+) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
             std::path::PathBuf::from(&s)
@@ -11,10 +16,9 @@ pub fn std_path_join(_: &mut Evaluator, path: Value, target: String) -> Result<V
                 .to_string_lossy()
                 .to_string(),
         )),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_join() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_parent.rs
+++ b/src/interpreter/stdlib/path/path_parent.rs
@@ -1,21 +1,20 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_parent(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_parent(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
             std::path::Path::new(&s)
                 .parent()
-                .ok_or_else(|| Error::init("path was not found".to_string(), None, None))?
+                .ok_or_else(|| eval.err("path was not found".to_string(), span))?
                 .to_string_lossy()
                 .to_string(),
         )),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_parent() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_pop.rs
+++ b/src/interpreter/stdlib/path/path_pop.rs
@@ -1,19 +1,18 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_pop(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_pop(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => {
             let mut buf = std::path::PathBuf::from(&s);
             buf.pop();
             Ok(Value::String(buf.to_string_lossy().to_string()))
         }
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_push() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_push.rs
+++ b/src/interpreter/stdlib/path/path_push.rs
@@ -1,19 +1,23 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_push(_: &mut Evaluator, path: Value, target: String) -> Result<Value, Error> {
+pub fn std_path_push(
+    eval: &mut Evaluator,
+    path: Value,
+    target: String,
+    span: Span,
+) -> Result<Value, Error> {
     match path {
         Value::String(s) => {
             let mut buf = std::path::PathBuf::from(&s);
             buf.push(&target);
             Ok(Value::String(buf.to_string_lossy().to_string()))
         }
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_push() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_set_extension.rs
+++ b/src/interpreter/stdlib/path/path_set_extension.rs
@@ -1,12 +1,13 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_path_set_extension(
-    _: &mut Evaluator,
+    eval: &mut Evaluator,
     path: Value,
     target: String,
+    span: Span,
 ) -> Result<Value, Error> {
     match path {
         Value::String(s) => {
@@ -14,13 +15,12 @@ pub fn std_path_set_extension(
             buf.set_extension(&target);
             Ok(Value::String(buf.to_string_lossy().to_string()))
         }
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!(
                 "path_set_extension() expects a string, got {}",
                 other.type_name()
             ),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/path/path_stem.rs
+++ b/src/interpreter/stdlib/path/path_stem.rs
@@ -1,21 +1,20 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_path_stem(_: &mut Evaluator, path: Value) -> Result<Value, Error> {
+pub fn std_path_stem(eval: &mut Evaluator, path: Value, span: Span) -> Result<Value, Error> {
     match path {
         Value::String(s) => Ok(Value::String(
             std::path::Path::new(&s)
                 .file_stem()
-                .ok_or_else(|| Error::init("file was not found".to_string(), None, None))?
+                .ok_or_else(|| eval.err("file was not found".to_string(), span))?
                 .to_string_lossy()
                 .to_string(),
         )),
-        other => Err(Error::init(
+        other => Err(eval.err(
             format!("path_stem() expects a string, got {}", other.type_name()),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/string/char_at.rs
+++ b/src/interpreter/stdlib/string/char_at.rs
@@ -1,29 +1,21 @@
 use crate::{
     interpreter::evaluator::Evaluator,
-    utils::{
-        errors::{Error, Reason},
-        span::Span,
-    },
+    utils::{errors::Error, span::Span},
 };
 
 pub fn std_char_at(
-    _: &mut Evaluator,
+    eval: &mut Evaluator,
     string: String,
     index: i64,
     span: Span,
 ) -> Result<char, Error> {
     if index < 0 {
-        return Err(Error::at(
-            Reason::Runtime,
-            format!("index cannot be negative: {}", index),
-            span,
-        ));
+        return Err(eval.err(format!("index cannot be negative: {}", index), span));
     }
     let mut chars = string.chars();
     let chars_count = chars.clone().count();
     if index as usize >= chars_count {
-        Err(Error::at(
-            Reason::Runtime,
+        Err(eval.err(
             format!(
                 "index out of bounds string length is {} , used {}",
                 chars_count, index

--- a/src/interpreter/stdlib/string/char_at.rs
+++ b/src/interpreter/stdlib/string/char_at.rs
@@ -1,26 +1,34 @@
 use crate::{
     interpreter::evaluator::Evaluator,
-    utils::errors::{Error, ErrorReason, Reason},
+    utils::{
+        errors::{Error, Reason},
+        span::Span,
+    },
 };
 
-pub fn std_char_at(_: &mut Evaluator, string: String, index: i64) -> Result<char, Error> {
+pub fn std_char_at(
+    _: &mut Evaluator,
+    string: String,
+    index: i64,
+    span: Span,
+) -> Result<char, Error> {
     if index < 0 {
-        return Err(Error::init(
+        return Err(Error::at(
+            Reason::Runtime,
             format!("index cannot be negative: {}", index),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         ));
     }
     let mut chars = string.chars();
     let chars_count = chars.clone().count();
     if index as usize >= chars_count {
-        Err(Error::init(
+        Err(Error::at(
+            Reason::Runtime,
             format!(
                 "index out of bounds string length is {} , used {}",
                 chars_count, index
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         ))
     } else {
         Ok(chars.nth(index as usize).unwrap())

--- a/src/interpreter/stdlib/string/concat.rs
+++ b/src/interpreter/stdlib/string/concat.rs
@@ -5,6 +5,6 @@ use crate::{
 
 pub fn std_concat(_: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     Ok(Value::String(
-        args.iter().map(|a| format!("{}", a)).collect::<String>(),
+        args.iter().map(|a| a.to_string()).collect::<String>(),
     ))
 }

--- a/src/interpreter/stdlib/string/concat.rs
+++ b/src/interpreter/stdlib/string/concat.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_concat(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_concat(_: &mut Evaluator, args: Vec<Value>, _: Span) -> Result<Value, Error> {
     Ok(Value::String(
         args.iter().map(|a| format!("{}", a)).collect::<String>(),
     ))

--- a/src/interpreter/stdlib/string/format.rs
+++ b/src/interpreter/stdlib/string/format.rs
@@ -1,14 +1,15 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
-use crate::utils::errors::{Error, ErrorReason, Reason};
+use crate::utils::errors::{Error, Reason};
+use crate::utils::span::Span;
 
-pub fn std_format(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
+pub fn std_format(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     // checks for incorrect usage
     if args.is_empty() {
-        return Err(Error::init(
+        return Err(Error::at(
+            Reason::Runtime,
             "expected arguments".to_string(),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         ));
     }
 
@@ -56,26 +57,26 @@ pub fn std_format(_: &mut Evaluator, args: Vec<Value>) -> Result<Value, Error> {
 
     // check for missing value that wasnt replaced
     if missing > 0 {
-        return Err(Error::init(
+        return Err(Error::at(
+            Reason::Runtime,
             format!(
                 "format() has {} placeholder(s) with no matching argument",
                 missing
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         ));
     }
 
     // check for additional values that is not used
     if used < args.len() - 1 {
-        return Err(Error::init(
+        return Err(Error::at(
+            Reason::Runtime,
             format!(
                 "format() received {} argument(s) but only {} placeholder(s) were used",
                 args.len() - 1,
                 used
             ),
-            None,
-            Some(ErrorReason::init(Reason::Runtime, None)),
+            span,
         ));
     }
 

--- a/src/interpreter/stdlib/string/format.rs
+++ b/src/interpreter/stdlib/string/format.rs
@@ -1,6 +1,6 @@
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
-use crate::utils::errors::{Error, Reason};
+use crate::utils::errors::Error;
 use crate::utils::span::Span;
 
 pub fn std_format(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
@@ -53,8 +53,7 @@ pub fn std_format(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<
 
     // check for missing value that wasnt replaced
     if missing > 0 {
-        return Err(Error::at(
-            Reason::Runtime,
+        return Err(eval.err(
             format!(
                 "format() has {} placeholder(s) with no matching argument",
                 missing
@@ -65,8 +64,7 @@ pub fn std_format(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<
 
     // check for additional values that is not used
     if used < args.len() - 1 {
-        return Err(Error::at(
-            Reason::Runtime,
+        return Err(eval.err(
             format!(
                 "format() received {} argument(s) but only {} placeholder(s) were used",
                 args.len() - 1,

--- a/src/interpreter/stdlib/string/format.rs
+++ b/src/interpreter/stdlib/string/format.rs
@@ -3,14 +3,10 @@ use crate::interpreter::values::Value;
 use crate::utils::errors::{Error, Reason};
 use crate::utils::span::Span;
 
-pub fn std_format(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+pub fn std_format(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     // checks for incorrect usage
     if args.is_empty() {
-        return Err(Error::at(
-            Reason::Runtime,
-            "expected arguments".to_string(),
-            span,
-        ));
+        return Err(eval.err("expected arguments".to_string(), span));
     }
 
     // making mutable empty string for the transformation

--- a/src/interpreter/stdlib/string/join.rs
+++ b/src/interpreter/stdlib/string/join.rs
@@ -1,9 +1,14 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_join(_: &mut Evaluator, strings_array: Value, delim: String) -> Result<Value, Error> {
+pub fn std_join(
+    eval: &mut Evaluator,
+    strings_array: Value,
+    delim: String,
+    span: Span,
+) -> Result<Value, Error> {
     match strings_array {
         Value::Values { items: array, .. } => {
             let mut strings: Vec<String> = vec![];
@@ -16,10 +21,9 @@ pub fn std_join(_: &mut Evaluator, strings_array: Value, delim: String) -> Resul
                     Value::Char(c) => strings.push(c.to_string()),
                     Value::Null => strings.push("null".to_string()),
                     Value::Function { .. } => {
-                        return Err(Error::init(
+                        return Err(eval.err(
                             "functions/lambdas/enclosures are not supported via join()".to_string(),
-                            None,
-                            None,
+                            span,
                         ));
                     }
                     _ => {}
@@ -27,10 +31,9 @@ pub fn std_join(_: &mut Evaluator, strings_array: Value, delim: String) -> Resul
             }
             Ok(Value::String(strings.join(&delim)))
         }
-        _ => Err(Error::init(
+        _ => Err(eval.err(
             "join() expects an array as first argument".to_string(),
-            None,
-            None,
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/string/slice.rs
+++ b/src/interpreter/stdlib/string/slice.rs
@@ -1,16 +1,24 @@
-use crate::{interpreter::evaluator::Evaluator, utils::errors::Error};
+use crate::{
+    interpreter::evaluator::Evaluator,
+    utils::{errors::Error, span::Span},
+};
 
-pub fn std_slice(_: &mut Evaluator, string: String, start: i64, end: i64) -> Result<String, Error> {
+pub fn std_slice(
+    eval: &mut Evaluator,
+    string: String,
+    start: i64,
+    end: i64,
+    span: Span,
+) -> Result<String, Error> {
     let chars = string.chars();
     let chars_count = chars.clone().count();
     if start as usize >= chars_count || end as usize >= chars_count {
-        return Err(Error::init(
+        return Err(eval.err(
             format!(
                 "index out of bounds string legth: {}, found start: {} and end: {}",
                 chars_count, start, end
             ),
-            None,
-            None,
+            span,
         ));
     }
 

--- a/src/interpreter/stdlib/types/to_bin.rs
+++ b/src/interpreter/stdlib/types/to_bin.rs
@@ -1,16 +1,11 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_bin(_: &mut Evaluator, value: Value) -> Result<String, Error> {
+pub fn std_to_bin(eval: &mut Evaluator, value: Value, span: Span) -> Result<String, Error> {
     match value {
         Value::Integer(v) => Ok(format!("{:b}", v)),
-        Value::Float(_) => Err(Error::init(
-            "cannot parse \"float\" as binary".to_string(),
-            None,
-            None,
-        )),
         Value::Bool(v) => {
             if v {
                 Ok("1".to_string())
@@ -20,20 +15,10 @@ pub fn std_to_bin(_: &mut Evaluator, value: Value) -> Result<String, Error> {
         }
         Value::Char(v) => Ok(format!("{:b}", v as u32)),
         Value::String(s) => Ok(s.bytes().map(|b| format!("{:b}", b)).collect::<String>()),
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as binary".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as binary".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as binary".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as binary", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_bool.rs
+++ b/src/interpreter/stdlib/types/to_bool.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_bool(_: &mut Evaluator, value: Value) -> Result<bool, Error> {
+pub fn std_to_bool(eval: &mut Evaluator, value: Value, span: Span) -> Result<bool, Error> {
     match value {
         Value::Bool(b) => Ok(b),
         Value::Integer(i) => Ok(i != 0),
@@ -14,20 +14,10 @@ pub fn std_to_bool(_: &mut Evaluator, value: Value) -> Result<bool, Error> {
             "false" | "0" | "" => Ok(false),
             _ => Ok(true),
         },
-        Value::Char(_) => Err(Error::init(
-            "cannot parse \"char\" as bool".to_string(),
-            None,
-            None,
-        )),
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as bool".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as bool".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_char.rs
+++ b/src/interpreter/stdlib/types/to_char.rs
@@ -2,56 +2,25 @@ use std::char;
 
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_char(_: &mut Evaluator, value: Value) -> Result<char, Error> {
+pub fn std_to_char(eval: &mut Evaluator, value: Value, span: Span) -> Result<char, Error> {
     match value {
         Value::Char(c) => Ok(c),
-        Value::Integer(i) => char::from_u32(i as u32).ok_or_else(|| {
-            Error::init(
-                format!("{} is not a valid unicode codepoint", i),
-                None,
-                None,
-            )
-        }),
+        Value::Integer(i) => char::from_u32(i as u32)
+            .ok_or_else(|| eval.err(format!("{} is not a valid unicode codepoint", i), span)),
         Value::String(s) => {
             let mut chars = s.chars();
             match (chars.next(), chars.next()) {
                 (Some(c), None) => Ok(c),
-                _ => Err(Error::init(
-                    "string must be exactly one character".to_string(),
-                    None,
-                    None,
-                )),
+                _ => Err(eval.err("string must be exactly one character".to_string(), span)),
             }
         }
 
-        Value::Float(_) => Err(Error::init(
-            "cannot parse \"float\" as character".to_string(),
-            None,
-            None,
-        )),
-        Value::Bool(_) => Err(Error::init(
-            "cannot parse \"bool\" as character".to_string(),
-            None,
-            None,
-        )),
-
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as character".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as character".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as character".to_string(),
-            None,
-            None,
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_float.rs
+++ b/src/interpreter/stdlib/types/to_float.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_float(_: &mut Evaluator, value: Value) -> Result<f64, Error> {
+pub fn std_to_float(eval: &mut Evaluator, value: Value, span: Span) -> Result<f64, Error> {
     match value {
         Value::Float(f) => Ok(f),
         Value::Integer(i) => Ok(i as f64),
@@ -11,27 +11,11 @@ pub fn std_to_float(_: &mut Evaluator, value: Value) -> Result<f64, Error> {
         Value::String(s) => s
             .trim()
             .parse::<f64>()
-            .map_err(|_| Error::init(format!("cannot parse \"{}\" as float", s), None, None)),
-        Value::Char(_) => Err(Error::init(
-            "cannot parse \"char\" as float".to_string(),
-            None,
-            None,
-        )),
+            .map_err(|_| eval.err(format!("cannot parse \"{}\" as float", s), span)),
 
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as float".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as float".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as float".to_string(),
-            None,
-            None,
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_hex.rs
+++ b/src/interpreter/stdlib/types/to_hex.rs
@@ -1,37 +1,17 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_hex(_: &mut Evaluator, value: Value) -> Result<String, Error> {
+pub fn std_to_hex(eval: &mut Evaluator, value: Value, span: Span) -> Result<String, Error> {
     match value {
         Value::Integer(v) => Ok(format!("{:x}", v)),
-        Value::Float(_) => Err(Error::init(
-            "cannot parse \"float\" as hexadecimal".to_string(),
-            None,
-            None,
-        )),
-        Value::Bool(_) => Err(Error::init(
-            "cannot parse \"bool\" as hexadecimal".to_string(),
-            None,
-            None,
-        )),
         Value::Char(v) => Ok(format!("{:x}", v as u32)),
         Value::String(s) => Ok(s.bytes().map(|b| format!("{:x}", b)).collect::<String>()),
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as hexadecimal".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as hexadecimal".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as hexadecimal".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_int.rs
+++ b/src/interpreter/stdlib/types/to_int.rs
@@ -1,9 +1,9 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_int(_: &mut Evaluator, value: Value) -> Result<i64, Error> {
+pub fn std_to_int(eval: &mut Evaluator, value: Value, span: Span) -> Result<i64, Error> {
     match value {
         Value::Integer(v) => Ok(v),
         Value::Float(v) => Ok(v as i64),
@@ -13,26 +13,16 @@ pub fn std_to_int(_: &mut Evaluator, value: Value) -> Result<i64, Error> {
             let s = s.trim();
             if s.starts_with("0x") || s.starts_with("0X") {
                 i64::from_str_radix(&s[2..], 16)
-                    .map_err(|_| Error::init(format!("cannot parse \"{}\" as int", s), None, None))
+                    .map_err(|_| eval.err(format!("cannot parse \"{}\" as int", s), span))
             } else {
                 s.parse::<i64>()
-                    .map_err(|_| Error::init(format!("cannot parse \"{}\" as int", s), None, None))
+                    .map_err(|_| eval.err(format!("cannot parse \"{}\" as int", s), span))
             }
         }
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as int".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as int".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as int".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_oct.rs
+++ b/src/interpreter/stdlib/types/to_oct.rs
@@ -1,37 +1,17 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_oct(_: &mut Evaluator, value: Value) -> Result<String, Error> {
+pub fn std_to_oct(eval: &mut Evaluator, value: Value, span: Span) -> Result<String, Error> {
     match value {
         Value::Integer(v) => Ok(format!("{:o}", v)),
-        Value::Float(_) => Err(Error::init(
-            "cannot parse \"float\" as octal".to_string(),
-            None,
-            None,
-        )),
-        Value::Bool(_) => Err(Error::init(
-            "cannot parse \"bool\" as octal".to_string(),
-            None,
-            None,
-        )),
         Value::Char(v) => Ok(format!("{:o}", v as u32)),
         Value::String(s) => Ok(s.bytes().map(|b| format!("{:o}", b)).collect::<String>()),
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as octal".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as octal".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as octal".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/stdlib/types/to_string.rs
+++ b/src/interpreter/stdlib/types/to_string.rs
@@ -1,29 +1,19 @@
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
-    utils::errors::Error,
+    utils::{errors::Error, span::Span},
 };
 
-pub fn std_to_string(_: &mut Evaluator, value: Value) -> Result<String, Error> {
+pub fn std_to_string(eval: &mut Evaluator, value: Value, span: Span) -> Result<String, Error> {
     match value {
         Value::Integer(v) => Ok(format!("{}", v)),
         Value::Float(v) => Ok(format!("{}", v)),
         Value::Bool(v) => Ok(format!("{}", v)),
         Value::Char(v) => Ok(v.to_string()),
         Value::String(s) => Ok(s),
-        Value::Function { .. } => Err(Error::init(
-            "cannot parse \"function\" as string".to_string(),
-            None,
-            None,
-        )),
-        Value::Values { .. } => Err(Error::init(
-            "cannot parse \"array\" as string".to_string(),
-            None,
-            None,
-        )),
-        Value::Null => Err(Error::init(
-            "cannot parse \"null\" as string".to_string(),
-            None,
-            None,
+
+        other => Err(eval.err(
+            format!("cannot parse \"{}\" as bool", other.type_name()),
+            span,
         )),
     }
 }

--- a/src/interpreter/utils/binary.rs
+++ b/src/interpreter/utils/binary.rs
@@ -29,100 +29,105 @@ impl Evaluator {
         operator: &TokenType,
         span: Span,
     ) -> Result<Value, Error> {
-        let v =
-            match operator {
-                TokenType::Plus => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a + b),
-                    (Value::Float(a), Value::Float(b)) => Value::Float(a + b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary("+", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::Minus => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a - b),
-                    (Value::Float(a), Value::Float(b)) => Value::Float(a - b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary("-", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::Star => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a * b),
-                    (Value::Float(a), Value::Float(b)) => Value::Float(a * b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary("*", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::Slash => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a / b),
-                    (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary("/", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::Less => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a < b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a < b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary("<", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::Greater => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a > b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a > b),
-                    _ => {
-                        return Err(self
-                            .type_mismatch_binary(">", &left, left_span, &right, right_span, span));
-                    }
-                },
-                TokenType::LessEqual => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a <= b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a <= b),
-                    _ => {
-                        return Err(self.type_mismatch_binary(
-                            "<=", &left, left_span, &right, right_span, span,
-                        ));
-                    }
-                },
-                TokenType::GreaterEqual => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a >= b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a >= b),
-                    _ => {
-                        return Err(self.type_mismatch_binary(
-                            ">=", &left, left_span, &right, right_span, span,
-                        ));
-                    }
-                },
-                TokenType::BangEqual => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a != b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a != b),
-                    (Value::String(a), Value::String(b)) => Value::Bool(a != b),
-                    (Value::Char(a), Value::Char(b)) => Value::Bool(a != b),
-                    (Value::Bool(a), Value::Bool(b)) => Value::Bool(a != b),
-                    _ => {
-                        return Err(self.type_mismatch_binary(
-                            "!=", &left, left_span, &right, right_span, span,
-                        ));
-                    }
-                },
-                TokenType::Compare => match (&left, &right) {
-                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a == b),
-                    (Value::Float(a), Value::Float(b)) => Value::Bool(a == b),
-                    (Value::String(a), Value::String(b)) => Value::Bool(a == b),
-                    (Value::Char(a), Value::Char(b)) => Value::Bool(a == b),
-                    (Value::Bool(a), Value::Bool(b)) => Value::Bool(a == b),
-                    _ => {
-                        return Err(self.type_mismatch_binary(
-                            "==", &left, left_span, &right, right_span, span,
-                        ));
-                    }
-                },
-                _ => return Err(self.err("unknown binary operator", span)),
-            };
+        let v = match operator {
+            TokenType::Plus => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a + b),
+                (Value::Float(a), Value::Float(b)) => Value::Float(a + b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("+", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Minus => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a - b),
+                (Value::Float(a), Value::Float(b)) => Value::Float(a - b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("-", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Star => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a * b),
+                (Value::Float(a), Value::Float(b)) => Value::Float(a * b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("*", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Slash => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a / b),
+                (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("/", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Less => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a < b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a < b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("<", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Greater => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a > b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a > b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary(">", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::LessEqual => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a <= b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a <= b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("<=", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::GreaterEqual => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a >= b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a >= b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary(">=", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::BangEqual => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a != b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a != b),
+                (Value::String(a), Value::String(b)) => Value::Bool(a != b),
+                (Value::Char(a), Value::Char(b)) => Value::Bool(a != b),
+                (Value::Bool(a), Value::Bool(b)) => Value::Bool(a != b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("!=", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            TokenType::Compare => match (&left, &right) {
+                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a == b),
+                (Value::Float(a), Value::Float(b)) => Value::Bool(a == b),
+                (Value::String(a), Value::String(b)) => Value::Bool(a == b),
+                (Value::Char(a), Value::Char(b)) => Value::Bool(a == b),
+                (Value::Bool(a), Value::Bool(b)) => Value::Bool(a == b),
+                _ => {
+                    return Err(
+                        self.type_mismatch_binary("==", &left, left_span, &right, right_span, span)
+                    );
+                }
+            },
+            _ => return Err(self.err("unknown binary operator", span)),
+        };
         Ok(v)
     }
 }

--- a/src/interpreter/utils/binary.rs
+++ b/src/interpreter/utils/binary.rs
@@ -29,105 +29,100 @@ impl Evaluator {
         operator: &TokenType,
         span: Span,
     ) -> Result<Value, Error> {
-        let v = match operator {
-            TokenType::Plus => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a + b),
-                (Value::Float(a), Value::Float(b)) => Value::Float(a + b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "+", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Minus => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a - b),
-                (Value::Float(a), Value::Float(b)) => Value::Float(a - b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "-", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Star => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a * b),
-                (Value::Float(a), Value::Float(b)) => Value::Float(a * b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "*", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Slash => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a / b),
-                (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "/", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Less => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a < b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a < b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "<", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Greater => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a > b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a > b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        ">", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::LessEqual => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a <= b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a <= b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "<=", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::GreaterEqual => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a >= b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a >= b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        ">=", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::BangEqual => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a != b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a != b),
-                (Value::String(a), Value::String(b)) => Value::Bool(a != b),
-                (Value::Char(a), Value::Char(b)) => Value::Bool(a != b),
-                (Value::Bool(a), Value::Bool(b)) => Value::Bool(a != b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "!=", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            TokenType::Compare => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Bool(a == b),
-                (Value::Float(a), Value::Float(b)) => Value::Bool(a == b),
-                (Value::String(a), Value::String(b)) => Value::Bool(a == b),
-                (Value::Char(a), Value::Char(b)) => Value::Bool(a == b),
-                (Value::Bool(a), Value::Bool(b)) => Value::Bool(a == b),
-                _ => {
-                    return Err(self.type_mismatch_binary(
-                        "==", &left, left_span, &right, right_span, span,
-                    ))
-                }
-            },
-            _ => return Err(self.err("unknown binary operator", span)),
-        };
+        let v =
+            match operator {
+                TokenType::Plus => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a + b),
+                    (Value::Float(a), Value::Float(b)) => Value::Float(a + b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary("+", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::Minus => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a - b),
+                    (Value::Float(a), Value::Float(b)) => Value::Float(a - b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary("-", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::Star => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a * b),
+                    (Value::Float(a), Value::Float(b)) => Value::Float(a * b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary("*", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::Slash => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Integer(a / b),
+                    (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary("/", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::Less => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a < b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a < b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary("<", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::Greater => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a > b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a > b),
+                    _ => {
+                        return Err(self
+                            .type_mismatch_binary(">", &left, left_span, &right, right_span, span));
+                    }
+                },
+                TokenType::LessEqual => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a <= b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a <= b),
+                    _ => {
+                        return Err(self.type_mismatch_binary(
+                            "<=", &left, left_span, &right, right_span, span,
+                        ));
+                    }
+                },
+                TokenType::GreaterEqual => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a >= b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a >= b),
+                    _ => {
+                        return Err(self.type_mismatch_binary(
+                            ">=", &left, left_span, &right, right_span, span,
+                        ));
+                    }
+                },
+                TokenType::BangEqual => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a != b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a != b),
+                    (Value::String(a), Value::String(b)) => Value::Bool(a != b),
+                    (Value::Char(a), Value::Char(b)) => Value::Bool(a != b),
+                    (Value::Bool(a), Value::Bool(b)) => Value::Bool(a != b),
+                    _ => {
+                        return Err(self.type_mismatch_binary(
+                            "!=", &left, left_span, &right, right_span, span,
+                        ));
+                    }
+                },
+                TokenType::Compare => match (&left, &right) {
+                    (Value::Integer(a), Value::Integer(b)) => Value::Bool(a == b),
+                    (Value::Float(a), Value::Float(b)) => Value::Bool(a == b),
+                    (Value::String(a), Value::String(b)) => Value::Bool(a == b),
+                    (Value::Char(a), Value::Char(b)) => Value::Bool(a == b),
+                    (Value::Bool(a), Value::Bool(b)) => Value::Bool(a == b),
+                    _ => {
+                        return Err(self.type_mismatch_binary(
+                            "==", &left, left_span, &right, right_span, span,
+                        ));
+                    }
+                },
+                _ => return Err(self.err("unknown binary operator", span)),
+            };
         Ok(v)
     }
 }

--- a/src/parser/statements/while_statement.rs
+++ b/src/parser/statements/while_statement.rs
@@ -13,6 +13,9 @@ impl Parser {
         let condition = self.parse_expression()?;
         let body = self.parse_block()?;
         let span = start.join(self.previous_span());
-        Ok(Statement::new(StatementKind::While { condition, body }, span))
+        Ok(Statement::new(
+            StatementKind::While { condition, body },
+            span,
+        ))
     }
 }

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -62,19 +62,6 @@ pub enum Reason {
 }
 
 impl Error {
-    /// legacy constructor: builds an error with just a message, optional line, and reason.
-    /// Used by call sites that haven't been migrated to span-based errors yet.
-    pub fn init(message: String, line: Option<usize>, reason: Option<ErrorReason>) -> Self {
-        #[cfg(feature = "debug")]
-        log::debug!("Error: {}", message);
-        Self {
-            message,
-            line,
-            reason,
-            detail: None,
-        }
-    }
-
     /// builder-style constructor for span-aware errors.
     /// the `span` becomes the primary anchor of the report.
     pub fn at(kind: Reason, message: impl Into<String>, span: Span) -> Self {


### PR DESCRIPTION
## What does this PR do?
drop the legacy error system `Error::init()` in favor of `Evaluator::err()` and `Error::at()`
both uses the stylish error system
(it was painful yet helpful)