### PR TITLE
95 explicit type declaration

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -125,4 +125,11 @@ pub enum ExpressionKind {
         callee: Box<Expression>,
         args: Vec<Expression>,
     },
+
+    /// A type cast expression ` value as type `.
+    /// Used for non-literal casts; literal casts are constant-folded in the parser.
+    Cast {
+        value: Box<Expression>,
+        target_type: TypeAnnotation,
+    },
 }

--- a/src/checker/statements/expression.rs
+++ b/src/checker/statements/expression.rs
@@ -244,7 +244,7 @@ impl TypeChecker {
                         expression.span,
                     );
                 }
-                return CheckType::Unknown;
+                CheckType::Unknown
             }
             _ => CheckType::Unknown,
         }

--- a/src/checker/statements/expression.rs
+++ b/src/checker/statements/expression.rs
@@ -212,6 +212,40 @@ impl TypeChecker {
                     return_type: resolved_return,
                 }
             }
+
+            ExpressionKind::Cast { value, target_type } => {
+                let value_type = self.check_expression(value);
+                self.check_is_null(&value_type, value.span);
+
+                let castable = matches!(
+                    &value_type,
+                    CheckType::Known(
+                        TypeAnnotation::CInt
+                            | TypeAnnotation::CByte
+                            | TypeAnnotation::CFloat
+                            | TypeAnnotation::Float
+                            | TypeAnnotation::Int
+                            | TypeAnnotation::Byte
+                    ) | CheckType::Unknown
+                );
+
+                let valid_target = matches!(
+                    target_type,
+                    TypeAnnotation::Int | TypeAnnotation::Float | TypeAnnotation::Byte
+                );
+
+                if !castable || !valid_target {
+                    self.error(
+                        format!(
+                            "invalid cast: cannot cast {} to {:?}",
+                            value_type.info(),
+                            target_type
+                        ),
+                        expression.span,
+                    );
+                }
+                return CheckType::Unknown;
+            }
             _ => CheckType::Unknown,
         }
     }

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -450,6 +450,34 @@ impl Evaluator {
             ExpressionKind::Assign { name, .. } => {
                 return Err(self.err(format!("undefined variable '{}'", name), expression.span));
             }
+
+            ExpressionKind::Cast { value, target_type } => {
+                let val = self.evaluate(value)?;
+                self.check_not_null(&val, value.span)?;
+                match (&val, target_type) {
+                    (Value::Integer(n), TypeAnnotation::Float) => Value::Float(*n as f64),
+                    (Value::Integer(n), TypeAnnotation::Byte) => Value::Byte(*n as u8),
+                    (Value::Integer(_), TypeAnnotation::Int) => val,
+                    (Value::Float(f), TypeAnnotation::Int) => Value::Integer(*f as i64),
+                    (Value::Float(f), TypeAnnotation::Byte) => Value::Byte(*f as u8),
+                    (Value::Float(_), TypeAnnotation::Float) => val,
+                    (Value::Byte(b), TypeAnnotation::Float) => Value::Float(*b as f64),
+                    (Value::Byte(b), TypeAnnotation::Int) => Value::Integer(*b as i64),
+                    (Value::Byte(_), TypeAnnotation::Byte) => val,
+
+                    _ => {
+                        return Err(self.err(
+                            format!(
+                                "invalid cast: cannot cast {} to {:?}",
+                                val.type_name(),
+                                target_type
+                            ),
+                            expression.span,
+                        ));
+                    }
+                }
+            }
+
             _ => Value::Null,
         };
         Ok(value)

