### PR TITLE
Feat/stdlib random

### DIFF
--- a/src/docs/entries/mod.rs
+++ b/src/docs/entries/mod.rs
@@ -13,6 +13,7 @@ pub fn stdlib_entries() -> Vec<&'static StdEntry> {
         &stdlib::types::TYPES,
         &stdlib::path::PATH,
         &stdlib::fs::FS,
+        &stdlib::random::RANDOM,
     ]
 }
 

--- a/src/docs/entries/stdlib/mod.rs
+++ b/src/docs/entries/stdlib/mod.rs
@@ -4,5 +4,6 @@ pub mod fs;
 pub mod io;
 pub mod math;
 pub mod path;
+pub mod random;
 pub mod str;
 pub mod types;

--- a/src/docs/entries/stdlib/random.rs
+++ b/src/docs/entries/stdlib/random.rs
@@ -14,6 +14,7 @@ static FUNCTIONS: &[&FnEntry] = &[
     &RAND_BOOL,
     &RAND_BOOL_WEIGHTED,
     &RAND_DICE,
+    &RAND_DICES,
     &RAND_RANGE,
     &RAND_RANGE_STEP,
     &RAND_CHOICE,
@@ -66,6 +67,12 @@ static RAND_DICE: FnEntry = FnEntry {
     signature: "rand_dice(sides)",
     description: "rolls a single die with the given number of sides and returns the result",
     example: "get std::random::rand_dice\n\nrand_dice(6) // 5",
+};
+
+static RAND_DICES: FnEntry = FnEntry {
+    signature: "rand_dices(count, sides)",
+    description: "rolls count dice with the given number of sides and returns the individual results as an array",
+    example: "get std::random::rand_dices\n\nrand_dices(3, 6) // [4, 1, 6]",
 };
 
 static RAND_RANGE: FnEntry = FnEntry {

--- a/src/docs/entries/stdlib/random.rs
+++ b/src/docs/entries/stdlib/random.rs
@@ -1,0 +1,129 @@
+use crate::docs::entry::{FnEntry, StdEntry};
+
+pub static RANDOM: StdEntry = StdEntry {
+    name: "random",
+    description: "functions for random number and value generation",
+    functions: FUNCTIONS,
+};
+
+static FUNCTIONS: &[&FnEntry] = &[
+    &RAND_INT,
+    &RAND_INT_RANGE,
+    &RAND_FLOAT,
+    &RAND_FLOAT_RANGE,
+    &RAND_BOOL,
+    &RAND_BOOL_WEIGHTED,
+    &RAND_DICE,
+    &RAND_RANGE,
+    &RAND_RANGE_STEP,
+    &RAND_CHOICE,
+    &RAND_CHOICES,
+    &RAND_SAMPLE,
+    &RAND_SHUFFLE,
+    &RAND_BYTE,
+    &RAND_BYTES,
+    &RAND_CHAR,
+    &RAND_STRING,
+];
+
+static RAND_INT: FnEntry = FnEntry {
+    signature: "rand_int()",
+    description: "returns a random int across the full int range",
+    example: "get std::random::rand_int\n\nrand_int() // 4650267523947147985",
+};
+
+static RAND_INT_RANGE: FnEntry = FnEntry {
+    signature: "rand_int_range(min, max)",
+    description: "returns a random int between min and max (inclusive)",
+    example: "get std::random::rand_int_range\n\nrand_int_range(1, 6) // 4",
+};
+
+static RAND_FLOAT: FnEntry = FnEntry {
+    signature: "rand_float()",
+    description: "returns a random float between 0.0 and 1.0",
+    example: "get std::random::rand_float\n\nrand_float() // 0.3528",
+};
+
+static RAND_FLOAT_RANGE: FnEntry = FnEntry {
+    signature: "rand_float_range(min, max)",
+    description: "returns a random float between min and max",
+    example: "get std::random::rand_float_range\n\nrand_float_range(1.0, 2.0) // 1.5124",
+};
+
+static RAND_BOOL: FnEntry = FnEntry {
+    signature: "rand_bool()",
+    description: "returns a random bool, using an internally randomized probability",
+    example: "get std::random::rand_bool\n\nrand_bool() // true",
+};
+
+static RAND_BOOL_WEIGHTED: FnEntry = FnEntry {
+    signature: "rand_bool_weighted(probability)",
+    description: "returns a random bool that is true with the given probability (0.0 to 1.0) values smaller than 0.0 will be 0.0 and values bigger than 1.0 will be 1.0",
+    example: "get std::random::rand_bool_weighted\n\nrand_bool_weighted(0.8) // true",
+};
+
+static RAND_DICE: FnEntry = FnEntry {
+    signature: "rand_dice(sides)",
+    description: "rolls a single die with the given number of sides and returns the result",
+    example: "get std::random::rand_dice\n\nrand_dice(6) // 5",
+};
+
+static RAND_RANGE: FnEntry = FnEntry {
+    signature: "rand_range(stop)",
+    description: "returns a random int from 0 to stop (exclusive), stop must be greater than zero",
+    example: "get std::random::rand_range\n\nrand_range(10) // 7",
+};
+
+static RAND_RANGE_STEP: FnEntry = FnEntry {
+    signature: "rand_range_step(start, end, step)",
+    description: "returns a random int from start to end, aligned to step; reaches end only if step divides (end - start) evenly, otherwise caps at the highest reachable multiple below end",
+    example: "get std::random::rand_range_step\n\nrand_range_step(0, 9, 2) // 8 (max possible, since 9 isn't reachable)",
+};
+
+static RAND_CHOICE: FnEntry = FnEntry {
+    signature: "rand_choice(arr)",
+    description: "returns a random element from the array",
+    example: "get std::random::rand_choice\n\nrand_choice([1, 2, 3]) // 1",
+};
+
+static RAND_CHOICES: FnEntry = FnEntry {
+    signature: "rand_choices(arr, count)",
+    description: "returns an array of count random elements from arr, with replacement",
+    example: "get std::random::rand_choices\n\nrand_choices([1, 2, 3], 5) // [1, 1, 3, 1, 1]",
+};
+
+static RAND_SAMPLE: FnEntry = FnEntry {
+    signature: "rand_sample(arr, count)",
+    description: "returns an array of count random elements from arr, without replacement (count must not exceed arr's length)",
+    example: "get std::random::rand_sample\n\nrand_sample([1, 2, 3, 4], 2) // [4, 2]",
+};
+
+static RAND_SHUFFLE: FnEntry = FnEntry {
+    signature: "rand_shuffle(arr)",
+    description: "returns the array with its elements in random order",
+    example: "get std::random::rand_shuffle\n\nrand_shuffle([1, 2, 3, 4, 5]) // [3, 5, 1, 4, 2]",
+};
+
+static RAND_BYTE: FnEntry = FnEntry {
+    signature: "rand_byte()",
+    description: "returns a random byte (0 to 255)",
+    example: "get std::random::rand_byte\n\nrand_byte() // 110",
+};
+
+static RAND_BYTES: FnEntry = FnEntry {
+    signature: "rand_bytes(count)",
+    description: "returns an array of count random bytes",
+    example: "get std::random::rand_bytes\n\nrand_bytes(4) // [226, 232, 81, 178]",
+};
+
+static RAND_CHAR: FnEntry = FnEntry {
+    signature: "rand_char()",
+    description: "returns a random printable ascii character (32 to 126)",
+    example: "get std::random::rand_char\n\nrand_char() // 'c'",
+};
+
+static RAND_STRING: FnEntry = FnEntry {
+    signature: "rand_string(count)",
+    description: "returns a random printable ascii string of the given length",
+    example: "get std::random::rand_string\n\nrand_string(8) // \"oNU7'=^:\"",
+};

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -97,7 +97,8 @@ impl Evaluator {
                 .with_module(stdlib::types::module())
                 .with_module(stdlib::array::module())
                 .with_module(stdlib::path::module())
-                .with_module(stdlib::fs::module()),
+                .with_module(stdlib::fs::module())
+                .with_module(stdlib::random::module()),
         )
     }
 
@@ -478,6 +479,7 @@ impl Evaluator {
                 .chain(stdlib::array::KEYWORDS)
                 .chain(stdlib::path::KEYWORDS)
                 .chain(stdlib::fs::KEYWORDS)
+                .chain(stdlib::random::KEYWORDS)
                 .copied();
             if let Some(suggestion) = closest_match(last, candidates) {
                 err = err.with_help(format!("did you mean `{}`?", suggestion));

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 use std::{collections::HashMap, rc::Rc};
 
+use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
 use crate::{
     ast::{
         nodes::{Expression, ExpressionKind},
@@ -40,6 +41,7 @@ pub struct Evaluator {
     pub is_breaking: bool,
     pub is_continuing: bool,
     pub output_buffer: Option<String>,
+    pub rng: Xoshiro256,
 }
 
 impl Default for Evaluator {
@@ -58,6 +60,7 @@ impl Evaluator {
             is_breaking: false,
             is_continuing: false,
             output_buffer: None,
+            rng: Xoshiro256::default(),
         }
     }
 

--- a/src/interpreter/stdlib/mod.rs
+++ b/src/interpreter/stdlib/mod.rs
@@ -5,5 +5,6 @@ pub mod io;
 pub mod len;
 pub mod math;
 pub mod path;
+pub mod random;
 pub mod string;
 pub mod types;

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -17,6 +17,17 @@ pub const KEYWORDS: &[&str] = &[
     "rand_float_range",
     "rand_bool",
     "rand_bool_weighted",
+    "rand_dice",
+    "rand_range",
+    "rand_range_step",
+    "rand_choice",
+    "rand_choices",
+    "rand_sample",
+    "rand_shuffle",
+    "rand_byte",
+    "rand_bytes",
+    "rand_char",
+    "rand_string",
 ];
 
 pub fn module() -> Module {
@@ -27,4 +38,15 @@ pub fn module() -> Module {
         .with_function("rand_float_range", rand_float_range::func)
         .with_function("rand_bool_weighted", rand_bool_weighted::func)
         .with_function("rand_bool", rand_bool::func)
+        .with_function("rand_dice", random_general::dice)
+        .with_function("rand_range", random_general::range)
+        .with_function("rand_range_step", random_general::range_step)
+        .with_function("rand_choice", random_general::choice)
+        .with_function("rand_choices", random_general::choices)
+        .with_function("rand_sample", random_general::sample)
+        .with_function("rand_shuffle", random_general::shuffle)
+        .with_function("rand_byte", random_general::byte)
+        .with_function("rand_bytes", random_general::bytes)
+        .with_function("rand_char", random_general::char)
+        .with_function("rand_string", random_general::string)
 }

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -6,6 +6,7 @@ mod rand_float;
 mod rand_float_range;
 mod rand_int;
 mod rand_int_range;
+mod random_general;
 
 use crate::interpreter::native::Module;
 

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -1,1 +1,22 @@
 pub mod xoshiro;
+
+//mod rand_float;
+mod rand_int_range;
+//mod rand_float_range
+//mod rand_bool;
+
+use crate::interpreter::native::Module;
+
+pub const KEYWORDS: &[&str] = &[
+    "rand_int_range",
+    "rand_float",
+    "rand_float_range",
+    "rand_bool",
+];
+
+pub fn module() -> Module {
+    Module::new("random").with_function("rand_int_range", rand_int_range::func)
+    //.with_function("rand_float", rand_float::func)
+    //.with_function("rand_float_range", rand_float_range::func)
+    //.with_function("rand_bool", rand_bool::func)
+}

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -1,0 +1,1 @@
+pub mod xoshiro;

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -4,11 +4,13 @@ mod rand_bool;
 mod rand_bool_weighted;
 mod rand_float;
 mod rand_float_range;
+mod rand_int;
 mod rand_int_range;
 
 use crate::interpreter::native::Module;
 
 pub const KEYWORDS: &[&str] = &[
+    "rand_int",
     "rand_int_range",
     "rand_float",
     "rand_float_range",
@@ -18,6 +20,7 @@ pub const KEYWORDS: &[&str] = &[
 
 pub fn module() -> Module {
     Module::new("random")
+        .with_function("rand_int", rand_int::func)
         .with_function("rand_int_range", rand_int_range::func)
         .with_function("rand_float", rand_float::func)
         .with_function("rand_float_range", rand_float_range::func)

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -1,8 +1,8 @@
 pub mod xoshiro;
 
-//mod rand_float;
+mod rand_float;
+mod rand_float_range;
 mod rand_int_range;
-//mod rand_float_range
 //mod rand_bool;
 
 use crate::interpreter::native::Module;
@@ -15,8 +15,9 @@ pub const KEYWORDS: &[&str] = &[
 ];
 
 pub fn module() -> Module {
-    Module::new("random").with_function("rand_int_range", rand_int_range::func)
-    //.with_function("rand_float", rand_float::func)
-    //.with_function("rand_float_range", rand_float_range::func)
+    Module::new("random")
+        .with_function("rand_int_range", rand_int_range::func)
+        .with_function("rand_float", rand_float::func)
+        .with_function("rand_float_range", rand_float_range::func)
     //.with_function("rand_bool", rand_bool::func)
 }

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -18,6 +18,7 @@ pub const KEYWORDS: &[&str] = &[
     "rand_bool",
     "rand_bool_weighted",
     "rand_dice",
+    "rand_dices",
     "rand_range",
     "rand_range_step",
     "rand_choice",
@@ -49,4 +50,5 @@ pub fn module() -> Module {
         .with_function("rand_bytes", random_general::bytes)
         .with_function("rand_char", random_general::char)
         .with_function("rand_string", random_general::string)
+        .with_function("rand_dices", random_general::dices)
 }

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -1,9 +1,10 @@
 pub mod xoshiro;
 
+mod rand_bool;
+mod rand_bool_weighted;
 mod rand_float;
 mod rand_float_range;
 mod rand_int_range;
-//mod rand_bool;
 
 use crate::interpreter::native::Module;
 
@@ -12,6 +13,7 @@ pub const KEYWORDS: &[&str] = &[
     "rand_float",
     "rand_float_range",
     "rand_bool",
+    "rand_bool_weighted",
 ];
 
 pub fn module() -> Module {
@@ -19,5 +21,6 @@ pub fn module() -> Module {
         .with_function("rand_int_range", rand_int_range::func)
         .with_function("rand_float", rand_float::func)
         .with_function("rand_float_range", rand_float_range::func)
-    //.with_function("rand_bool", rand_bool::func)
+        .with_function("rand_bool_weighted", rand_bool_weighted::func)
+        .with_function("rand_bool", rand_bool::func)
 }

--- a/src/interpreter/stdlib/random/plan.md
+++ b/src/interpreter/stdlib/random/plan.md
@@ -1,7 +1,0 @@
-# random
-- `rand_int(min, max)`
-- `rand_float()`
-- `rand_bool()`
-- `rand_choice(arr)`
-- `shuffle(arr)`
-- `seed(n)`

--- a/src/interpreter/stdlib/random/rand_bool.rs
+++ b/src/interpreter/stdlib/random/rand_bool.rs
@@ -1,0 +1,6 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn func(eval: &mut Evaluator) -> bool {
+    let rand_float = eval.rng.generate_random_float();
+    eval.rng.generate_random_bool(rand_float)
+}

--- a/src/interpreter/stdlib/random/rand_bool_weighted.rs
+++ b/src/interpreter/stdlib/random/rand_bool_weighted.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn func(eval: &mut Evaluator, weight: f64) -> bool {
+    eval.rng.generate_random_bool(weight)
+}

--- a/src/interpreter/stdlib/random/rand_float.rs
+++ b/src/interpreter/stdlib/random/rand_float.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn func(eval: &mut Evaluator) -> f64 {
+    eval.rng.generate_random_float()
+}

--- a/src/interpreter/stdlib/random/rand_float_range.rs
+++ b/src/interpreter/stdlib/random/rand_float_range.rs
@@ -3,7 +3,7 @@ use crate::{
     utils::{errors::Error, span::Span},
 };
 
-pub fn func(eval: &mut Evaluator, min: i64, max: i64, span: Span) -> Result<Value, Error> {
+pub fn func(eval: &mut Evaluator, min: f64, max: f64, span: Span) -> Result<Value, Error> {
     if min >= max {
         return Err(eval.err(
             "min value shouldn't be bigger than or equal to maximum value",
@@ -11,5 +11,5 @@ pub fn func(eval: &mut Evaluator, min: i64, max: i64, span: Span) -> Result<Valu
         ));
     }
 
-    Ok(Value::Integer(eval.rng.generate_random_int_range(min, max)))
+    Ok(Value::Float(eval.rng.generate_random_float_range(min, max)))
 }

--- a/src/interpreter/stdlib/random/rand_int.rs
+++ b/src/interpreter/stdlib/random/rand_int.rs
@@ -1,0 +1,5 @@
+use crate::interpreter::evaluator::Evaluator;
+
+pub fn func(eval: &mut Evaluator) -> i64 {
+    eval.rng.generate_random_int_range(i64::MIN, i64::MAX)
+}

--- a/src/interpreter/stdlib/random/rand_int_range.rs
+++ b/src/interpreter/stdlib/random/rand_int_range.rs
@@ -1,0 +1,15 @@
+use crate::{
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{errors::Error, span::Span},
+};
+
+pub fn func(eval: &mut Evaluator, min: i64, max: i64, span: Span) -> Result<Value, Error> {
+    if min >= max {
+        return Err(eval.err(
+            "min value shouldn't be bigger than or equal to maximum value",
+            span,
+        ));
+    }
+
+    Ok(Value::Integer(eval.rng.generate_random_int(min, max)))
+}

--- a/src/interpreter/stdlib/random/random_general.rs
+++ b/src/interpreter/stdlib/random/random_general.rs
@@ -1,5 +1,3 @@
-use std::clone;
-
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{evaluator::Evaluator, values::Value},
@@ -129,15 +127,15 @@ pub fn sample(eval: &mut Evaluator, array: Value, count: i64, span: Span) -> Res
     }
 }
 
-fn char(eval: &mut Evaluator) -> char {
+pub fn char(eval: &mut Evaluator) -> char {
     eval.rng.generate_random_int_range(32, 126) as u8 as char
 }
 
-fn byte(eval: &mut Evaluator) -> i64 {
+pub fn byte(eval: &mut Evaluator) -> i64 {
     eval.rng.generate_random_int_range(0, 255)
 }
 
-fn string(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
+pub fn string(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
     if count as usize <= 0 {
         return Err(eval.err("count cannot be less than zero", span));
     }
@@ -147,7 +145,7 @@ fn string(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> 
     Ok(Value::String(result))
 }
 
-fn bytes(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
+pub fn bytes(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
     if count as usize <= 0 {
         return Err(eval.err("count cannot be less than zero", span));
     }

--- a/src/interpreter/stdlib/random/random_general.rs
+++ b/src/interpreter/stdlib/random/random_general.rs
@@ -159,3 +159,26 @@ fn bytes(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
         items: result,
     })
 }
+
+pub fn shuffle(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
+    match array {
+        Value::Values { items, items_type } => {
+            if items.is_empty() {
+                return Err(eval.err("array is empty", span));
+            }
+
+            let mut items = items;
+            for i in (1..items.len()).rev() {
+                let j = eval.rng.generate_random_int_range(0, i as i64) as usize;
+                items.swap(i, j);
+            }
+
+            Ok(Value::Values { items_type, items })
+        }
+
+        other => Err(eval.err(
+            format!("rand_shuffle() expected array found {}", other),
+            span,
+        )),
+    }
+}

--- a/src/interpreter/stdlib/random/random_general.rs
+++ b/src/interpreter/stdlib/random/random_general.rs
@@ -4,8 +4,29 @@ use crate::{
     utils::{errors::Error, span::Span},
 };
 
-pub fn dice(eval: &mut Evaluator, sides: i64) -> i64 {
-    eval.rng.generate_random_int_range(1, sides)
+pub fn dice(eval: &mut Evaluator, sides: i64, span: Span) -> Result<Value, Error> {
+    if sides <= 0 {
+        return Err(eval.err("sides should be 1 or higher", span));
+    }
+    Ok(Value::Integer(eval.rng.generate_random_int_range(1, sides)))
+}
+
+pub fn dices(eval: &mut Evaluator, count: i64, sides: i64, span: Span) -> Result<Value, Error> {
+    if count <= 0 {
+        return Err(eval.err("count should be 1 or higher", span));
+    }
+    if sides <= 0 {
+        return Err(eval.err("sides should be 1 or higher", span));
+    }
+
+    let result: Vec<Value> = (0..count)
+        .map(|_| Value::Integer(eval.rng.generate_random_int_range(1, sides)))
+        .collect();
+
+    Ok(Value::Values {
+        items_type: TypeAnnotation::Int,
+        items: result,
+    })
 }
 
 pub fn range(eval: &mut Evaluator, stop: i64, span: Span) -> Result<Value, Error> {

--- a/src/interpreter/stdlib/random/random_general.rs
+++ b/src/interpreter/stdlib/random/random_general.rs
@@ -1,0 +1,161 @@
+use std::clone;
+
+use crate::{
+    ast::statements::TypeAnnotation,
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{errors::Error, span::Span},
+};
+
+pub fn dice(eval: &mut Evaluator, sides: i64) -> i64 {
+    eval.rng.generate_random_int_range(1, sides)
+}
+
+pub fn range(eval: &mut Evaluator, stop: i64, span: Span) -> Result<Value, Error> {
+    if 0 == stop {
+        return Err(eval.err("rand_range() stop shouldn't be zero", span));
+    }
+    if 0 > stop {
+        return Err(eval.err("rand_range() stop shouldn't be less than zero", span));
+    }
+
+    Ok(Value::Integer(eval.rng.generate_random_int_range(0, stop)))
+}
+
+pub fn range_step(
+    eval: &mut Evaluator,
+    start: i64,
+    end: i64,
+    step: i64,
+    span: Span,
+) -> Result<Value, Error> {
+    if 0 == step {
+        return Err(eval.err("rand_range_step() stop shouldn't be zero", span));
+    }
+    if start >= end {
+        return Err(eval.err(
+            format!(
+                "rand_range_step() end shouldn't be less than or equal to {}",
+                start
+            ),
+            span,
+        ));
+    }
+
+    let count = ((end - start) / step) + 1;
+    let i = eval.rng.generate_random_int_range(0, count - 1);
+    Ok(Value::Integer(start + i * step))
+}
+
+pub fn choice(eval: &mut Evaluator, array: Value, span: Span) -> Result<Value, Error> {
+    match array {
+        Value::Values { items, .. } => {
+            if items.is_empty() {
+                return Err(eval.err("array is empty", span));
+            }
+            Ok(items[eval
+                .rng
+                .generate_random_int_range(0, items.len() as i64 - 1)
+                as usize]
+                .clone())
+        }
+
+        other => Err(eval.err(
+            format!("rand_choice() expected array found {}", other),
+            span,
+        )),
+    }
+}
+
+pub fn choices(eval: &mut Evaluator, array: Value, count: i64, span: Span) -> Result<Value, Error> {
+    if count <= 0 {
+        return Err(eval.err("count should be 1 or higher", span));
+    }
+
+    match array.clone() {
+        Value::Values { items_type, items } => {
+            let result = (0..count)
+                .map(|_| {
+                    items[eval
+                        .rng
+                        .generate_random_int_range(0, items.len() as i64 - 1)
+                        as usize]
+                        .clone()
+                })
+                .collect();
+            Ok(Value::Values {
+                items_type,
+                items: result,
+            })
+        }
+
+        other => Err(eval.err(
+            format!("rand_choices() expected array found {}", other),
+            span,
+        )),
+    }
+}
+
+pub fn sample(eval: &mut Evaluator, array: Value, count: i64, span: Span) -> Result<Value, Error> {
+    if count <= 0 {
+        return Err(eval.err("count should be 1 or higher", span));
+    }
+
+    match array.clone() {
+        Value::Values { items_type, items } => {
+            if count as usize > items.len() {
+                return Err(eval.err("count larger than array", span));
+            }
+            let mut indices: Vec<usize> = (0..items.len()).collect();
+            for i in (1..items.len()).rev() {
+                let j = eval.rng.generate_random_int_range(0, i as i64) as usize;
+                indices.swap(i, j);
+            }
+
+            let result = indices[..count as usize]
+                .iter()
+                .map(|&i| items[i].clone())
+                .collect();
+
+            Ok(Value::Values {
+                items_type,
+                items: result,
+            })
+        }
+
+        other => Err(eval.err(
+            format!("rand_sample() expected array found {}", other),
+            span,
+        )),
+    }
+}
+
+fn char(eval: &mut Evaluator) -> char {
+    eval.rng.generate_random_int_range(32, 126) as u8 as char
+}
+
+fn byte(eval: &mut Evaluator) -> i64 {
+    eval.rng.generate_random_int_range(0, 255)
+}
+
+fn string(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
+    if count as usize <= 0 {
+        return Err(eval.err("count cannot be less than zero", span));
+    }
+
+    let result: String = (0..count).map(|_| char(eval)).collect();
+
+    Ok(Value::String(result))
+}
+
+fn bytes(eval: &mut Evaluator, count: i64, span: Span) -> Result<Value, Error> {
+    if count as usize <= 0 {
+        return Err(eval.err("count cannot be less than zero", span));
+    }
+
+    let result: Vec<Value> = (0..count).map(|_| Value::Integer(byte(eval))).collect();
+
+    Ok(Value::Values {
+        items_type: TypeAnnotation::Int,
+        items: result,
+    })
+}

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -18,13 +18,13 @@ impl Xoshiro256 {
         // spread the seed into 4 u64
         let mut state = [0u64; 4];
         let mut x = seed;
-        for i in 0..4 {
+        for i in &mut state {
             // golden ratio * 2^64
             x = x.wrapping_add(0x9e3779b97f4a7c15);
             // magic constants
             x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
             x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
-            state[i] = x ^ (x >> 31);
+            *i = x ^ (x >> 31);
         }
 
         Self { state }

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -49,8 +49,9 @@ impl Xoshiro256 {
 
     // primitive functions
     pub fn generate_random_int_range(&mut self, min: i64, max: i64) -> i64 {
-        let range = (max - min + 1) as u64;
-        min + (self.next() % range) as i64
+        let range = (max as i128 - min as i128 + 1) as u128;
+        let offset = (self.next() as u128) % range;
+        (min as i128 + offset as i128) as i64
     }
 
     pub fn generate_random_float(&mut self) -> f64 {

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -46,4 +46,10 @@ impl Xoshiro256 {
         self.state[3] = self.state[3].rotate_left(45);
         result
     }
+
+    // primitive functions
+    pub fn generate_random_int(&mut self, min: i64, max: i64) -> i64 {
+        let range = (max - min + 1) as u64;
+        min + (self.next() % range) as i64
+    }
 }

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -48,8 +48,16 @@ impl Xoshiro256 {
     }
 
     // primitive functions
-    pub fn generate_random_int(&mut self, min: i64, max: i64) -> i64 {
+    pub fn generate_random_int_range(&mut self, min: i64, max: i64) -> i64 {
         let range = (max - min + 1) as u64;
         min + (self.next() % range) as i64
+    }
+
+    pub fn generate_random_float(&mut self) -> f64 {
+        self.next() as f64 / u64::MAX as f64
+    }
+
+    pub fn generate_random_float_range(&mut self, min: f64, max: f64) -> f64 {
+        min + self.generate_random_float() * (max - min)
     }
 }

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -1,0 +1,30 @@
+pub struct Xoshiro256 {
+    state: [u64; 4],
+}
+
+impl Default for Xoshiro256 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Xoshiro256 {
+    fn new() -> Self {
+        let seed = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(12345);
+
+        // spread the seed into 4 u64
+        let mut state = [0u64; 4];
+        let mut x = seed;
+        for i in 0..4 {
+            x = x.wrapping_add(0x9e3779b97f4a7c15);
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+            state[i] = x ^ (x >> 31);
+        }
+
+        Self { state }
+    }
+}

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -60,4 +60,8 @@ impl Xoshiro256 {
     pub fn generate_random_float_range(&mut self, min: f64, max: f64) -> f64 {
         min + self.generate_random_float() * (max - min)
     }
+
+    pub fn generate_random_bool(&mut self, weight: f64) -> bool {
+        self.generate_random_float() < weight.clamp(0.0, 1.0)
+    }
 }

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -19,12 +19,31 @@ impl Xoshiro256 {
         let mut state = [0u64; 4];
         let mut x = seed;
         for i in 0..4 {
+            // golden ratio * 2^64
             x = x.wrapping_add(0x9e3779b97f4a7c15);
+            // magic constants
             x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
             x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
             state[i] = x ^ (x >> 31);
         }
 
         Self { state }
+    }
+
+    fn next(&mut self) -> u64 {
+        // compute result before scrambling the state
+        let result = (self.state[0].wrapping_add(self.state[3]))
+            .rotate_left(23)
+            .wrapping_add(self.state[0]);
+
+        // scramble the state
+        let temp = self.state[1] << 17;
+        self.state[2] ^= self.state[0];
+        self.state[3] ^= self.state[1];
+        self.state[1] ^= self.state[2];
+        self.state[0] ^= self.state[3];
+        self.state[2] ^= temp;
+        self.state[3] = self.state[3].rotate_left(45);
+        result
     }
 }

--- a/syntax.rl
+++ b/syntax.rl
@@ -8,7 +8,7 @@
 // ------------------------------------------------------------
 // 1. imports
 // ------------------------------------------------------------
-get len from std::display
+get len from std::array
 get println from std::io
 get sin, cos, tan, pow, mod, is_prime, factorial, fibonacci from std::math
 get PI, TAU, PHI, E from std::math::consts


### PR DESCRIPTION
## What does this PR do?
Adds a new `random` stdlib module for random value generation (ints, floats, bools, dice, array operations, bytes/strings), backed by a custom Xoshiro256 PRNG, plus its docs entry (`FnEntry`/`StdEntry`) following the existing stdlib documentation pattern.

### functions
- `rand_int()` -> returns a random int across the full int range
- `rand_int_range(min, max)` -> returns a random int between min and max (inclusive)
- `rand_float()` -> returns a random float between 0.0 and 1.0
- `rand_float_range(min, max)` -> returns a random float between min and max
- `rand_bool()` -> returns a random bool, using an internally randomized probability rather than a fixed 50/50 split
- `rand_bool_weighted(probability)` -> returns a random bool that is true with the given probability (0.0 to 1.0)
- `rand_dice(sides)` -> rolls a single die with the given number of sides and returns the result
- `rand_dices(count, sides)` -> rolls count dice with the given number of sides and returns the individual results as an array
- `rand_range(stop)` -> returns a random int from 0 to stop (exclusive)
- `rand_range_step(start, end, step)` -> returns a random int from start to end, aligned to step
- `rand_choice(arr)` -> returns a random element from the array
- `rand_choices(arr, count)` -> returns count random elements from arr, with replacement
- `rand_sample(arr, count)` -> returns count random elements from arr, without replacement
- `rand_shuffle(arr)` -> returns the array with its elements in random order
- `rand_byte()` -> returns a random byte (0 to 255)
- `rand_bytes(count)` -> returns an array of count random bytes
- `rand_char()` -> returns a random printable ascii character
- `rand_string(count)` -> returns a random printable ascii string of the given length

Closes #35 