### PR TITLE
Docs/add docs to rest of modules

### DIFF
--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -1,3 +1,23 @@
+//! Static type checker for rl - runs after parsing, before evaluation.
+//!
+//! The checker walks the AST and verifies:
+//! - Variable and constant declarations match their declared types
+//! - Binary/unary operators receive compatible operand types
+//! - Function calls receive the correct number and types of arguments
+//! - `return` types match the enclosing function's declared return type
+//! - `break` and `continue` only appear inside loops
+//! - Array elements are all the same type
+//!
+//! It also populates [`TypeChecker::hovers`] - a side-table of
+//! `(Span, markdown)` pairs used by the LSP hover provider.
+//!
+//! # Two-pass function checking
+//!
+//! [`TypeChecker::check`] does two passes over the statement list:
+//! first it pre-declares all top-level `FunctionDeclaration`s so they
+//! are visible to each other regardless of order, then it checks every
+//! statement body. This allows mutual recursion at the top level.
+
 pub mod operators;
 pub mod scope;
 pub mod statements;
@@ -133,8 +153,7 @@ impl TypeChecker {
     }
 }
 
-// collects the stdlib functions names for recgonizing
-// the functions
+/// Collects all function names from a stdlib [`Module`] tree into `out`.
 fn collect_fn_names(
     module: &crate::interpreter::native::Module,
     out: &mut std::collections::HashSet<String>,

--- a/src/checker/operators/binary.rs
+++ b/src/checker/operators/binary.rs
@@ -1,3 +1,19 @@
+//! Binary operator type checking.
+//!
+//! # Rules
+//!
+//! | Operator          | Left / Right                    | Result  |
+//! |-------------------|---------------------------------|---------|
+//! | `+` `-` `*` `/`  | int + int                       | int     |
+//! | `+` `-` `*` `/`  | float + float                   | float   |
+//! | `+` `-` `*` `/`  | byte + byte                     | byte    |
+//! | `+` `-` `*` `/`  | byte + int (or int + byte)      | int     |
+//! | `<` `>` `<=` `>=`| int/byte pairs                  | bool    |
+//! | `<` `>` `<=` `>=`| float + float                   | bool    |
+//! | `==` `!=`         | matching primitive types        | bool    |
+//!
+//! Any side being `Unknown` short-circuits to `Unknown` to suppress cascading errors.
+
 use crate::{
     ast::statements::TypeAnnotation,
     checker::{

--- a/src/checker/operators/index_assign.rs
+++ b/src/checker/operators/index_assign.rs
@@ -1,3 +1,11 @@
+//! Index-assign type checking (`arr[i] = value`).
+//!
+//! Validates:
+//! - The index is an `int` or `byte`
+//! - The value type matches the array's element type
+//! - `byte` widens to `int` when the array element type is `int`
+//! - Assigning `null` is always allowed (absence of value)
+
 use crate::{
     ast::{nodes::Expression, statements::TypeAnnotation},
     checker::structs::{CheckType, TypeChecker},

--- a/src/checker/operators/mod.rs
+++ b/src/checker/operators/mod.rs
@@ -1,10 +1,12 @@
+//! Operator type-checking - binary, unary, and index-assign.
+
 mod binary;
 mod index_assign;
 mod unary;
 
 use crate::lexer::tokentypes::TokenType;
 
-// returns the operand as str
+/// Returns the display string for a binary operator token, used in error messages.
 pub fn op_str(op: &TokenType) -> &'static str {
     match op {
         TokenType::Plus => "+",

--- a/src/checker/operators/unary.rs
+++ b/src/checker/operators/unary.rs
@@ -1,3 +1,11 @@
+//! Unary operator type checking.
+//!
+//! | Operator | Operand         | Result |
+//! |----------|-----------------|--------|
+//! | `!`      | bool            | bool   |
+//! | `-`      | int / byte      | int    |
+//! | `-`      | float           | float  |
+
 use crate::{
     ast::statements::TypeAnnotation,
     checker::structs::{CheckType, TypeChecker},

--- a/src/checker/scope/assign.rs
+++ b/src/checker/scope/assign.rs
@@ -1,3 +1,5 @@
+//! Assignment type checking - validates reassignment against the declared type.
+
 use crate::{
     ast::statements::TypeAnnotation,
     checker::structs::{CheckType, TypeChecker},
@@ -5,12 +7,12 @@ use crate::{
 };
 
 impl TypeChecker {
-    // search for variable name via loop thru the scopes
-    // and if it is found then checks
-    // if constant add error to const_error
-    // if variable but type mismatch add error to type_error
-    // then break the loop and push the error
-    // if not found pushs undefined variable error
+    /// Checks that assigning `value_type` to `name` is valid.
+    ///
+    /// Walks scopes from innermost to outermost. Emits an error if:
+    /// - The variable is declared `const`
+    /// - The value type doesn't match the declared type (with `byte` -> `int` widening)
+    /// - The name is not declared in any scope (with a "did you mean?" suggestion)
     pub fn assign(&mut self, name: &str, value_type: CheckType, span: Span) {
         let mut const_error: Option<String> = None;
         let mut type_error: Option<String> = None;

--- a/src/checker/scope/call.rs
+++ b/src/checker/scope/call.rs
@@ -1,3 +1,5 @@
+//! Function call type checking - path resolution and argument validation.
+
 use crate::{
     ast::statements::TypeAnnotation,
     checker::structs::{CheckType, TypeChecker},
@@ -6,7 +8,16 @@ use crate::{
 };
 
 impl TypeChecker {
-    // is it callable path?
+    /// Resolves a call path and checks argument types.
+    ///
+    /// Resolution order:
+    /// 1. Full stdlib path (`std::io::print`) via [`root_module`]
+    /// 2. Single-name stdlib shorthand (`print`) via [`stdlib_fn_names`]
+    /// 3. User-defined name via [`lookup`]
+    /// 4. Error - unknown function, with a "did you mean?" suggestion from stdlib keywords
+    ///
+    /// Stdlib calls always return [`CheckType::Unknown`] since their return
+    /// types are not tracked statically.
     pub fn check_call_path(
         &mut self,
         path: &[String],
@@ -55,7 +66,12 @@ impl TypeChecker {
         CheckType::Unknown
     }
 
-    // is it callable?
+    /// Checks that a resolved callee value is callable and receives the correct arguments.
+    ///
+    /// - `Unknown` and `Known(Fn)` pass through without argument checking
+    /// - `Function { params, return_type }` validates arity and argument types,
+    ///   then returns `Known(return_type)`
+    /// - Anything else emits a "not callable" error
     pub fn check_call_value(
         &mut self,
         callee_type: CheckType,

--- a/src/checker/scope/declare.rs
+++ b/src/checker/scope/declare.rs
@@ -1,12 +1,16 @@
+//! Variable and constant declaration for the type checker scope.
+
 use crate::{
     checker::structs::{CheckType, ScopeItem, TypeChecker},
     utils::span::Span,
 };
 
 impl TypeChecker {
-    // checks if is it declared constant or variable
-    // if consant and was declared push error if not then add the constant to the last scope
-    // otherwise add the the last scope the new variable
+    /// Declares `name` in the current (innermost) scope.
+    ///
+    /// For constants, emits an error if the name is already declared in the
+    /// same scope. On success, pushes a hover entry showing the kind, name,
+    /// and type.
     pub fn declare(&mut self, name: String, item_type: CheckType, is_const: bool, span: Span) {
         if let Some(scope) = self.scopes.last_mut() {
             if is_const && scope.contains_key(&name) {

--- a/src/checker/scope/mod.rs
+++ b/src/checker/scope/mod.rs
@@ -1,3 +1,5 @@
+//! Scope management and name lookup for the type checker.
+
 mod assign;
 mod call;
 mod declare;
@@ -9,15 +11,20 @@ use crate::{
 use std::collections::HashMap;
 
 impl TypeChecker {
-    // adds or removes scope from/to TypeChecker scopes
+    /// Pushes a new empty scope onto the scope stack.
     pub fn push_scope(&mut self) {
         self.scopes.push(HashMap::new());
     }
+    /// Pops the innermost scope from the stack.
     pub fn pop_scope(&mut self) {
         self.scopes.pop();
     }
 
-    // checks current scope for the said identifier
+    /// Looks up `name` in all scopes from innermost to outermost.
+    ///
+    /// On success, pushes a hover entry with the variable's type and kind,
+    /// then returns the [`CheckType`]. On failure, emits an undefined variable
+    /// error with a "did you mean?" suggestion and returns [`CheckType::Unknown`].
     pub fn lookup(&mut self, name: &str, span: Span) -> CheckType {
         let found = self.scopes.iter().rev().find_map(|scope| {
             scope

--- a/src/checker/statements/expression.rs
+++ b/src/checker/statements/expression.rs
@@ -1,3 +1,6 @@
+//! Expression type checking - walks every [`ExpressionKind`] variant and
+//! returns the static [`CheckType`] of the expression.
+
 use crate::{
     ast::{
         nodes::{Expression, ExpressionKind},

--- a/src/checker/statements/mod.rs
+++ b/src/checker/statements/mod.rs
@@ -1,3 +1,5 @@
+//! Statement-level helpers shared between expression and statement checking.
+
 mod expression;
 mod statement;
 
@@ -8,13 +10,15 @@ use crate::{
 };
 
 impl TypeChecker {
-    // functions for lambdas and functions to track return type
+    /// Returns the expected return type of the current function or lambda, if any.
     pub fn current_return_type(&self) -> Option<&TypeAnnotation> {
         self.return_type_stack.last()
     }
+    /// Pushes `ty` as the expected return type when entering a function or lambda body.
     pub fn push_return_type(&mut self, ty: TypeAnnotation) {
         self.return_type_stack.push(ty);
     }
+    /// Pops the expected return type when exiting a function or lambda body.
     pub fn pop_return_type(&mut self) {
         self.return_type_stack.pop();
     }
@@ -29,6 +33,7 @@ impl TypeChecker {
     pub fn exit_loop(&mut self) {
         self.loop_depth = self.loop_depth.saturating_sub(1);
     }
+    /// Checks all statements in `statements` inside a fresh scope.
     pub fn check_block(&mut self, statements: &[crate::ast::statements::Statement]) {
         self.push_scope();
         for stmt in statements {
@@ -37,7 +42,9 @@ impl TypeChecker {
         self.pop_scope();
     }
 
-    // checks weather the item has known type or not
+    /// Emits a `"value is null"` error if `item_type` is [`CheckType::Known(Null)`].
+    ///
+    /// Returns `false` if null, `true` otherwise.
     pub fn check_is_null(&mut self, item_type: &CheckType, span: Span) -> bool {
         if item_type.is_null() {
             self.error("value is null", span);
@@ -47,8 +54,7 @@ impl TypeChecker {
         }
     }
 
-    // transforms CheckType to TypeAnnotation
-    // skips unknown types and assigns Null to them
+    /// Converts a [`CheckType`] to a [`TypeAnnotation`], mapping `Unknown` to `Null`.
     pub(crate) fn to_type_annotation(item_type: &CheckType) -> TypeAnnotation {
         match item_type {
             CheckType::Known(t) => t.clone(),

--- a/src/checker/statements/statement.rs
+++ b/src/checker/statements/statement.rs
@@ -1,3 +1,6 @@
+//! Statement type checking - walks every [`StatementKind`] variant,
+//! declares names into scope, and validates control flow constraints.
+
 use crate::{
     ast::statements::{StatementKind, TypeAnnotation},
     checker::structs::{CheckType, TypeChecker},

--- a/src/checker/structs.rs
+++ b/src/checker/structs.rs
@@ -1,3 +1,5 @@
+//! Core data structures for the type checker.
+//!
 use std::collections::HashMap;
 
 use crate::{
@@ -6,42 +8,46 @@ use crate::{
     utils::{errors::Error, source::SourceFile, span::Span},
 };
 
+/// The stateful type checker, threaded through the entire AST walk.
 pub struct TypeChecker {
-    // list of scopes
+    /// Stack of scopes, each mapping variable/function names to their [`ScopeItem`].
     pub scopes: Vec<HashMap<String, ScopeItem>>,
-    // source file if exists for ariadne
+    /// Source file attached for Ariadne error rendering; `None` in LSP-less contexts.
     pub source_file: Option<SourceFile>,
-    // for the stdlib modules to populate the stdlib functions name
+    /// The stdlib module tree, used to resolve stdlib call paths.
     pub root_module: Module,
-    // all errors found in same file
+    /// All type errors accumulated during the check pass.
     pub errors: Vec<Error>,
-    // for lambdas and functions to check what type should be returned
+    /// Stack of expected return types, pushed/popped on function and lambda entry/exit.
     pub return_type_stack: Vec<TypeAnnotation>,
-    // for loops to know what level of depth in loop the checker at
+    /// Nesting depth of loops - used to validate `break` and `continue`.
     pub loop_depth: u32,
-    // functions name to use in check_call_path
+    /// Flat set of all stdlib function names for fast single-name lookup.
     pub stdlib_fn_names: std::collections::HashSet<String>,
-    // (span, markdown text) pairs collected while checking
-    // one per declaration or usage site
+    /// `(span, markdown)` pairs collected at every declaration and usage site,
+    /// consumed by the LSP hover provider.
     pub hovers: Vec<(Span, String)>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// A single entry in a type checker scope.
 pub struct ScopeItem {
-    // item type
+    /// The static type of this variable or function.
     pub type_annotation: CheckType,
-    // weather is it a constant or variable
+    /// Whether this binding is immutable (`CONST`).
     pub is_const: bool,
 }
 
+/// The type of a value as seen by the static checker.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CheckType {
-    // types that can be known during checks
+    /// A fully resolved type (e.g. `int`, `arr[string]`).
     Known(TypeAnnotation),
+    /// A function type with known parameter and return types.
     Function {
         params: Vec<TypeAnnotation>,
         return_type: TypeAnnotation,
     },
-    // types that cannot be known during checks
+    /// Type could not be determined statically (stdlib calls, unresolved names).
+    /// Propagates silently to avoid cascading false errors.
     Unknown,
 }

--- a/src/checker/types.rs
+++ b/src/checker/types.rs
@@ -1,3 +1,5 @@
+//! Helper methods on [`CheckType`] and [`ScopeItem`], plus private type-matching utilities.
+
 use crate::{
     ast::statements::TypeAnnotation,
     checker::structs::{CheckType, ScopeItem},
@@ -14,22 +16,22 @@ impl ScopeItem {
 
 // helper functions for CheckType
 impl CheckType {
-    /// returns [`CheckType::Known(type)`] if the item type can be determinated while being checked
+    /// Constructs a [`CheckType::Known`] from a [`TypeAnnotation`].
     pub fn known(ty: TypeAnnotation) -> Self {
         CheckType::Known(ty)
     }
 
-    /// returns true if the item type is [`TypeAnnotation::null`]
+    /// Returns `true` if this type is [`TypeAnnotation::Null`].
     pub fn is_null(&self) -> bool {
         matches!(self, CheckType::Known(TypeAnnotation::Null))
     }
 
-    /// returns [`CheckType::Unknown`] for items type that cannot be determinated while being checked
+    /// Returns `true` if this type is [`CheckType::Unknown`].
     pub fn is_unknown(&self) -> bool {
         matches!(self, CheckType::Unknown)
     }
 
-    /// converts the [`CheckType::Known`] variable variant to constant variant
+    /// Converts a mutable `Known` type to its `const` variant (e.g. `Int` -> `CInt`).
     pub fn into_const(self) -> Self {
         match self {
             CheckType::Known(ty) => CheckType::Known(const_variant(ty)),
@@ -37,7 +39,14 @@ impl CheckType {
         }
     }
 
-    /// returns [`bool`] weather true or false if the conditions for matching met
+    /// Returns `true` if `self` is compatible with `expected`.
+    ///
+    /// Compatibility rules:
+    /// - Either side being `Unknown` always matches (avoids cascading errors)
+    /// - `Null` matches anything (represents the absence of a value)
+    /// - `Function { .. }` matches `Known(Fn)` and vice versa
+    /// - Two `Function` types match only if params and return type are identical
+    /// - Two `Known` types match if equal, or via [`null_array_elision`] or [`const_matches`]
     pub fn matches(&self, expected: &CheckType) -> bool {
         match (self, expected) {
             // if any side is [`CheckType::Unknown`] returns true
@@ -72,7 +81,7 @@ impl CheckType {
         }
     }
 
-    /// returns string value of the current item descriptions
+    /// Returns a human-readable description of this type for error messages.
     pub fn info(&self) -> String {
         match self {
             CheckType::Known(ty) => format!("{:?}", ty),
@@ -93,8 +102,8 @@ impl CheckType {
     }
 }
 
-/// matches mutable arrays and immmutables arrays both sides should match to return true
-/// otherwise false
+/// Returns `true` if two array types are compatible when either inner type is `Null`
+/// (i.e. an empty array `[]` is compatible with any typed array).
 fn null_array_elision(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {
     match (a, b) {
         (
@@ -105,7 +114,7 @@ fn null_array_elision(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {
     }
 }
 
-/// transforms the mutable [`TypeAnnotation`] to its immutable version
+/// Converts a mutable [`TypeAnnotation`] to its immutable (`C`-prefixed) variant.
 fn const_variant(ty: TypeAnnotation) -> TypeAnnotation {
     match ty {
         TypeAnnotation::Int => TypeAnnotation::CInt,
@@ -119,7 +128,7 @@ fn const_variant(ty: TypeAnnotation) -> TypeAnnotation {
     }
 }
 
-/// compares two values (the immutable TypeAnnotation to its mutable value)
+/// Returns `true` if `a` is the const variant of `b` or vice versa (e.g. `CInt` <-> `Int`).
 fn const_matches(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {
     matches!(
         (a, b),

--- a/src/docs/entries/concepts/mod.rs
+++ b/src/docs/entries/concepts/mod.rs
@@ -1,3 +1,4 @@
+//! Language concept documentation entries (variables, types, loops, etc.).
 pub mod arrays;
 pub mod byte;
 pub mod constants;

--- a/src/docs/entries/mod.rs
+++ b/src/docs/entries/mod.rs
@@ -1,9 +1,12 @@
+//! Aggregates all documentation entries and exposes them as flat `Vec`s
+//! for the renderer functions in [`crate::docs`].
 use crate::docs::entry::{ConceptEntry, StdEntry};
 
 mod concepts;
 mod stdlib;
 mod tutorial;
 
+/// Returns all stdlib module entries in display order.
 pub fn stdlib_entries() -> Vec<&'static StdEntry> {
     vec![
         &stdlib::math::MATH,
@@ -20,6 +23,7 @@ pub fn stdlib_entries() -> Vec<&'static StdEntry> {
     ]
 }
 
+/// Returns all language concept entries in display order.
 pub fn concept_entries() -> Vec<&'static ConceptEntry> {
     vec![
         &concepts::arrays::ARRAYS,
@@ -40,6 +44,7 @@ pub fn concept_entries() -> Vec<&'static ConceptEntry> {
     ]
 }
 
+/// Returns all tutorial step entries in display order.
 pub fn tutorial_entries() -> Vec<&'static ConceptEntry> {
     vec![
         &tutorial::STEP_FIRST_PROGRAM,

--- a/src/docs/entries/stdlib/mod.rs
+++ b/src/docs/entries/stdlib/mod.rs
@@ -1,3 +1,4 @@
+//! Standard library documentation entries, one module per file.
 pub mod arrays;
 pub mod constants;
 pub mod fs;

--- a/src/docs/entries/tutorial/mod.rs
+++ b/src/docs/entries/tutorial/mod.rs
@@ -1,3 +1,4 @@
+//! Tutorial documentation entries (beginner, advanced, etc.).
 use crate::docs::entry::{ConceptEntry, DescriptionEntry};
 
 pub static STEP_FIRST_PROGRAM: ConceptEntry = ConceptEntry {

--- a/src/docs/entry.rs
+++ b/src/docs/entry.rs
@@ -1,40 +1,43 @@
-// function entry that contains signature (for example `pop(arr)`)
-// and description of what said function can and cannot do
-// and usage example in `rl`
+//! Static data types used to represent all documentation entries.
+//!
+//! Every entry is a `'static` struct so the entire doc system lives in the
+//! binary with zero heap allocation at startup.
+
+/// A single stdlib function's documentation.
 pub struct FnEntry {
-    // what function look like
+    /// The function signature as it appears in rl (e.g. `"arr_push(arr, value)"`).
     pub signature: &'static str,
-    // what function can do and use cases
+    /// What the function does, including edge cases and constraints.
     pub description: &'static str,
-    // how to use it in `rl`
+    /// A runnable rl example showing typical usage.
     pub example: &'static str,
 }
 
-// std entry that contains std name and description about it
-// and has functions entry
+/// A stdlib module's documentation, grouping related [`FnEntry`]s together.
 pub struct StdEntry {
-    // what is the std entry called
+    /// The module name as used in imports (e.g. `"io"`, `"math::consts"`).
     pub name: &'static str,
-    // what is the std entry used for
+    /// A short description of the module's purpose.
     pub description: &'static str,
-    // std functions
+    /// All documented functions in this module.
     pub functions: &'static [&'static FnEntry],
 }
 
-// entry for explaining concepts of `rl` like variables
-// each concept entry can have multiple discriptions and each
-// discription can have multiple example
+/// Documentation for a language concept (variables, loops, types, etc.).
+///
+/// Each concept has one or more [`DescriptionEntry`]s, each of which
+/// pairs a prose explanation with one or more runnable rl examples.
 pub struct ConceptEntry {
-    // concept name
+    /// The concept name shown as a section header (e.g. `"arrays"`, `"for loops"`).
     pub name: &'static str,
-    // descriptions about the concept (description and one or multiple examples)
+    /// One or more description+example pairs explaining this concept.
     pub descriptions: &'static [DescriptionEntry],
 }
 
-// entry for descriptions
-// one entry can have multiple examples
-// useful for diffrent approach examples
+/// A single description with one or more accompanying rl code examples.
 pub struct DescriptionEntry {
+    /// Prose explanation of this aspect of the concept.
     pub description: &'static str,
+    /// One or more rl snippets illustrating the description.
     pub examples: &'static [&'static str],
 }

--- a/src/docs/mod.rs
+++ b/src/docs/mod.rs
@@ -1,9 +1,25 @@
+//! In-process documentation system for the `rl docs` CLI command.
+//!
+//! Stores all language reference material as static data compiled into the binary -
+//! no external files needed at runtime. Organized into three categories:
+//!
+//! - **stdlib** - [`StdEntry`] / [`FnEntry`] for every stdlib module and function
+//! - **concepts** - [`ConceptEntry`] for language features (types, loops, imports, etc.)
+//! - **tutorials** - [`ConceptEntry`] steps for the beginner and advanced tutorials
+//!
+//! The [`std_to_markdown`], [`concept_to_markdown`], and [`tutorial_to_markdown`]
+//! functions render these entries into Markdown for display in the terminal.
+
 pub mod entries;
 pub mod entry;
 use crate::docs::entry::{ConceptEntry, FnEntry, StdEntry};
 
-// finds the FnEntry whose signature starts with `fn_name(`
-// can accept std::io::print() and print()
+/// Searches all stdlib entries for a function whose signature starts with `fn_name(`.
+///
+/// `module` narrows the search to a specific stdlib module (e.g. `"io"`, `"math"`).
+/// Accepts both bare names (`print`) and qualified names (`std::io::print`).
+///
+/// Returns `None` if no match is found.
 pub fn find_fn_doc(
     module: Option<&str>,
     fn_name: &str,
@@ -24,9 +40,19 @@ pub fn find_fn_doc(
     None
 }
 
-// helper functions that transform docs into readable mark down
+/// Renders all stdlib entries into a Markdown reference document.
+///
+/// Output is structured as:
+/// ```text
+/// # rl stdlib reference
+/// ## std::<module>
+/// ### `<signature>`
+/// <description>
+/// ```rl
+/// <example>
+/// ```
+/// ```
 pub fn std_to_markdown(entries: &[&StdEntry]) -> String {
-    // markdown header
     let mut output = String::from("# rl stdlib reference\n\n");
     for entry in entries {
         output.push_str(&format!("## std::{}\n\n", entry.name));
@@ -41,7 +67,7 @@ pub fn std_to_markdown(entries: &[&StdEntry]) -> String {
     output
 }
 
-// shared renderer for any list of ConceptEntry under a custom header
+/// shared renderer for any list of ConceptEntry under a custom header
 fn entries_to_markdown(header: &str, entries: &[&ConceptEntry]) -> String {
     let mut output = format!("# {}\n\n", header);
     for entry in entries {
@@ -56,12 +82,12 @@ fn entries_to_markdown(header: &str, entries: &[&ConceptEntry]) -> String {
     output
 }
 
-// returns concept with the example provided
+/// Renders concept entries into a Markdown language reference document.
 pub fn concept_to_markdown(entries: &[&ConceptEntry]) -> String {
     entries_to_markdown("rl concepts reference", entries)
 }
 
-// returns the tutorial, step by step, same format as concepts
+/// Renders tutorial entries into a Markdown step-by-step tutorial document.
 pub fn tutorial_to_markdown(entries: &[&ConceptEntry]) -> String {
     entries_to_markdown("rl tutorial", entries)
 }

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -1,3 +1,5 @@
+//! Core evaluator - expression evaluation, function calls, and the runtime state.
+
 use std::sync::Arc;
 
 use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
@@ -20,28 +22,45 @@ use crate::{
     },
 };
 
+/// A slot in the environment - holds a value, its declared type, and mutability.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PItem {
+    /// The runtime value stored in this slot.
     pub value: Value,
+    /// The declared type of this slot, used for assignment type checking.
     pub type_annotation: TypeAnnotation,
+    /// Whether this slot is immutable (`CONST`).
     pub is_const: bool,
 }
 
+/// A single environment entry. Currently only [`PItem`] exists;
+/// the enum wrapper leaves room for future variants (e.g. closures, records).
 #[derive(Debug, Clone, PartialEq)]
 pub enum EnvironmentItem {
     PItem(PItem),
 }
 
+/// The tree-walking interpreter, carrying all runtime state.
 pub struct Evaluator {
+    /// The environment stack - each frame is a scope; innermost is last.
     pub environment: Vec<Vec<EnvironmentItem>>,
+    /// Source file for Ariadne error rendering; `None` in embedded/test contexts.
     pub source_file: Option<SourceFile>,
+    /// The stdlib module tree, used for resolving `std::*` calls.
     pub root_module: Module,
+    /// Set by a `return` statement; cleared when the enclosing function call collects it.
     pub return_value: Option<Value>,
+    /// Set by `break`; cleared by the enclosing loop after it exits.
     pub is_breaking: bool,
+    /// Set by `continue`; cleared by the enclosing loop at the top of the next iteration.
     pub is_continuing: bool,
+    /// When `Some`, `print`/`println` write here instead of stdout (used by the LSP and REPL).
     pub output_buffer: Option<String>,
+    /// The Xoshiro256** PRNG instance shared across all `std::random` calls.
     pub rng: Xoshiro256,
+    /// The resolver, kept alive so import statements can resolve newly loaded files inline.
     pub resolver: Resolver,
+    /// Maps top-level function names to their environment slot for `call_path` shortcut.
     pub fn_names: std::collections::HashMap<String, usize>,
 }
 
@@ -67,20 +86,24 @@ impl Evaluator {
         }
     }
 
+    /// Attaches a source file for error rendering.
     pub fn with_source_file(mut self, file: SourceFile) -> Self {
         self.source_file = Some(file);
         self
     }
 
+    /// Attaches a source file for error rendering (mutable reference variant).
     pub fn set_source_file(&mut self, file: SourceFile) {
         self.source_file = Some(file);
     }
 
+    /// Registers a [`Module`] as a submodule of the root module.
     pub fn with_module(mut self, m: Module) -> Self {
         self.root_module.submodules.insert(m.name.clone(), m);
         self
     }
 
+    /// Registers a typed Rust function directly on the root module.
     pub fn with_function<F, A>(mut self, name: impl Into<String>, f: F) -> Self
     where
         F: IntoNativeFn<A>,
@@ -91,6 +114,7 @@ impl Evaluator {
         self
     }
 
+    /// Loads the full stdlib into the root module under `std::*`.
     pub fn with_stdlib(self) -> Self {
         self.with_module(
             Module::new("std")
@@ -117,7 +141,10 @@ impl Evaluator {
         }
     }
 
-    /// Infer the [`TypeAnnotation`] of a runtime [`Value`].
+    /// Infers the [`TypeAnnotation`] of a runtime [`Value`].
+    ///
+    /// For arrays, uses the type of the first element; empty arrays infer `Null`.
+    /// `is_const` controls whether the result is the mutable or const variant.
     pub fn infer_type(value: &Value, is_const: bool) -> TypeAnnotation {
         match value {
             Value::Integer(_) => {
@@ -178,11 +205,18 @@ impl Evaluator {
         }
     }
 
+    /// Returns `true` if `value`'s inferred type is compatible with `expected`.
     pub fn value_compatible(value: &Value, expected: &TypeAnnotation) -> bool {
         let actual = Self::infer_type(value, false);
         Self::types_compatible(&actual, expected)
     }
 
+    /// Returns `true` if `actual` and `expected` types are assignment-compatible.
+    ///
+    /// Compatibility rules (beyond equality):
+    /// - `Null` is compatible with anything
+    /// - `Byte` widens to `Int` / `CInt`
+    /// - Arrays are compatible if their element types are compatible (recursive)
     pub fn types_compatible(actual: &TypeAnnotation, expected: &TypeAnnotation) -> bool {
         if actual == expected {
             return true;
@@ -206,6 +240,8 @@ impl Evaluator {
         }
     }
 
+    /// Recursively coerces `value` to match `expected`, primarily widening
+    /// `Byte` elements to `Int` inside arrays when the declared element type is `Int`.
     pub fn coerce_array_type(value: Value, expected: &TypeAnnotation) -> Value {
         match (value, expected) {
             (Value::Values { items, .. }, expected) => {
@@ -419,6 +455,10 @@ impl Evaluator {
         Ok(value)
     }
 
+    /// Calls a [`Value::Function`], setting up the captured environment, inserting
+    /// arguments into a new scope, running the body, and validating the return type.
+    ///
+    /// Global scope mutations made inside the call are propagated back to the caller.
     pub fn call_value(
         &mut self,
         func: Value,
@@ -493,6 +533,13 @@ impl Evaluator {
         Err(self.err("value is not callable", span))
     }
 
+    /// Resolves a call path and dispatches to either a stdlib [`NativeFn`] or a
+    /// user-defined function looked up via [`fn_names`].
+    ///
+    /// Resolution order:
+    /// 1. Full stdlib path via [`root_module.resolve`]
+    /// 2. Single-name shorthand via [`fn_names`]
+    /// 3. Error with "did you mean?" suggestion from stdlib keywords
     pub fn call_path(
         &mut self,
         path: &[String],

--- a/src/interpreter/evaluator_types/index_assign.rs
+++ b/src/interpreter/evaluator_types/index_assign.rs
@@ -1,3 +1,12 @@
+//! Index-assign evaluation (`arr[i] = value`, including nested `arr[i][j] = value`).
+//!
+//! Uses two recursive helpers:
+//! - `get_root_addr` - walks the chain of `Index` nodes to find the root `ResolvedIdentifier`
+//! - `get_indices_as_vec` - evaluates all intermediate indices into a `Vec<usize>`
+//!
+//! The final index is appended, then the function traverses into the nested `Value::Values`
+//! structure mutably to perform the assignment, enforcing type compatibility and bounds.
+
 use crate::{
     ast::{
         nodes::{Expression, ExpressionKind},

--- a/src/interpreter/evaluator_types/mod.rs
+++ b/src/interpreter/evaluator_types/mod.rs
@@ -1,1 +1,3 @@
+//! Extra expression evaluation helpers that live outside the main `evaluator.rs`
+//! to keep it from becoming too large.
 mod index_assign;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,3 +1,23 @@
+//! The rl tree-walking interpreter.
+//!
+//! # Pipeline
+//!
+//! ```text
+//! source text
+//!   └─ Tokenizer::lex()       → Vec<Token>
+//!   └─ Parser::parse()        → Vec<Statement>
+//!   └─ Resolver::resolve()    → Vec<Statement>  (names → depth/slot)
+//!   └─ Evaluator::evaluate_program() → ()
+//! ```
+//!
+//! # Modules
+//!
+//! - [`evaluator`] - the core [`Evaluator`] struct and expression evaluation
+//! - [`values`] - the [`Value`] enum representing all runtime values
+//! - [`native`] - [`Module`], [`NativeFn`], and the trait system for binding Rust functions
+//! - [`scopes`] - environment stack: push/pop/insert/assign/get
+//! - [`stdlib`] - all built-in stdlib modules
+//! - [`utils`] - binary/unary operator dispatch and statement evaluation
 pub mod evaluator;
 mod evaluator_types;
 pub mod native;

--- a/src/interpreter/native.rs
+++ b/src/interpreter/native.rs
@@ -1,3 +1,26 @@
+//! The native function binding system - [`Module`], [`NativeFn`], and the
+//! [`IntoNativeFn`] / [`FromValue`] / [`IntoValue`] trait machinery.
+//!
+//! # How it works
+//!
+//! Stdlib functions are plain Rust functions. The [`IntoNativeFn`] trait
+//! (implemented by a macro for up to 10 arguments) wraps them into [`NativeFn`]
+//! closures that handle arity checking and argument extraction automatically.
+//!
+//! Two variants exist:
+//! - **Infallible** (`IntoNativeFn<(A1, A2, ...)>`) - for functions that return `R: IntoValue`
+//! - **Fallible** (`IntoNativeFn<(Fallible<(A1, A2, ...)>,)>`) - for functions returning `Result<R, Error>`
+//! - **Spanned** (`IntoNativeFn<(Spanned<(A1, A2, ...)>,)>`) - fallible functions that also receive the call [`Span`]
+//!
+//! # Example
+//!
+//! ```rust
+//! use rl_lang::interpreter::{evaluator::Evaluator, native::Module};
+//!
+//! fn my_fn(_: &mut Evaluator, x: i64, y: i64) -> i64 { x + y }
+//! Module::new("math").with_function("add", my_fn);
+//! ```
+
 use crate::ast::statements::TypeAnnotation;
 use crate::interpreter::evaluator::Evaluator;
 use crate::interpreter::values::Value;
@@ -5,11 +28,18 @@ use crate::utils::errors::{Error, Reason};
 use crate::utils::span::Span;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+/// A thread-safe, heap-allocated native function callable from rl.
 pub type NativeFn =
     Arc<dyn Fn(&mut Evaluator, Vec<Value>, Span) -> Result<Value, Error> + Send + Sync>;
+
+/// A named collection of [`NativeFn`]s, optionally containing sub-[`Module`]s.
 pub struct Module {
+    /// The module name as used in import paths (e.g. `"io"`, `"math"`).
     pub name: String,
+    /// Named functions registered in this module.
     pub functions: HashMap<String, NativeFn>,
+    /// Named submodules (e.g. `math::consts`).
     pub submodules: HashMap<String, Module>,
 }
 
@@ -22,6 +52,7 @@ impl Module {
         }
     }
 
+    /// Registers a typed Rust function using the [`IntoNativeFn`] trait.
     pub fn with_function<F, A>(mut self, name: impl Into<String>, f: F) -> Self
     where
         F: IntoNativeFn<A>,
@@ -30,6 +61,8 @@ impl Module {
         self
     }
 
+    /// Registers a raw `fn(&mut Evaluator, Vec<Value>, Span) -> Result<Value, Error>` directly,
+    /// bypassing the [`IntoNativeFn`] machinery (used for variadic functions like `print`).
     pub fn with_raw_function<F>(mut self, name: impl Into<String>, f: F) -> Self
     where
         F: Fn(&mut Evaluator, Vec<Value>, Span) -> Result<Value, Error> + Send + Sync + 'static,
@@ -38,11 +71,14 @@ impl Module {
         self
     }
 
+    /// Registers a submodule.
     pub fn with_module(mut self, m: Module) -> Self {
         self.submodules.insert(m.name.clone(), m);
         self
     }
 
+    /// Walks the module tree along `path`, returning the [`NativeFn`] at the leaf,
+    /// or `None` if any segment is missing.
     pub fn resolve(&self, path: &[String]) -> Option<&NativeFn> {
         if path.is_empty() {
             return None;
@@ -55,6 +91,8 @@ impl Module {
     }
 }
 
+/// Extracts the static [`TypeAnnotation`] for a Rust type.
+/// Used by [`IntoValue`] for `Vec<T>` to set the array's `items_type`.
 pub trait ValueType {
     fn type_annotation() -> TypeAnnotation;
 }
@@ -95,6 +133,8 @@ impl<T: ValueType> ValueType for Vec<T> {
     }
 }
 
+/// Converts a [`Value`] into a typed Rust value, or returns a runtime error.
+/// Implemented for `i64`, `f64`, `String`, `bool`, `char`, `Vec<T>`, and `Value` itself.
 pub trait FromValue: Sized {
     fn from_value(v: Value, span: Span) -> Result<Self, Error>;
 }
@@ -187,6 +227,8 @@ impl<T: FromValue> FromValue for Vec<T> {
     }
 }
 
+/// Converts a typed Rust value into a [`Value`].
+/// Implemented for `()` (→ `Null`), `i64`, `f64`, `String`, `bool`, `char`, `Vec<T>`, and `Value`.
 pub trait IntoValue {
     fn into_value(self) -> Value;
 }
@@ -242,6 +284,8 @@ impl<T: IntoValue + ValueType> IntoValue for Vec<T> {
     }
 }
 
+/// Wraps a typed Rust function into a [`NativeFn`] with automatic arity checking
+/// and argument extraction. Implemented by macro for 0–10 arguments.
 pub trait IntoNativeFn<Args> {
     fn into_native(self) -> NativeFn;
 }
@@ -267,6 +311,7 @@ where
     }
 }
 
+/// Marker type for fallible native functions (returning `Result<R, Error>`).
 pub struct Fallible<T>(std::marker::PhantomData<T>);
 
 macro_rules! impl_into_native_fn {
@@ -375,6 +420,7 @@ impl_into_native_fn!(
     (A10, a10)
 );
 
+/// Marker type for spanned fallible native functions (also receiving the call [`Span`]).
 pub struct Spanned<T>(std::marker::PhantomData<T>);
 
 macro_rules! impl_into_native_fn_spanned {

--- a/src/interpreter/scopes.rs
+++ b/src/interpreter/scopes.rs
@@ -1,3 +1,9 @@
+//! Environment stack operations - scope management and slot-indexed value access.
+//!
+//! The environment is a `Vec<Vec<EnvironmentItem>>` - a stack of frames.
+//! Each frame is a flat vec of slots indexed by the resolver's slot numbers.
+//! Depth 0 = current frame, depth 1 = one scope up, etc.
+
 use crate::{
     ast::statements::TypeAnnotation,
     interpreter::{
@@ -8,10 +14,12 @@ use crate::{
 };
 
 impl Evaluator {
+    /// Pushes a new empty scope frame onto the environment stack.
     pub fn push_scope(&mut self) {
         self.environment.push(vec![]);
     }
 
+    /// Pops the innermost scope frame.
     pub fn pop_scope(&mut self) {
         self.environment.pop();
     }
@@ -29,6 +37,9 @@ impl Evaluator {
         frame[slot] = item;
     }
 
+    /// Reads the value at `(depth, slot)` in the environment.
+    ///
+    /// `depth` counts from the innermost frame outward (0 = current).
     pub fn get_value(&self, depth: usize, slot: usize, span: Span) -> Result<Value, Error> {
         let idx = self.environment.len().saturating_sub(1 + depth);
         match self.environment.get(idx).and_then(|f| f.get(slot)) {
@@ -37,6 +48,9 @@ impl Evaluator {
         }
     }
 
+    /// Inserts a mutable value at `slot` in the current (innermost) frame.
+    ///
+    /// Grows the frame with `Null` placeholders if `slot` is past the end.
     pub fn insert_value(
         &mut self,
         slot: usize,
@@ -58,6 +72,9 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Inserts an immutable (const) value at `slot` in the current frame.
+    ///
+    /// Returns an error if the slot already holds a const.
     pub fn insert_const(
         &mut self,
         slot: usize,
@@ -84,6 +101,7 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Overwrites the value at `(depth, slot)`, enforcing type compatibility and immutability.
     pub fn assign_value(
         &mut self,
         depth: usize,
@@ -132,7 +150,7 @@ impl Evaluator {
         }
     }
 
-    // tests only
+    /// Looks up a variable by name via the resolver - used only in tests.
     pub fn get_value_raw(&self, name: &str) -> Option<Value> {
         let (depth, slot) = self.resolver.resolve_name(name)?;
         let idx = self.environment.len().saturating_sub(1 + depth);
@@ -141,6 +159,7 @@ impl Evaluator {
         }
     }
 
+    /// Returns the declared [`TypeAnnotation`] of the slot at `(depth, slot)`, if it exists.
     pub fn get_declared_type(&self, depth: usize, slot: usize) -> Option<TypeAnnotation> {
         let idx = self.environment.len().saturating_sub(1 + depth);
         match self.environment.get(idx)?.get(slot)? {

--- a/src/interpreter/stdlib/array/mod.rs
+++ b/src/interpreter/stdlib/array/mod.rs
@@ -1,3 +1,9 @@
+//! `std::array` - array manipulation functions.
+//!
+//! All functions operate on [`Value::Values`] and return errors for non-array inputs.
+//! Higher-order functions (`map`, `filter`, `reduce`, etc.) require a [`Value::Function`]
+//! with the correct return type annotation.
+
 use super::len;
 use crate::interpreter::native::Module;
 

--- a/src/interpreter/stdlib/bitwise/mod.rs
+++ b/src/interpreter/stdlib/bitwise/mod.rs
@@ -1,3 +1,7 @@
+//! `std::bitwise` - bitwise operations on `byte` and `int` values.
+//!
+//! Mixed `byte`/`int` operands widen to `int`. `bit_xor` requires matching types.
+
 pub mod bit_and;
 pub mod bit_not;
 pub mod bit_or;

--- a/src/interpreter/stdlib/fs/mod.rs
+++ b/src/interpreter/stdlib/fs/mod.rs
@@ -1,3 +1,8 @@
+//! `std::fs` - filesystem operations: create, remove, list, copy, move, and metadata.
+//!
+//! All errors include the path and the underlying OS error message.
+//! `temp_dir` uses `with_raw_function` since it takes no arguments.
+
 mod copy_file;
 mod file_modified;
 mod file_size;

--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -1,3 +1,11 @@
+//! `std::io` - input/output: reading from stdin, reading/writing files, printing.
+//!
+//! `print` and `println` write to [`Evaluator::output_buffer`] when set (LSP/REPL),
+//! otherwise they write directly to stdout.
+//!
+//! `eprint` raises a runtime error rather than writing to stderr, so errors
+//! surface through rl's normal error reporting pipeline.
+
 mod append_file;
 mod delete_file;
 mod eprint;

--- a/src/interpreter/stdlib/math/constants/mod.rs
+++ b/src/interpreter/stdlib/math/constants/mod.rs
@@ -1,28 +1,33 @@
-pub mod e;
-pub mod euler_gamma;
-pub mod frac_1_pi;
-pub mod frac_1_sqrt_2;
-pub mod frac_2_pi;
-pub mod frac_2_sqrt_pi;
-pub mod frac_pi_2;
-pub mod frac_pi_3;
-pub mod frac_pi_4;
-pub mod frac_pi_6;
-pub mod frac_pi_8;
-pub mod inf;
-pub mod is_inf;
-pub mod is_nan;
-pub mod ln_10;
-pub mod ln_2;
-pub mod log10_2;
-pub mod log10_e;
-pub mod log2_10;
-pub mod log2_e;
-pub mod nan;
-pub mod phi;
-pub mod pi;
-pub mod sqrt_2;
-pub mod tau;
+//! `std::math::consts` - mathematical constants from [`std::f64::consts`].
+//!
+//! All constants are zero-argument functions returning `f64`.
+//! Accessed as `std::math::consts::PI()` in rl.
+
+mod e;
+mod euler_gamma;
+mod frac_1_pi;
+mod frac_1_sqrt_2;
+mod frac_2_pi;
+mod frac_2_sqrt_pi;
+mod frac_pi_2;
+mod frac_pi_3;
+mod frac_pi_4;
+mod frac_pi_6;
+mod frac_pi_8;
+mod inf;
+mod is_inf;
+mod is_nan;
+mod ln_10;
+mod ln_2;
+mod log10_2;
+mod log10_e;
+mod log2_10;
+mod log2_e;
+mod nan;
+mod phi;
+mod pi;
+mod sqrt_2;
+mod tau;
 
 use crate::interpreter::native::Module;
 

--- a/src/interpreter/stdlib/math/mod.rs
+++ b/src/interpreter/stdlib/math/mod.rs
@@ -1,36 +1,42 @@
-pub mod abs;
-pub mod acos;
-pub mod asin;
-pub mod atan;
-pub mod atan2;
-pub mod ceil;
-pub mod clamp;
+//! `std::math` - mathematical functions and the `std::math::consts` submodule.
+//!
+//! Most functions accept both `int` and `float`; mixed types are handled per-function.
+//! `pow` uses `with_raw_function` to handle `(int, int)`, `(int, float)`, `(float, float)`,
+//! and `(float, int)` combinations manually.
+
+mod abs;
+mod acos;
+mod asin;
+mod atan;
+mod atan2;
+mod ceil;
+mod clamp;
 pub mod constants;
-pub mod cos;
-pub mod degrees;
-pub mod exp;
-pub mod factorial;
-pub mod fibonacci;
-pub mod floor;
-pub mod gcd;
-pub mod hypot;
-pub mod is_prime;
-pub mod lcm;
-pub mod lerp;
-pub mod log;
-pub mod log10;
-pub mod log2;
-pub mod map_range;
-pub mod max;
-pub mod min;
-pub mod modulo;
-pub mod power;
-pub mod radians;
-pub mod round;
-pub mod sign;
-pub mod sin;
-pub mod sqrt;
-pub mod tan;
+mod cos;
+mod degrees;
+mod exp;
+mod factorial;
+mod fibonacci;
+mod floor;
+mod gcd;
+mod hypot;
+mod is_prime;
+mod lcm;
+mod lerp;
+mod log;
+mod log10;
+mod log2;
+mod map_range;
+mod max;
+mod min;
+mod modulo;
+mod power;
+mod radians;
+mod round;
+mod sign;
+mod sin;
+mod sqrt;
+mod tan;
 
 use crate::interpreter::native::Module;
 

--- a/src/interpreter/stdlib/mod.rs
+++ b/src/interpreter/stdlib/mod.rs
@@ -1,5 +1,6 @@
-pub mod array;
+//! The rl standard library - all built-in modules registered under `std::*`.
 
+pub mod array;
 pub mod bitwise;
 pub mod fs;
 pub mod io;

--- a/src/interpreter/stdlib/path/mod.rs
+++ b/src/interpreter/stdlib/path/mod.rs
@@ -1,3 +1,9 @@
+//! `std::path` - path manipulation using [`std::path::PathBuf`].
+//!
+//! All functions take path strings and return strings or booleans.
+//! `path_pop` removes the last component (returns the shortened path).
+//! `path_push` appends a component (same as `path_join`).
+
 mod path_exists;
 mod path_extension;
 mod path_filename;

--- a/src/interpreter/stdlib/process/mod.rs
+++ b/src/interpreter/stdlib/process/mod.rs
@@ -1,3 +1,11 @@
+//! `std::process` - process management: args, env, cwd, exec, exit, pid, sleep.
+//!
+//! `exec` captures stdout and returns it as a string (trailing newline stripped).
+//! `exec_code` returns only the exit code as `int`.
+//! `exec_lines` returns stdout split into lines as `arr[string]`.
+//! Both `args` and `cwd` use `with_raw_function` since they take no rl arguments.
+//! `env` returns `null` (not an error) when the variable is not set.
+
 mod args;
 mod cwd;
 mod env;

--- a/src/interpreter/stdlib/random/mod.rs
+++ b/src/interpreter/stdlib/random/mod.rs
@@ -1,4 +1,7 @@
-pub mod xoshiro;
+//! `std::random` - random number generation using a custom Xoshiro256** PRNG.
+//!
+//! The PRNG state is stored on [`Evaluator::rng`] and seeded from the system clock
+//! at startup. All random functions share this single instance.
 
 mod rand_bool;
 mod rand_bool_weighted;
@@ -7,6 +10,7 @@ mod rand_float_range;
 mod rand_int;
 mod rand_int_range;
 mod random_general;
+pub mod xoshiro;
 
 use crate::interpreter::native::Module;
 

--- a/src/interpreter/stdlib/random/xoshiro.rs
+++ b/src/interpreter/stdlib/random/xoshiro.rs
@@ -1,4 +1,11 @@
+//! Xoshiro256** pseudo-random number generator.
+//!
+//! A fast, high-quality 256-bit state PRNG. Seeded from [`SystemTime`] at construction.
+//! The seed is spread across 4 `u64` state words using the finalizer from
+//! `splitmix64` (golden ratio + two mixing steps).
+
 pub struct Xoshiro256 {
+    /// The 256-bit PRNG state as four `u64` words.
     state: [u64; 4],
 }
 
@@ -30,6 +37,7 @@ impl Xoshiro256 {
         Self { state }
     }
 
+    /// Advances the state and returns the next raw `u64` output.
     fn next(&mut self) -> u64 {
         // compute result before scrambling the state
         let result = (self.state[0].wrapping_add(self.state[3]))
@@ -47,21 +55,24 @@ impl Xoshiro256 {
         result
     }
 
-    // primitive functions
+    /// Returns a random `i64` in `[min, max]` inclusive.
     pub fn generate_random_int_range(&mut self, min: i64, max: i64) -> i64 {
         let range = (max as i128 - min as i128 + 1) as u128;
         let offset = (self.next() as u128) % range;
         (min as i128 + offset as i128) as i64
     }
 
+    /// Returns a random `f64` in `[0.0, 1.0)`.
     pub fn generate_random_float(&mut self) -> f64 {
         self.next() as f64 / u64::MAX as f64
     }
 
+    /// Returns a random `f64` in `[min, max)`.
     pub fn generate_random_float_range(&mut self, min: f64, max: f64) -> f64 {
         min + self.generate_random_float() * (max - min)
     }
 
+    /// Returns `true` with probability `weight` (clamped to `[0.0, 1.0]`).
     pub fn generate_random_bool(&mut self, weight: f64) -> bool {
         self.generate_random_float() < weight.clamp(0.0, 1.0)
     }

--- a/src/interpreter/stdlib/string/contains.rs
+++ b/src/interpreter/stdlib/string/contains.rs
@@ -1,5 +1,5 @@
 use crate::interpreter::evaluator::Evaluator;
 
-pub fn std_cotains(_: &mut Evaluator, string: String, sub: String) -> bool {
+pub fn std_contains(_: &mut Evaluator, string: String, sub: String) -> bool {
     string.contains(&sub)
 }

--- a/src/interpreter/stdlib/string/mod.rs
+++ b/src/interpreter/stdlib/string/mod.rs
@@ -1,3 +1,11 @@
+//! `std::str` - string manipulation functions.
+//!
+//! Note: the module name in rl imports is `str`, not `string`
+//! (registered as `Module::new("str")`).
+//!
+//! `format` uses `with_raw_function` for variadic `{}` placeholder substitution.
+//! `concat` also variadic - concatenates any number of values as strings.
+
 mod bytes;
 mod char_at;
 mod chars;
@@ -66,7 +74,7 @@ pub fn module() -> Module {
         .with_function("chars", chars::std_chars)
         .with_function("reverse", reverse::std_reverse)
         .with_function("slice", slice::std_slice)
-        .with_function("contains", contains::std_cotains)
+        .with_function("contains", contains::std_contains)
         .with_function("starts_with", starts_with::std_starts_with)
         .with_function("ends_with", ends_with::std_ends_with)
         .with_function("join", join::std_join)

--- a/src/interpreter/stdlib/time/format_time.rs
+++ b/src/interpreter/stdlib/time/format_time.rs
@@ -1,3 +1,11 @@
+//! Unix timestamp -> formatted string conversion.
+//!
+//! `unix_to_parts` decomposes a Unix timestamp into `(year, month, day, hour, minute, second)`
+//! using the Gregorian calendar algorithm (proleptic calendar, UTC only, no DST).
+//!
+//! `apply_pattern` performs simple string substitution on strftime-like tokens:
+//! `%Y` (4-digit year), `%m` (month), `%d` (day), `%H` (hour), `%M` (minute), `%S` (second).
+
 use crate::{
     interpreter::{evaluator::Evaluator, values::Value},
     utils::{errors::Error, span::Span},

--- a/src/interpreter/stdlib/time/mod.rs
+++ b/src/interpreter/stdlib/time/mod.rs
@@ -1,3 +1,10 @@
+//! `std::time` - Unix timestamp functions and time formatting.
+//!
+//! All timestamps are Unix seconds as `i64`.
+//! `format_time` uses a minimal strftime-like pattern (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`).
+//! `time_parts` returns `[year, month, day, hour, minute, second]` as an `arr[int]`.
+//! `time_add` and `time_diff` are trivial arithmetic helpers - a proper time type is planned.
+
 mod format_time;
 mod now;
 mod time_arith;

--- a/src/interpreter/stdlib/types/mod.rs
+++ b/src/interpreter/stdlib/types/mod.rs
@@ -1,3 +1,8 @@
+//! `std::types` - type inspection and conversion functions.
+//!
+//! `is_*` functions check the runtime type of a value without conversion.
+//! `to_int` accepts hex strings prefixed with `0x`/`0X`.
+
 mod is_bool;
 mod is_char;
 mod is_float;

--- a/src/interpreter/stdlib/types/to_char.rs
+++ b/src/interpreter/stdlib/types/to_char.rs
@@ -21,7 +21,7 @@ pub fn std_to_char(eval: &mut Evaluator, value: Value, span: Span) -> Result<cha
         }
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as character", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/stdlib/types/to_float.rs
+++ b/src/interpreter/stdlib/types/to_float.rs
@@ -15,7 +15,7 @@ pub fn std_to_float(eval: &mut Evaluator, value: Value, span: Span) -> Result<f6
             .map_err(|_| eval.err(format!("cannot parse \"{}\" as float", s), span)),
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as float", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/stdlib/types/to_hex.rs
+++ b/src/interpreter/stdlib/types/to_hex.rs
@@ -11,7 +11,7 @@ pub fn std_to_hex(eval: &mut Evaluator, value: Value, span: Span) -> Result<Stri
         Value::String(s) => Ok(s.bytes().map(|b| format!("{:x}", b)).collect::<String>()),
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as hexadecimal", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/stdlib/types/to_int.rs
+++ b/src/interpreter/stdlib/types/to_int.rs
@@ -22,7 +22,7 @@ pub fn std_to_int(eval: &mut Evaluator, value: Value, span: Span) -> Result<i64,
         }
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as int", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/stdlib/types/to_oct.rs
+++ b/src/interpreter/stdlib/types/to_oct.rs
@@ -11,7 +11,7 @@ pub fn std_to_oct(eval: &mut Evaluator, value: Value, span: Span) -> Result<Stri
         Value::String(s) => Ok(s.bytes().map(|b| format!("{:o}", b)).collect::<String>()),
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as octal", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/stdlib/types/to_string.rs
+++ b/src/interpreter/stdlib/types/to_string.rs
@@ -13,7 +13,7 @@ pub fn std_to_string(eval: &mut Evaluator, value: Value, span: Span) -> Result<S
         Value::String(s) => Ok(s),
 
         other => Err(eval.err(
-            format!("cannot parse \"{}\" as bool", other.type_name()),
+            format!("cannot parse \"{}\" as string", other.type_name()),
             span,
         )),
     }

--- a/src/interpreter/utils/binary.rs
+++ b/src/interpreter/utils/binary.rs
@@ -1,3 +1,9 @@
+//! Binary operator evaluation for all supported operand type combinations.
+//!
+//! `byte op int` and `int op byte` always widen to `int`.
+//! `byte op byte` stays `byte` if the result fits in `0..=255`, otherwise widens to `int`.
+//! All type mismatches emit a labeled error pointing at both operands.
+
 use crate::{
     interpreter::evaluator::Evaluator,
     interpreter::values::Value,

--- a/src/interpreter/utils/mod.rs
+++ b/src/interpreter/utils/mod.rs
@@ -1,3 +1,5 @@
+//! Internal evaluator utilities - binary/unary operator dispatch and statement evaluation.
+
 mod binary;
 mod statements;
 mod unary;

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-use std::sync::Arc;
+//! Statement evaluation - the main dispatch loop and control flow primitives.
 
 use crate::{
     ast::statements::{Statement, StatementKind, TypeAnnotation},
@@ -8,8 +7,15 @@ use crate::{
     parser::parser_logic::Parser,
     utils::{errors::Error, source::SourceFile, span::Span},
 };
+use std::path::Path;
+use std::sync::Arc;
 
 impl Evaluator {
+    /// Evaluates a single statement, mutating the environment and control-flow flags.
+    ///
+    /// Loop control (`break`, `continue`) and function return (`return`) are signalled
+    /// via `is_breaking`, `is_continuing`, and `return_value` flags on [`Evaluator`]
+    /// rather than exceptions, so callers must check these flags after each statement.
     pub fn evaluate_statement(&mut self, statement: &Statement) -> Result<(), Error> {
         match &statement.kind {
             StatementKind::ResolvedVariableDeclaration {
@@ -508,6 +514,8 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Evaluates a [`ConditionalBranch`] or [`Conditional`] and returns `true` if the
+    /// branch was taken (condition was true or it was an `else`).
     fn evaluate_branch(&mut self, statement: &Statement) -> Result<bool, Error> {
         match &statement.kind {
             StatementKind::ConditionalBranch { condition, body } => match condition {
@@ -565,6 +573,13 @@ impl Evaluator {
         }
     }
 
+    /// The top-level entry point for a full rl program.
+    ///
+    /// If a function is annotated `!#[entry]` or named `main`, only declarations
+    /// and imports are evaluated first, then that function is called with no arguments.
+    /// If no entry point exists, all statements are evaluated top-to-bottom (script mode).
+    ///
+    /// Returns an error if multiple `!#[entry]` functions are found.
     pub fn evaluate_program(&mut self, statements: &[Statement]) -> Result<(), Error> {
         let mut explicit_entry: Option<(Span, usize)> = None;
         let mut main_entry: Option<(Span, usize)> = None;
@@ -623,6 +638,7 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Evaluates a list of statements inside a fresh scope, used for inline blocks.
     pub fn evaluate_block(&mut self, statements: &[Statement]) -> Result<(), Error> {
         self.push_scope();
         for statement in statements {

--- a/src/interpreter/utils/unary.rs
+++ b/src/interpreter/utils/unary.rs
@@ -1,3 +1,11 @@
+//! Unary operator evaluation.
+//!
+//! | Operator | Operand       | Result                  |
+//! |----------|---------------|-------------------------|
+//! | `!`      | `bool`        | `bool`                  |
+//! | `-`      | `int` / `byte`| `int` (byte is widened) |
+//! | `-`      | `float`       | `float`                 |
+
 use crate::{
     interpreter::evaluator::Evaluator,
     interpreter::values::Value,

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -1,27 +1,41 @@
-use std::fmt;
+//! Runtime value types for the rl interpreter.
 
 use crate::{
     ast::statements::{Param, Statement, TypeAnnotation},
     interpreter::evaluator::EnvironmentItem,
 };
+use std::fmt;
 
+/// A runtime value produced by evaluating an rl expression.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
+    /// A 64-bit signed integer.
     Integer(i64),
+    /// A 64-bit float.
     Float(f64),
+    /// A UTF-8 string.
     String(String),
+    /// A boolean.
     Bool(bool),
+    /// A single unsigned byte (`u8`).
     Byte(u8),
+    /// A single Unicode character.
     Char(char),
+    /// A homogeneous array of values with a tracked element type.
     Values {
+        /// The declared element type of this array.
         items_type: TypeAnnotation,
         items: Vec<Value>,
     },
+    /// The absence of a value - equivalent to `null` in rl source.
     Null,
+    /// A first-class function or lambda value, carrying its closure environment.
     Function {
         params: Vec<Param>,
         body: Vec<Statement>,
+        /// Declared return type; `None` for lambdas without an annotation.
         return_type: Option<TypeAnnotation>,
+        /// The captured environment frames at the point of lambda definition.
         captured_env: Vec<Vec<EnvironmentItem>>,
     },
 }

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -1,14 +1,24 @@
+//! [`LanguageServer`] implementation - the JSON-RPC entry point for all LSP events.
+//!
+//! [`Backend`] holds a [`RwLock`]-guarded map of open document URIs to their
+//! latest source text. Every file event updates this cache so [`hover`] always
+//! has the most recent content to work with.
+
+use crate::lsp::hover::run_hover;
+use crate::lsp::pipeline::run_pipeline;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
-use crate::lsp::hover::run_hover;
-use crate::lsp::pipeline::run_pipeline;
-
+/// The LSP backend, wiring tower-lsp events to the rl pipeline.
 pub struct Backend {
+    /// The tower-lsp client handle used to send messages and diagnostics back to the editor.
     pub client: Client,
+    /// Cache of open document source text, keyed by URI.
+    ///
+    /// Written on `didOpen`/`didChange`, read on `hover`, cleared on `didClose`.
     pub docs: RwLock<HashMap<Url, String>>,
 }
 
@@ -85,8 +95,7 @@ impl LanguageServer for Backend {
 }
 
 impl Backend {
-    // caches the latest full text for a document so hover() has
-    // something to read later
+    /// Inserts or updates the cached source text for `uri`.
     async fn store(&self, uri: &Url, source: &str) {
         self.docs
             .write()
@@ -94,7 +103,7 @@ impl Backend {
             .insert(uri.clone(), source.to_string());
     }
 
-    // pushes the diagnostics from pipeline to client (editors)
+    /// Runs the rl pipeline on `source` and publishes the resulting diagnostics to the editor.
     async fn publish(&self, uri: &Url, source: &str) {
         let diagnostics = run_pipeline(source);
 

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -1,3 +1,10 @@
+//! Hover resolution: lex -> parse -> type-check -> pick the smallest matching span.
+//!
+//! The [`TypeChecker`] populates a `hovers` side-table of `(Span, markdown)`
+//! pairs at every declaration, identifier usage, and stdlib call site.
+//! [`run_hover`] finds the entry whose span contains the cursor offset and
+//! whose span is the smallest (to prefer the most specific match when multiple
+//! spans overlap on the same line).
 use crate::{
     checker::TypeChecker,
     lexer::{tokenizer::Tokenizer, tokentypes::TokenType},
@@ -7,12 +14,11 @@ use crate::{
 };
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Range};
 
-/// lex -> parse -> type-check `source` then resolve a hover for the
-/// given cursor `position`
-/// mirrors `pipeline::run_pipeline` but instead
-/// of diagnostics it reads `checker.hovers` the side table of
-/// (span, markdown) pairs the checker records at every declaration
-/// identifier usage and stdlib call site
+/// Runs the full pipeline on `source` and returns a [`Hover`] for `position`,
+/// or `None` if the cursor is not over a hoverable token.
+///
+/// Only [`TokenType::Identifier`] tokens carry hover info - non-identifier
+/// positions short-circuit early before running the parser and type-checker.
 pub fn run_hover(source: &str, position: Position) -> Option<Hover> {
     let offset = position_to_offset(source, position);
     let file = SourceFile::new("buffer", source.to_string());
@@ -54,6 +60,8 @@ pub fn run_hover(source: &str, position: Position) -> Option<Hover> {
     })
 }
 
+/// Returns the [`Span`] of the identifier token that contains `offset`,
+/// or `None` if no identifier token covers that position.
 fn find_identifier_span_at(
     tokens: &[crate::lexer::tokentypes::Token],
     offset: usize,

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,13 +1,36 @@
+//! LSP server for rl, built on [`tower_lsp`].
+//!
+//! Communicates with editors over stdio using JSON-RPC.
+//! Currently supports:
+//! - **Diagnostics** - lex/parse/type-check errors on every file change
+//! - **Hover** - markdown type info at the cursor position
+//!
+//! # Architecture
+//!
+//! ```text
+//! editor (VS Code, Zed, Neovim, ...)
+//!     │  JSON-RPC over stdio
+//! |---V----------------------------|
+//! |  Backend  (tower-lsp handler)  |
+//! |  |-- did_open / did_change --> pipeline::run_pipeline  --> diagnostics
+//! |  |-- hover -----------------> hover::run_hover         --> hover info
+//! |--------------------------------|
+//! ```
+
+use tower_lsp::{LspService, Server};
+
+use crate::lsp::backend::Backend;
+
 mod backend;
 mod hover;
 mod pipeline;
 mod to_diagnostic;
 mod utils;
 
-use tower_lsp::{LspService, Server};
-
-use crate::lsp::backend::Backend;
-
+/// Starts the LSP server, reading JSON-RPC from stdin and writing to stdout.
+///
+/// Blocks indefinitely - intended to be spawned as a long-running process
+/// by the editor's LSP client.
 pub async fn run_lsp() {
     // declare stdin and out for editor and lsp communications
     let stdin = tokio::io::stdin();

--- a/src/lsp/pipeline.rs
+++ b/src/lsp/pipeline.rs
@@ -1,3 +1,9 @@
+//! Diagnostic pipeline: lex -> parse -> type-check.
+//!
+//! The evaluator is intentionally excluded. Running user code on every
+//! keystroke caused the LSP to hang on infinite loops (e.g. `while true {}`).
+//! The [`TypeChecker`] walks the AST without executing anything, making it
+//! always safe to run on in-progress or non-terminating source.
 use crate::{
     checker::TypeChecker, lexer::tokenizer::Tokenizer, lsp::to_diagnostic::error_to_diagnostic,
     parser::parser_logic::Parser, utils::source::SourceFile,

--- a/src/lsp/to_diagnostic.rs
+++ b/src/lsp/to_diagnostic.rs
@@ -1,8 +1,14 @@
+//! Converts rl [`Error`]s into LSP [`Diagnostic`]s.
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Range};
 
 use crate::lsp::utils::offset_to_position;
 
-// converts normal Error to diagnostic that lsp can understand
+/// Converts an rl [`Error`] into an LSP [`Diagnostic`].
+///
+/// Uses the error's primary [`Span`] for the diagnostic range.
+/// Falls back to `(0, 0)` if no span is present (legacy errors).
+/// All diagnostics are emitted at [`DiagnosticSeverity::ERROR`] -
+/// warnings and hints are planned post v0.2.0.
 pub fn error_to_diagnostic(source: &str, error: &crate::utils::errors::Error) -> Diagnostic {
     // extract the bytes from the start of span and the end of it
     let (start, end) = error.span().map(|s| (s.start, s.end)).unwrap_or((0, 0));

--- a/src/lsp/utils.rs
+++ b/src/lsp/utils.rs
@@ -1,7 +1,13 @@
+//! Conversions between byte offsets and LSP [`Position`]s (line + character).
+//!
+//! LSP uses 0-indexed `(line, character)` pairs; rl's [`Span`] uses byte offsets
+//! into the source string. These two functions bridge that gap.
+
 use tower_lsp::lsp_types::Position;
 
-// since span works with bytes
-// this function should simplify the process
+/// Converts a byte `offset` into the source string into an LSP [`Position`].
+///
+/// Clamps `offset` to `source.len()` if out of bounds.
 pub fn offset_to_position(source: &str, offset: usize) -> Position {
     let offset = offset.min(source.len());
     let before = &source[..offset];
@@ -10,7 +16,10 @@ pub fn offset_to_position(source: &str, offset: usize) -> Position {
     Position::new(line as u32, character as u32)
 }
 
-// inverse of offset_to_position
+/// Converts an LSP [`Position`] back into a byte offset into `source`.
+///
+/// Returns `source.len()` if the position is past the end.
+/// The `+1` in the line accumulator accounts for the `\n` separator consumed by `split`.
 pub fn position_to_offset(source: &str, position: Position) -> usize {
     let mut offset = 0usize;
     for (i, line) in source.split('\n').enumerate() {

--- a/src/repl/command_handler.rs
+++ b/src/repl/command_handler.rs
@@ -1,3 +1,21 @@
+//! REPL command dispatcher - handles all `:` prefixed commands.
+//!
+//! # Commands
+//!
+//! | Command              | Description                                   |
+//! |----------------------|-----------------------------------------------|
+//! | `:help`              | Print all available commands                  |
+//! | `:stdlib`            | List all stdlib modules                       |
+//! | `:stdlib <mod>`      | List all functions in a stdlib module         |
+//! | `:save <file>`       | Save all `ValidInput` lines to a file         |
+//! | `:load <file>`       | Print a file's contents into the output       |
+//! | `:attach <file>`     | Lex, parse, and evaluate a file into the env  |
+//! | `:detach <file>`     | Remove a file from the attached list          |
+//! | `:exit`              | Exit the REPL                                 |
+//!
+//! Note: `:detach` removes the file from the tracked list but does **not**
+//! undefine variables or functions already loaded into the evaluator environment.
+
 use std::{fs, path::PathBuf};
 
 use ratatui::style::{Color, Modifier, Style};
@@ -10,6 +28,7 @@ use crate::{
     utils::source::SourceFile,
 };
 
+/// Dispatches a `:command` string, mutating `output`, `evaluator`, and `attached` as needed.
 pub fn handle_command(
     cmd: &str,
     output: &mut Vec<OutputLine>,

--- a/src/repl/depth_checker.rs
+++ b/src/repl/depth_checker.rs
@@ -1,8 +1,17 @@
+//! Determines whether a multiline input block is complete and ready to evaluate.
 use crate::{
     lexer::{tokenizer::Tokenizer, tokentypes::TokenType},
     utils::source::SourceFile,
 };
 
+/// Returns `true` if `input` is a syntactically complete expression or statement.
+///
+/// Lexes `input` and counts bracket/brace/paren depth. The input is considered
+/// incomplete (returns `false`) when:
+/// - any parentheses or brackets are unclosed
+/// - braces are unclosed and the input does not end with `{` (a block opener)
+///
+/// On lex error, returns `true` so the evaluator can surface the error to the user.
 pub fn is_complete(input: &str) -> bool {
     let source = SourceFile::new("<check>", input.to_string());
     let tokens = match Tokenizer::lex(source) {

--- a/src/repl/input_eval.rs
+++ b/src/repl/input_eval.rs
@@ -1,3 +1,4 @@
+//! Evaluates a complete input string and appends results to the output buffer.
 use crate::{
     interpreter::evaluator::Evaluator,
     lexer::tokenizer::Tokenizer,
@@ -6,6 +7,16 @@ use crate::{
     utils::source::SourceFile,
 };
 
+/// Lexes, parses, and evaluates `input`, appending results to `output`.
+///
+/// Expression statements have their return value rendered directly with syntax
+/// highlighting (unless the value is `null`). Non-expression statements
+/// (declarations, loops, etc.) are evaluated for their side effects only.
+///
+/// Any `println` / `print` output captured in [`Evaluator::output_buffer`]
+/// is flushed into `output` as [`OutputLine::Result`] lines after evaluation.
+///
+/// Returns `true` if all statements evaluated without error.
 pub fn eval_input(input: &str, evaluator: &mut Evaluator, output: &mut Vec<OutputLine>) -> bool {
     let source = SourceFile::new("<repl>", input.to_string());
 

--- a/src/repl/lines_types.rs
+++ b/src/repl/lines_types.rs
@@ -1,11 +1,20 @@
+//! Output line variants used by the REPL output buffer.
 use ratatui::style::Style;
 
+/// A line in the REPL output buffer.
 pub enum OutputLine {
+    /// Raw user input - rendered with `>>` or `..` prompt and syntax highlighting.
     Input(String),
+    /// Successfully evaluated input - stored for `:save` but not rendered.
     ValidInput(String),
+    /// Output produced by evaluating an expression (e.g. a value or `println` output).
     Result(String),
+    /// An error message - rendered in red with a `✗` prefix.
     Error(String),
+    /// An informational message - rendered in dark gray (used by commands and startup).
     Info(String),
+    /// A pre-styled run of `(text, Style)` pairs - used by `:help` and `:stdlib`.
     Styled(Vec<(String, Style)>),
+    /// A horizontal separator line.
     Separator,
 }

--- a/src/repl/logic_loop.rs
+++ b/src/repl/logic_loop.rs
@@ -1,3 +1,37 @@
+//! The main REPL event loop - input handling, rendering, and evaluation dispatch.
+//!
+//! # State
+//!
+//! | Variable        | Purpose                                                  |
+//! |-----------------|----------------------------------------------------------|
+//! | `input_buf`     | The current line being typed                             |
+//! | `accumulated`   | Multiline buffer - grows until [`is_complete`] is true   |
+//! | `cursor_pos`    | Cursor position in chars (not bytes)                     |
+//! | `history`       | Submitted input history, navigated with `↑`/`↓`          |
+//! | `history_idx`   | Current position in history (`None` = live input)        |
+//! | `attached`      | Files evaluated into the env via `:attach`               |
+//! | `scroll_offset` | Output scroll position (`0` = bottom, higher = older)    |
+//!
+//! # Multiline input
+//!
+//! Lines are accumulated into `accumulated` until [`is_complete`] returns `true`
+//! and the last line does not end with `{` (a bare block opener waits for body).
+//! The prompt switches from `>>` to `..` while accumulating.
+//! `Esc` cancels and clears the accumulator.
+//!
+//! # Evaluation flow
+//!
+//! ```text
+//! Enter key
+//!   |
+//!   |- starts with ':'  ──► handle_command
+//!   |
+//!   |- code input
+//!        |
+//!        |- not complete yet --> keep accumulating
+//!        |
+//!        |- complete --> eval_input --> output buffer
+//! ```
 use super::{
     command_handler::handle_command, depth_checker::is_complete, input_eval::eval_input,
     lines_types::OutputLine, output_render::render_output, syntax_highlighting::highlight,
@@ -15,6 +49,12 @@ use std::path::PathBuf;
 
 use crate::interpreter::evaluator::Evaluator;
 
+/// Runs the REPL event loop until the user exits with `Ctrl+C` or `:exit`.
+///
+/// Initializes a fresh [`Evaluator`] with the stdlib loaded, then enters a
+/// draw-then-poll loop: renders the current state, blocks on the next key
+/// event, and dispatches it. Returns an [`io::Result`] so terminal errors
+/// propagate cleanly to [`start_repl`].
 pub fn run_repl(terminal: &mut DefaultTerminal) -> std::io::Result<()> {
     let mut evaluator = Evaluator::default().with_stdlib();
     let mut output: Vec<OutputLine> = vec![

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,3 +1,30 @@
+//! TUI REPL for rl, built on [`ratatui`] and [`crossterm`].
+//!
+//! # Layout
+//!
+//! ```text
+//! |---------------------------------|
+//! |  output area  (scrollable)      |
+//! |  >> dec int x = 10              |
+//! |  >> x + 1                       |
+//! |  11                             |
+//! |---------------------------------|
+//! |  >> _  (input bar)              |
+//! |---------------------------------|
+//! ```
+//!
+//! # Key bindings
+//!
+//! | Key            | Action                        |
+//! |----------------|-------------------------------|
+//! | `Enter`        | Submit / continue multiline   |
+//! | `Ctrl+C`       | Exit                          |
+//! | `Esc`          | Cancel multiline input        |
+//! | `↑` / `↓`     | History navigation            |
+//! | `Shift+↑/↓`   | Scroll output                 |
+//! | `Ctrl+←/→`    | Word jump                     |
+//! | `Home` / `End` | Line start / end              |
+
 mod command_handler;
 mod depth_checker;
 mod input_eval;
@@ -7,6 +34,8 @@ mod output_render;
 mod syntax_highlighting;
 mod utils;
 
+/// Initializes the ratatui terminal, runs the REPL loop, and restores the
+/// terminal on exit. Prints any IO error to stderr.
 pub fn start_repl() {
     let mut terminal = ratatui::init();
     let result = logic_loop::run_repl(&mut terminal);

--- a/src/repl/output_render.rs
+++ b/src/repl/output_render.rs
@@ -1,3 +1,12 @@
+//! Converts the [`OutputLine`] buffer into ratatui [`Line`]s for rendering.
+//!
+//! `ValidInput` lines are intentionally filtered out - they exist only for
+//! `:save` and are never shown in the output area.
+//!
+//! `Result` lines run through [`highlight`] first; if the highlighter returns
+//! only red or white spans (i.e. plain text, not code), the line is rendered
+//! as plain green instead.
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -5,6 +14,7 @@ use ratatui::{
 
 use crate::repl::{lines_types::OutputLine, syntax_highlighting::highlight};
 
+/// Converts the output buffer into a list of styled ratatui lines ready to render.
 pub fn render_output(output: &[OutputLine]) -> Vec<Line<'static>> {
     output
         .iter()

--- a/src/repl/syntax_highlighting.rs
+++ b/src/repl/syntax_highlighting.rs
@@ -1,3 +1,28 @@
+//! Token-based syntax highlighting for the REPL input bar and output.
+//!
+//! Lexes the input with the real rl lexer and maps each [`TokenType`] to a
+//! ratatui [`Style`]. Gaps between token spans are emitted as unstyled raw spans
+//! to preserve whitespace exactly. On lex failure the entire input is returned
+//! as a single red span.
+//!
+//! # Color scheme
+//!
+//! | Token group         | Color / modifier         |
+//! |---------------------|--------------------------|
+//! | Control flow        | Cyan bold                |
+//! | Declarations        | Cyan italic              |
+//! | Import keywords     | Cyan dim                 |
+//! | Type keywords       | Light blue italic        |
+//! | Logical operators   | Yellow bold              |
+//! | Number literals     | Magenta                  |
+//! | String literals     | Yellow                   |
+//! | Char literals       | Light yellow             |
+//! | Bool literals       | Magenta italic           |
+//! | `null`              | Dark gray italic         |
+//! | Comparison ops      | Light cyan               |
+//! | Punctuation/braces  | Dark gray                |
+//! | Identifiers         | White                    |
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::Span,
@@ -8,6 +33,7 @@ use crate::{
     utils::source::SourceFile,
 };
 
+/// Returns the ratatui [`Style`] for a given [`TokenType`].
 fn token_color(tt: &TokenType) -> Style {
     match tt {
         // control flow - cyan bold
@@ -118,6 +144,9 @@ fn token_color(tt: &TokenType) -> Style {
     }
 }
 
+/// Lexes `input` and returns a vec of syntax-highlighted [`Span`]s.
+///
+/// On lex error returns a single red span containing the raw input.
 pub fn highlight(input: &str) -> Vec<Span<'static>> {
     let source = SourceFile::new("<hl>", input.to_string());
     let tokens = match Tokenizer::lex(source) {

--- a/src/repl/utils.rs
+++ b/src/repl/utils.rs
@@ -1,9 +1,16 @@
+//! Small shared utilities for the REPL.
+
 use crate::repl::lines_types::OutputLine;
 
+/// Appends an [`OutputLine::Error`] derived from `e` to `output`.
 pub fn push_error(output: &mut Vec<OutputLine>, e: &crate::utils::errors::Error) {
     output.push(OutputLine::Error(format!("error: {}", e.message())));
 }
 
+/// Converts a char-indexed position in `s` to its byte offset.
+///
+/// Returns `s.len()` if `char_idx` is past the end, making it safe to use
+/// directly with [`String::insert`] and [`String::remove`].
 pub fn char_to_byte(s: &str, char_idx: usize) -> usize {
     s.char_indices()
         .nth(char_idx)

--- a/src/resolver/expressions.rs
+++ b/src/resolver/expressions.rs
@@ -1,3 +1,16 @@
+//! Expression resolution - transforms name references into indexed lookups.
+//!
+//! Each expression variant is handled in [`Resolver::resolve_expression`]:
+//!
+//! - `Identifier` -> `ResolvedIdentifier { depth, slot }` if found in scope,
+//!   left as `Identifier` if not (stdlib names, unresolved at this stage)
+//! - `Assign` -> `ResolvedAssign { depth, slot, value }`
+//! - `Lambda` -> `ResolvedLambda { capture_depth, ... }` with a fresh scope
+//!   for its parameters; `capture_depth` is the scope stack length at the
+//!   point of definition, used by the evaluator to capture the environment
+//! - `Call` with a single-segment path -> `CallExpr` with a `ResolvedIdentifier`
+//!   callee if the name is in scope; left as `Call` for stdlib paths
+//! - All other variants recurse into their sub-expressions unchanged
 use crate::{
     ast::nodes::{Expression, ExpressionKind},
     resolver::Resolver,

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,7 +1,24 @@
+//! Variable resolution pass - runs between parsing and evaluation.
+//!
+//! The resolver walks the AST and transforms unresolved name references
+//! into slot-indexed lookups (`depth`, `slot`), eliminating string-based
+//! name lookups at runtime.
+//!
+//! - `depth` - how many scopes up from the current scope the variable lives
+//! - `slot`  - the index of the variable within that scope's slot array
+//!
+//! Unresolved `Identifier` nodes become `ResolvedIdentifier { depth, slot }`.
+//! Unresolved `Assign` nodes become `ResolvedAssign { depth, slot, value }`.
+//! Function and lambda bodies are resolved in their own pushed scope.
+//! Import statements are read from disk, lexed, parsed, and resolved inline.
+
 mod expressions;
 mod statements;
 
+/// Walks the AST and resolves all name references to `(depth, slot)` pairs.
 pub struct Resolver {
+    /// Stack of scopes, each scope being an ordered list of declared names.
+    /// Index in the list is the slot number; distance from the top is the depth.
     scopes: Vec<Vec<String>>,
 }
 
@@ -12,19 +29,27 @@ impl Default for Resolver {
 }
 
 impl Resolver {
+    /// Creates a new [`Resolver`] with a single empty global scope.
     pub fn new() -> Self {
         Self {
             scopes: vec![vec![]],
         }
     }
 
+    /// Pushes a new empty scope onto the scope stack.
     pub fn push_scope(&mut self) {
         self.scopes.push(vec![]);
     }
+
+    /// Pops the innermost scope from the stack.
     pub fn pop_scope(&mut self) {
         self.scopes.pop();
     }
 
+    /// Declares a name in the current scope and returns its slot index.
+    ///
+    /// The slot is the position of the name within the current scope frame,
+    /// used later by the evaluator for direct indexed access.
     pub fn declare(&mut self, name: String) -> usize {
         let frame = self.scopes.last_mut().unwrap();
         let slot = frame.len();
@@ -32,6 +57,11 @@ impl Resolver {
         slot
     }
 
+    /// Searches for `name` by walking scopes from innermost to outermost.
+    ///
+    /// Returns `Some((depth, slot))` where `depth` is the number of scopes
+    /// above the current one (0 = current), and `slot` is the index within
+    /// that scope. Returns `None` if the name is not declared in any scope.
     pub fn resolve_name(&self, name: &str) -> Option<(usize, usize)> {
         for (depth, frame) in self.scopes.iter().rev().enumerate() {
             if let Some(slot) = frame.iter().position(|n| n == name) {

--- a/src/resolver/statements.rs
+++ b/src/resolver/statements.rs
@@ -1,3 +1,20 @@
+//! Statement resolution - transforms declarations and control flow into
+//! slot-indexed variants and resolves import statements at compile time.
+//!
+//! Key behaviors:
+//!
+//! - Variable/constant/array declarations: resolve the initializer expression
+//!   first, *then* declare the name so the initializer cannot reference itself
+//! - Function declarations: declare the name in the outer scope first (enabling
+//!   recursion), then push a new scope for parameters and resolve the body
+//! - `ForEach`/`ForRange`: the loop variable is declared inside its own scope
+//!   so it does not leak into the surrounding scope after the loop ends
+//! - `ImportFile` / `ImportFileNamed`: reads the file from disk, lexes, parses,
+//!   and resolves it inline - the result replaces the import statement with
+//!   `ResolvedImportFile { body }` containing the fully resolved statements.
+//!   `ImportFileNamed` additionally filters to only the requested names before resolving.
+//!   Both silently return the original unresolved statement on any IO/parse failure
+
 use crate::{
     ast::{
         nodes::{Expression, ExpressionKind},
@@ -191,16 +208,13 @@ impl Resolver {
             StatementKind::ImportFile { path } => {
                 let import_name = format!("{}.rl", path.join("/"));
                 let Ok(source_text) = std::fs::read_to_string(&import_name) else {
-                    eprintln!("DEBUG import: could not read '{}'", import_name);
                     return Statement::new(StatementKind::ImportFile { path }, span);
                 };
                 let source_file = SourceFile::new(import_name, source_text);
                 let Ok(tokens) = Tokenizer::lex(source_file.clone()) else {
-                    eprintln!("DEBUG import: lex failed");
                     return Statement::new(StatementKind::ImportFile { path }, span);
                 };
                 let Ok(stmts) = Parser::parse(tokens, source_file) else {
-                    eprintln!("DEBUG import: parse failed");
                     return Statement::new(StatementKind::ImportFile { path }, span);
                 };
                 let resolved = self.resolve_statements(stmts);

--- a/src/tooling/dev.rs
+++ b/src/tooling/dev.rs
@@ -1,17 +1,27 @@
 use serde::Deserialize;
 
+/// Represents the full `rl.toml` project manifest.
 #[derive(Deserialize)]
 pub struct RlToml {
     pub project: Project,
 }
 
+/// The `[project]` section of `rl.toml`.
 #[derive(Deserialize)]
 pub struct Project {
+    /// The project name.
     pub name: String,
+    /// The project version string (e.g. `"0.1.0"`).
     pub version: String,
+    /// Path to the entry point relative to the project root (e.g. `"src/main.rl"`).
     pub entry: String,
 }
 
+/// Reads and parses `rl.toml` from the current directory.
+///
+/// Exits with code `1` if:
+/// - `rl.toml` is not found in the current directory
+/// - the file content is not valid TOML or doesn't match [`RlToml`]
 pub fn read_rl_toml() -> RlToml {
     let content = std::fs::read_to_string("rl.toml").unwrap_or_else(|_| {
         eprintln!("error: no rl.toml found in current directory");

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -1,2 +1,6 @@
+//! Tooling support for rl projects.
+//!
+//! - [`new`] - project scaffolding (`rl new <name>`)
+//! - [`dev`] - project manifest parsing (`rl.toml`)
 pub mod dev;
 pub mod new;

--- a/src/tooling/new.rs
+++ b/src/tooling/new.rs
@@ -1,5 +1,21 @@
 use std::io;
 
+/// Creates a new rl project directory at `name`.
+///
+/// Scaffolds the following structure:
+/// ```text
+/// <name>/
+/// |-- .gitignore
+/// |-- rl.toml
+/// |-- src/
+///     |-- main.rl
+/// ```
+///
+/// `rl.toml` is pre-filled with the project name and current rl version.
+/// `src/main.rl` contains a hello world entry point.
+/// A git repository is initialized automatically.
+///
+/// Prints an error and exits with code `1` on any IO failure.
 pub fn create_project(name: &str) {
     if let Err(e) = try_create_project(name) {
         eprintln!("error: failed to create project '{}': {}", name, e);
@@ -8,6 +24,9 @@ pub fn create_project(name: &str) {
     println!("created project '{}'", name);
 }
 
+/// Inner fallible implementation of [`create_project`].
+///
+/// Returns [`io::Error`] if any filesystem operation or `git init` fails.
 fn try_create_project(name: &str) -> io::Result<()> {
     let toml = format!(
         r#"[project]

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -192,7 +192,7 @@ impl Error {
         }
     }
 
-    // adds a way to extract bytes from span in Error
+    /// Extracts the primary [`Span`] of this error, if one was set.
     pub fn span(&self) -> Option<crate::utils::span::Span> {
         self.detail.as_ref().map(|d| d.primary.0)
     }
@@ -227,6 +227,7 @@ impl ErrorReason {
 }
 
 impl Error {
+    /// Returns the raw error message string.
     pub fn message(&self) -> &str {
         &self.message
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,9 @@
+//! Shared utilities used across the rl pipeline.
+//!
+//! - [`errors`] - [`Error`] type and [`Reason`] categories
+//! - [`source`] - [`SourceFile`] carrying source text through the pipeline
+//! - [`span`] - [`Span`] for pointing errors at exact source locations
+//! - [`suggest`] - fuzzy name matching for "did you mean?" hints
 pub mod errors;
 pub mod source;
 pub mod span;

--- a/src/utils/source.rs
+++ b/src/utils/source.rs
@@ -1,14 +1,17 @@
 use std::sync::Arc;
 
-/// A named source file (or `<repl>` snippet) carried by each pipeline subsystem
-/// so error reports can quote the original code.
+/// A named source file (or `<repl>` snippet) carried through each pipeline
+/// stage so error reports can quote the original source text.
 #[derive(Clone)]
 pub struct SourceFile {
+    /// The file name shown in error report headers (e.g. `"main.rl"`, `"<repl>"`).
     pub name: Arc<str>,
+    /// The full source text, reference-counted to avoid cloning across pipeline stages.
     pub text: Arc<String>,
 }
 
 impl SourceFile {
+    /// Creates a new [`SourceFile`] from a name and source text.
     pub fn new(name: impl Into<Arc<str>>, text: impl Into<Arc<String>>) -> Self {
         Self {
             name: name.into(),

--- a/src/utils/suggest.rs
+++ b/src/utils/suggest.rs
@@ -20,6 +20,7 @@ where
     best.map(|(s, _)| s)
 }
 
+/// Computes the Levenshtein edit distance between two strings.
 fn levenshtein(a: &str, b: &str) -> usize {
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();


### PR DESCRIPTION
## What does this PR do?
Add docs for the following modules:
- Interpreter
- Checker
- REPL
- Resolver
- Docs
- LSP
- Tooling
