### PR TITLE
fix module name in docs

### DIFF
--- a/src/docs/entries/stdlib/arrays.rs
+++ b/src/docs/entries/stdlib/arrays.rs
@@ -177,7 +177,7 @@ static ARR_UNIQUE: FnEntry = FnEntry {
 static LEN: FnEntry = FnEntry {
     signature: "len(x)",
     description: "length of string or array",
-    example: "get std::display::len\n\nlen(\"hello\") // 5",
+    example: "get std::array::len\n\nlen(\"hello\") // 5",
 };
 
 static ARR_ALL: FnEntry = FnEntry {


### PR DESCRIPTION
## What does this PR do?
replace `std::display::len` with `std::array::len` in docs
