### PR TITLE
Add entry point function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ rl new <name>       # create a new project
 rl docs             # print language reference
 ```
 
+## Entry points
+
+Source files still work as scripts when no entry function is present. If a file declares `fn main()`, `rl run` registers declarations and runs `main()` instead of evaluating top-level expressions. A different zero-argument function can be selected with `!#[entry]`:
+
+```rl
+!#[entry]
+fn start() {
+    std::io::println("hello")
+}
+```
 ## Documentation
 
 Full language reference and stdlib documentation is available on the [wiki](https://github.com/rl-lang/rl-lang/wiki).

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -72,6 +72,7 @@ pub enum StatementKind {
         params: Vec<Param>,
         return_type: TypeAnnotation,
         body: Vec<Statement>,
+        is_entry: bool,
     },
     Return(Option<Expression>),
 

--- a/src/checker/statements/statement.rs
+++ b/src/checker/statements/statement.rs
@@ -283,6 +283,7 @@ impl TypeChecker {
                 params,
                 return_type,
                 body,
+                ..
             } => {
                 let fn_type = CheckType::Function {
                     params: params.iter().map(|p| p.param_type.clone()).collect(),

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -446,6 +446,7 @@ impl Evaluator {
                 params,
                 return_type,
                 body,
+                ..
             } => {
                 let func = Value::Function {
                     params: params.clone(),
@@ -530,6 +531,51 @@ impl Evaluator {
         }
     }
 
+    pub fn evaluate_program(&mut self, statements: &[Statement]) -> Result<(), Error> {
+        let mut explicit_entry: Option<(&str, crate::utils::span::Span)> = None;
+        let mut main_entry: Option<crate::utils::span::Span> = None;
+
+        for statement in statements {
+            if let StatementKind::FunctionDeclaration { name, is_entry, .. } = &statement.kind {
+                if *is_entry {
+                    if explicit_entry.is_some() {
+                        return Err(
+                            self.err("multiple `!#[entry]` functions found", statement.span)
+                        );
+                    }
+                    explicit_entry = Some((name.as_str(), statement.span));
+                }
+                if name == "main" {
+                    main_entry = Some(statement.span);
+                }
+            }
+        }
+
+        let entry = explicit_entry.or_else(|| main_entry.map(|span| ("main", span)));
+        let Some((entry_name, entry_span)) = entry else {
+            for statement in statements {
+                self.evaluate_statement(statement)?;
+            }
+            return Ok(());
+        };
+
+        for statement in statements {
+            match &statement.kind {
+                StatementKind::FunctionDeclaration { .. }
+                | StatementKind::Import { .. }
+                | StatementKind::ImportFile { .. }
+                | StatementKind::ImportFileNamed { .. }
+                | StatementKind::VariableDeclaration { .. }
+                | StatementKind::ConstantDeclaration { .. }
+                | StatementKind::Array { .. }
+                | StatementKind::ConstantArray { .. } => self.evaluate_statement(statement)?,
+                _ => {}
+            }
+        }
+
+        self.call_path(&[entry_name.to_string()], Vec::new(), entry_span)?;
+        Ok(())
+    }
     pub fn evaluate_block(&mut self, statements: &[Statement]) -> Result<(), Error> {
         self.push_scope();
         for statement in statements {

--- a/src/logic_loops.rs
+++ b/src/logic_loops.rs
@@ -40,11 +40,9 @@ pub fn eval_loop(source: SourceFile, statements: Vec<Statement>) {
     #[cfg(feature = "debug")]
     info!("evaluating the ast tree...");
     let mut evaluator = Evaluator::default().with_stdlib().with_source_file(source);
-    for statement in statements {
-        if let Err(e) = evaluator.evaluate_statement(&statement) {
-            e.report_to_stderr();
-            std::process::exit(1);
-        }
+    if let Err(e) = evaluator.evaluate_program(&statements) {
+        e.report_to_stderr();
+        std::process::exit(1);
     }
 
     #[cfg(feature = "debug")]

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -14,7 +14,7 @@ impl Parser {
     //     body
     // }
 
-    pub fn parse_function(&mut self, start: Span) -> Result<Statement, Error> {
+    pub fn parse_function(&mut self, start: Span, is_entry: bool) -> Result<Statement, Error> {
         // function name
         let name = match self.peek() {
             TokenType::Identifier(n) => {
@@ -68,6 +68,7 @@ impl Parser {
                 params,
                 return_type,
                 body,
+                is_entry,
             },
             span,
         ))

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -77,9 +77,13 @@ impl Parser {
                 self.advance();
                 #[cfg(feature = "debug")]
                 log::info!("found 'fn' while parsing");
-                self.parse_function(start)
+                self.parse_function(start, false)
             }
 
+            TokenType::BangHash => {
+                self.advance();
+                self.parse_entry_attribute(start)
+            }
             TokenType::Return => {
                 self.advance();
                 // if next token can start an expression, parse it
@@ -136,5 +140,30 @@ impl Parser {
         // is it double consuming?
         // self.match_type(&[TokenType::RightBrace]);
         Ok(statements)
+    }
+    fn parse_entry_attribute(
+        &mut self,
+        start: crate::utils::span::Span,
+    ) -> Result<Statement, Error> {
+        if !self.match_type(&[TokenType::LeftBracket]) {
+            return Err(self.err("expected `[` after `!#`", self.peek_span()));
+        }
+        match self.peek() {
+            TokenType::Identifier(name) if name == "entry" => {
+                self.advance();
+            }
+            _ => return Err(self.err("expected `entry` attribute", self.peek_span())),
+        }
+        if !self.match_type(&[TokenType::RightBracket]) {
+            return Err(self.err("expected `]` after entry attribute", self.peek_span()));
+        }
+        while self.match_type(&[TokenType::Newline]) {}
+        if !self.match_type(&[TokenType::Fn]) {
+            return Err(self.err(
+                "expected function declaration after `!#[entry]`",
+                self.peek_span(),
+            ));
+        }
+        self.parse_function(start, true)
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,8 +18,6 @@ pub fn eval_program(source: &str) -> Result<Evaluator, Error> {
     let tokens = rl_lang::lexer::tokenizer::Tokenizer::lex(file.clone())?;
     let stmts = rl_lang::parser::parser_logic::Parser::parse(tokens, file.clone())?;
     let mut evaluator = Evaluator::default().with_stdlib().with_source_file(file);
-    for stmt in &stmts {
-        evaluator.evaluate_statement(stmt)?;
-    }
+    evaluator.evaluate_program(&stmts)?;
     Ok(evaluator)
 }

--- a/tests/interpreter/functions/mod.rs
+++ b/tests/interpreter/functions/mod.rs
@@ -1,0 +1,51 @@
+use rl_lang::interpreter::values::Value;
+
+use crate::common::eval_program;
+
+#[test]
+fn main_function_is_entry_point_when_present() {
+    let evaluator = eval_program(
+        r#"
+dec int x = 0
+fn main() {
+    x = 7
+}
+x = 99
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(evaluator.get_value_raw("x"), Some(Value::Integer(7)));
+}
+
+#[test]
+fn explicit_entry_function_overrides_main() {
+    let evaluator = eval_program(
+        r#"
+dec int x = 0
+fn main() {
+    x = 1
+}
+!#[entry]
+fn custom() {
+    x = 2
+}
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(evaluator.get_value_raw("x"), Some(Value::Integer(2)));
+}
+
+#[test]
+fn scripts_without_entry_still_run_top_level() {
+    let evaluator = eval_program(
+        r#"
+dec int x = 0
+x = 3
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(evaluator.get_value_raw("x"), Some(Value::Integer(3)));
+}

--- a/tests/interpreter/mod.rs
+++ b/tests/interpreter/mod.rs
@@ -1,1 +1,3 @@
 mod numbers;
+
+mod functions;

--- a/tests/parser/fns_lambdas.rs
+++ b/tests/parser/fns_lambdas.rs
@@ -19,6 +19,7 @@ fn fn_simple() {
                 param_type: TypeAnnotation::Int,
             }],
             return_type: TypeAnnotation::Null,
+            is_entry: false,
             body: vec![Statement::new(
                 StatementKind::Return(Some(Expression::new(
                     ExpressionKind::Identifier("x".to_string()),
@@ -49,6 +50,7 @@ fn fn_fn_param() {
                 },
             ],
             return_type: TypeAnnotation::Null,
+            is_entry: false,
             body: vec![Statement::new(
                 StatementKind::Return(Some(Expression::new(
                     ExpressionKind::Call {
@@ -96,4 +98,16 @@ fn dec_fn_lambda() {
         Span::new(0, 31),
     );
     assert_eq!(statements, vec![expected]);
+}
+
+#[test]
+fn entry_attribute_marks_function() {
+    let statements = common::parse("!#[entry]\nfn start () {return 1}");
+    match &statements[0].kind {
+        StatementKind::FunctionDeclaration { name, is_entry, .. } => {
+            assert_eq!(name, "start");
+            assert!(*is_entry);
+        }
+        other => panic!("expected function declaration, got {:?}", other),
+    }
 }


### PR DESCRIPTION
## Summary

Adds entry point support for RL programs.

- Runs `fn main()` as the program entry point when present
- Supports `!#[entry]` to select a custom zero-argument entry function
- Preserves existing script behavior when no entry function is present
- Adds parser and interpreter tests
- Documents entry point behavior in README

Closes #63.

## Validation

- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`