--- a/src/lexer/tokentypes.rs
+++ b/src/lexer/tokentypes.rs
@@ -98,6 +98,7 @@ pub enum TokenType {
     Else,
     Const,
     Dec,
+    As,
 
     // -- type keywords --
     Int,

--- a/src/lexer/types/identifier.rs
+++ b/src/lexer/types/identifier.rs
@@ -21,6 +21,7 @@ impl Tokenizer {
     /// | Types          | `int`, `float`, `bool`, `string`, `byte`, `char`, `arr` |
     /// | Declarations   | `dec`, `CONST`                                        |
     /// | Literals       | `true`, `false`, `null`                               |
+    /// | Special        | `as`                                                  |
     ///
     /// `CONST` in uppercase in intentional
     pub fn identifier(&mut self) {
@@ -56,6 +57,7 @@ impl Tokenizer {
             "if" => self.add_token(TokenType::If),
             "else" => self.add_token(TokenType::Else),
             "arr" => self.add_token(TokenType::Array),
+            "as" => self.add_token(TokenType::As),
 
             &_ => self.add_token(TokenType::Identifier(value)),
         }

--- a/src/lexer/types/number_literal.rs
+++ b/src/lexer/types/number_literal.rs
@@ -38,10 +38,6 @@ impl Tokenizer {
             self.add_token(TokenType::FloatLiteral(parsed_value));
         } else {
             let parsed_value: i64 = value.parse().unwrap();
-            if (0..=255).contains(&parsed_value) {
-                self.add_token(TokenType::ByteLiteral(parsed_value as u8));
-                return;
-            }
             self.add_token(TokenType::NumberLiteral(parsed_value));
         }
     }

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -407,44 +407,45 @@ impl Parser {
             log::debug!("found number");
             let span = self.previous_span();
             if let TokenType::NumberLiteral(n) = self.previous() {
-                if self.match_type(&[TokenType::As])
-                    && self.match_type(&[TokenType::Int, TokenType::Byte, TokenType::Float])
-                {
-                    match self.previous() {
-                        TokenType::Int => {
-                            return self.parse_postfix(
-                                Expression::new(ExpressionKind::Integer(n), span),
-                                start,
-                            );
-                        }
-
-                        TokenType::Float => {
-                            return self.parse_postfix(
-                                Expression::new(ExpressionKind::Float(n as f64), span),
-                                start,
-                            );
-                        }
-
-                        TokenType::Byte => {
-                            if !(0..=255).contains(&n) {
-                                return Err(
-                                    self.err(format!("value {} is too large for byte", n), span)
+                if self.match_type(&[TokenType::As]) {
+                    if self.match_type(&[TokenType::Int, TokenType::Byte, TokenType::Float]) {
+                        match self.previous() {
+                            TokenType::Int => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Integer(n), span),
+                                    start,
                                 );
                             }
-                            return self.parse_postfix(
-                                Expression::new(ExpressionKind::Byte(n as u8), span),
-                                start,
-                            );
-                        }
 
-                        other => {
-                            return Err(self.err(
-                                format!("expected int/byte/float types found {:?}", other),
-                                span,
-                            ));
+                            TokenType::Float => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Float(n as f64), span),
+                                    start,
+                                );
+                            }
+
+                            TokenType::Byte => {
+                                if !(0..=255).contains(&n) {
+                                    return Err(self
+                                        .err(format!("value {} is too large for byte", n), span));
+                                }
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Byte(n as u8), span),
+                                    start,
+                                );
+                            }
+
+                            other => {
+                                return Err(self.err(
+                                    format!("expected int/byte/float types found {:?}", other),
+                                    span,
+                                ));
+                            }
                         }
                     }
+                    return Err(self.err("expected type after `as`", self.previous_span()));
                 }
+
                 let expr = Expression::new(ExpressionKind::Integer(n), span);
                 return self.parse_postfix(expr, start);
             }
@@ -453,6 +454,44 @@ impl Parser {
         if self.match_type(&[TokenType::ByteLiteral(0)]) {
             let span = self.previous_span();
             if let TokenType::ByteLiteral(b) = self.previous() {
+                if self.match_type(&[TokenType::As]) {
+                    if self.match_type(&[TokenType::Int, TokenType::Byte, TokenType::Float]) {
+                        match self.previous() {
+                            TokenType::Int => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Integer(b as i64), span),
+                                    start,
+                                );
+                            }
+
+                            TokenType::Float => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Float(b as f64), span),
+                                    start,
+                                );
+                            }
+
+                            TokenType::Byte => {
+                                if !(0..=255).contains(&b) {
+                                    return Err(self
+                                        .err(format!("value {} is too large for byte", b), span));
+                                }
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Byte(b as u8), span),
+                                    start,
+                                );
+                            }
+
+                            other => {
+                                return Err(self.err(
+                                    format!("expected int/byte/float types found {:?}", other),
+                                    span,
+                                ));
+                            }
+                        }
+                    }
+                    return Err(self.err("expected type after `as`", self.previous_span()));
+                }
                 let expr = Expression::new(ExpressionKind::Byte(b), span);
                 return self.parse_postfix(expr, start);
             }
@@ -495,7 +534,45 @@ impl Parser {
             log::debug!("oh no found float");
             let span = self.previous_span();
             if let TokenType::FloatLiteral(f) = self.previous() {
-                let expr = Expression::new(ExpressionKind::Float(f), span);
+                if self.match_type(&[TokenType::As]) {
+                    if self.match_type(&[TokenType::Int, TokenType::Byte, TokenType::Float]) {
+                        match self.previous() {
+                            TokenType::Int => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Integer(f as i64), span),
+                                    start,
+                                );
+                            }
+
+                            TokenType::Float => {
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Float(f as f64), span),
+                                    start,
+                                );
+                            }
+
+                            TokenType::Byte => {
+                                if !(0.0..=255.0).contains(&f) {
+                                    return Err(self
+                                        .err(format!("value {} is too large for byte", f), span));
+                                }
+                                return self.parse_postfix(
+                                    Expression::new(ExpressionKind::Byte(f as u8), span),
+                                    start,
+                                );
+                            }
+
+                            other => {
+                                return Err(self.err(
+                                    format!("expected int/byte/float types found {:?}", other),
+                                    span,
+                                ));
+                            }
+                        }
+                    }
+                    return Err(self.err("expected type after `as`", span));
+                }
+                let expr = Expression::new(ExpressionKind::Float(f), self.previous_span());
                 return self.parse_postfix(expr, start);
             }
         }

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -477,7 +477,7 @@ impl Parser {
                                         .err(format!("value {} is too large for byte", b), span));
                                 }
                                 return self.parse_postfix(
-                                    Expression::new(ExpressionKind::Byte(b as u8), span),
+                                    Expression::new(ExpressionKind::Byte(b), span),
                                     start,
                                 );
                             }
