### PR TITLE
99 resolve the following bugs

### DIFF
--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -358,8 +358,8 @@ impl Evaluator {
             } => {
                 let left_val = self.evaluate(left)?;
                 let right_val = self.evaluate(right)?;
-                if matches!(operator, TokenType::Compare | TokenType::BangEqual) {
-                    if matches!(left_val, Value::Null) || matches!(right_val, Value::Null) {
+                if matches!(operator, TokenType::Compare | TokenType::BangEqual)
+                    && (matches!(left_val, Value::Null) || matches!(right_val, Value::Null)) {
                         let result = matches!((&left_val, &right_val), (Value::Null, Value::Null));
                         return Ok(if matches!(operator, TokenType::Compare) {
                             Value::Bool(result)
@@ -367,7 +367,6 @@ impl Evaluator {
                             Value::Bool(!result)
                         });
                     }
-                }
                 self.check_not_null(&left_val, left.span)?;
                 self.check_not_null(&right_val, right.span)?;
                 self.match_binary_operator(

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
+use crate::lexer::tokentypes::TokenType;
 use crate::resolver::Resolver;
 use crate::{
     ast::{
@@ -356,8 +357,18 @@ impl Evaluator {
                 right,
             } => {
                 let left_val = self.evaluate(left)?;
-                self.check_not_null(&left_val, left.span)?;
                 let right_val = self.evaluate(right)?;
+                if matches!(operator, TokenType::Compare | TokenType::BangEqual) {
+                    if matches!(left_val, Value::Null) || matches!(right_val, Value::Null) {
+                        let result = matches!((&left_val, &right_val), (Value::Null, Value::Null));
+                        return Ok(if matches!(operator, TokenType::Compare) {
+                            Value::Bool(result)
+                        } else {
+                            Value::Bool(!result)
+                        });
+                    }
+                }
+                self.check_not_null(&left_val, left.span)?;
                 self.check_not_null(&right_val, right.span)?;
                 self.match_binary_operator(
                     left_val,

--- a/src/interpreter/utils/binary.rs
+++ b/src/interpreter/utils/binary.rs
@@ -94,11 +94,29 @@ impl Evaluator {
                 }
             },
             TokenType::Slash => match (&left, &right) {
-                (Value::Integer(a), Value::Integer(b)) => Value::Integer(a / b),
+                (Value::Integer(a), Value::Integer(b)) => {
+                    if *b == 0 {
+                        return Err(self.err("division by zero", span));
+                    }
+                    Value::Integer(a / b)
+                }
                 (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
-                (Value::Integer(a), Value::Byte(b)) => Value::Integer(a / *b as i64),
-                (Value::Byte(a), Value::Integer(b)) => Value::Integer(*a as i64 / b),
+                (Value::Integer(a), Value::Byte(b)) => {
+                    if *b == 0 {
+                        return Err(self.err("division by zero", span));
+                    }
+                    Value::Integer(a / *b as i64)
+                }
+                (Value::Byte(a), Value::Integer(b)) => {
+                    if *b == 0 {
+                        return Err(self.err("division by zero", span));
+                    }
+                    Value::Integer(*a as i64 / b)
+                }
                 (Value::Byte(a), Value::Byte(b)) => {
+                    if *b == 0 {
+                        return Err(self.err("division by zero", span));
+                    }
                     let ab = *a as i64 / *b as i64;
                     if !(0..=255).contains(&ab) {
                         Value::Integer(ab)

--- a/src/interpreter/utils/binary.rs
+++ b/src/interpreter/utils/binary.rs
@@ -101,18 +101,6 @@ impl Evaluator {
                     Value::Integer(a / b)
                 }
                 (Value::Float(a), Value::Float(b)) => Value::Float(a / b),
-                (Value::Integer(a), Value::Byte(b)) => {
-                    if *b == 0 {
-                        return Err(self.err("division by zero", span));
-                    }
-                    Value::Integer(a / *b as i64)
-                }
-                (Value::Byte(a), Value::Integer(b)) => {
-                    if *b == 0 {
-                        return Err(self.err("division by zero", span));
-                    }
-                    Value::Integer(*a as i64 / b)
-                }
                 (Value::Byte(a), Value::Byte(b)) => {
                     if *b == 0 {
                         return Err(self.err("division by zero", span));

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -88,7 +88,7 @@ impl Evaluator {
                     Value::Values { items, .. } => {
                         for item in &items {
                             let actual = Self::infer_type(item, false);
-                            if !Self::types_compatible(&actual, &type_annotation) {
+                            if !Self::types_compatible(&actual, type_annotation) {
                                 return Err(self.err(
                                     format!(
                                         "array element type mismatch: expected {:?}, found {:?}",
@@ -125,7 +125,7 @@ impl Evaluator {
                     Value::Values { items, .. } => {
                         for item in &items {
                             let actual = Self::infer_type(item, false);
-                            if !Self::types_compatible(&actual, &type_annotation) {
+                            if !Self::types_compatible(&actual, type_annotation) {
                                 return Err(self.err(
                                     format!(
                                         "array element type mismatch: expected {:?}, found {:?}",

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -85,10 +85,24 @@ impl Evaluator {
             } => {
                 let val = self.evaluate(value)?;
                 let val = match val {
-                    Value::Values { items, .. } => Value::Values {
-                        items_type: type_annotation.clone(),
-                        items,
-                    },
+                    Value::Values { items, .. } => {
+                        for item in &items {
+                            let actual = Self::infer_type(item, false);
+                            if !Self::types_compatible(&actual, &type_annotation) {
+                                return Err(self.err(
+                                    format!(
+                                        "array element type mismatch: expected {:?}, found {:?}",
+                                        type_annotation, actual
+                                    ),
+                                    statement.span,
+                                ));
+                            }
+                        }
+                        Value::Values {
+                            items_type: type_annotation.clone(),
+                            items,
+                        }
+                    }
                     other => {
                         return Err(self.err(
                             format!("expected array value found {}", other.type_name()),
@@ -108,10 +122,24 @@ impl Evaluator {
             } => {
                 let val = self.evaluate(value)?;
                 let val = match val {
-                    Value::Values { items, .. } => Value::Values {
-                        items_type: type_annotation.clone(),
-                        items,
-                    },
+                    Value::Values { items, .. } => {
+                        for item in &items {
+                            let actual = Self::infer_type(item, false);
+                            if !Self::types_compatible(&actual, &type_annotation) {
+                                return Err(self.err(
+                                    format!(
+                                        "array element type mismatch: expected {:?}, found {:?}",
+                                        type_annotation, actual
+                                    ),
+                                    statement.span,
+                                ));
+                            }
+                        }
+                        Value::Values {
+                            items_type: type_annotation.clone(),
+                            items,
+                        }
+                    }
                     other => {
                         return Err(self.err(
                             format!("expected array value found {}", other.type_name()),

--- a/src/lexer/tokenizer.rs
+++ b/src/lexer/tokenizer.rs
@@ -57,9 +57,9 @@ impl Tokenizer {
     ///     },
     /// };
     ///
-    /// assert_eq!(tokens[0].token, TokenType::ByteLiteral(1));
+    /// assert_eq!(tokens[0].token, TokenType::NumberLiteral(1));
     /// assert_eq!(tokens[1].token, TokenType::Compare);
-    /// assert_eq!(tokens[2].token, TokenType::ByteLiteral(1));
+    /// assert_eq!(tokens[2].token, TokenType::NumberLiteral(1));
     /// assert_eq!(tokens[3].token, TokenType::Eof);
     /// ```
     pub fn lex(source_file: SourceFile) -> Result<Vec<Token>, Error> {


### PR DESCRIPTION
## What does this PR do?
Add division by zero check
Allow Equal `==` and Not Equal `!=` for `null`s
Change `ResolvedArray` and `ResolvedConstantArray` items to be checked to allow stricter items type 


## Related issue
Closes #99