@@ -546,7 +546,7 @@ impl Parser {
 
                             TokenType::Float => {
                                 return self.parse_postfix(
-                                    Expression::new(ExpressionKind::Float(f as f64), span),
+                                    Expression::new(ExpressionKind::Float(f), span),
                                     start,
                                 );
                             }

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -407,6 +407,44 @@ impl Parser {
             log::debug!("found number");
             let span = self.previous_span();
             if let TokenType::NumberLiteral(n) = self.previous() {
+                if self.match_type(&[TokenType::As])
+                    && self.match_type(&[TokenType::Int, TokenType::Byte, TokenType::Float])
+                {
+                    match self.previous() {
+                        TokenType::Int => {
+                            return self.parse_postfix(
+                                Expression::new(ExpressionKind::Integer(n), span),
+                                start,
+                            );
+                        }
+
+                        TokenType::Float => {
+                            return self.parse_postfix(
+                                Expression::new(ExpressionKind::Float(n as f64), span),
+                                start,
+                            );
+                        }
+
+                        TokenType::Byte => {
+                            if !(0..=255).contains(&n) {
+                                return Err(
+                                    self.err(format!("value {} is too large for byte", n), span)
+                                );
+                            }
+                            return self.parse_postfix(
+                                Expression::new(ExpressionKind::Byte(n as u8), span),
+                                start,
+                            );
+                        }
+
+                        other => {
+                            return Err(self.err(
+                                format!("expected int/byte/float types found {:?}", other),
+                                span,
+                            ));
+                        }
+                    }
+                }
                 let expr = Expression::new(ExpressionKind::Integer(n), span);
                 return self.parse_postfix(expr, start);
             }

--- a/src/parser/expressions/mod.rs
+++ b/src/parser/expressions/mod.rs
@@ -705,6 +705,19 @@ impl Parser {
                     },
                     span,
                 );
+            } else if self.match_type(&[TokenType::As]) {
+                let span = self.previous_span();
+                let target_type = self
+                    .parse_type(true)
+                    .map_err(|_| self.err("expected type after `as`", span))?;
+                let span = start.join(self.previous_span());
+                expr = Expression::new(
+                    ExpressionKind::Cast {
+                        value: Box::new(expr),
+                        target_type,
+                    },
+                    span,
+                )
             } else {
                 break;
             }

--- a/src/resolver/expressions.rs
+++ b/src/resolver/expressions.rs
@@ -145,6 +145,11 @@ impl Resolver {
                     .collect(),
             },
 
+            ExpressionKind::Cast { value, target_type } => ExpressionKind::Cast {
+                value: Box::new(self.resolve_expression(*value)),
+                target_type,
+            },
+
             other => other,
         };
 

--- a/tests/interpreter/std/bitwise.rs
+++ b/tests/interpreter/std/bitwise.rs
@@ -53,7 +53,7 @@ dec int x = bit_not(0)
 
     assert_eq!(
         evaluator.get_value_raw("x"),
-        Some(Value::Integer(!0i64 as i64))
+        Some(Value::Integer(!0i64 ))
     );
 }
 

--- a/tests/interpreter/std/bitwise.rs
+++ b/tests/interpreter/std/bitwise.rs
@@ -53,7 +53,7 @@ dec int x = bit_not(0)
 
     assert_eq!(
         evaluator.get_value_raw("x"),
-        Some(Value::Integer(!0u8 as i64))
+        Some(Value::Integer(!0i64 as i64))
     );
 }
 
@@ -108,7 +108,7 @@ dec int x = leading_zeros(8)
 
     assert_eq!(
         evaluator.get_value_raw("x"),
-        Some(Value::Integer(8u8.leading_zeros() as i64))
+        Some(Value::Integer(8i64.leading_zeros() as i64))
     );
 }
 
@@ -124,6 +124,6 @@ dec int x = trailing_zeros(8)
 
     assert_eq!(
         evaluator.get_value_raw("x"),
-        Some(Value::Integer(8u8.trailing_zeros() as i64))
+        Some(Value::Integer(8i64.trailing_zeros() as i64))
     );
 }


### PR DESCRIPTION
## What does this PR do?
Add explicit value type
Add explicit Cast for identifiers

~~### current limitations~~
~~- cannot be used on identifiers~~
~~- works only on the value directly~~
  ~~- using `std::types` to convert between types is the solution~~

### usage
```rl
dec int x = 10.3 as int
dec byte y = 10 as byte
dec float z = 12 as float
```

## Related issue
Closes #95 
