### PR TITLE
add arr_zip function

### DIFF
--- a/src/interpreter/stdlib/array/arr_zip.rs
+++ b/src/interpreter/stdlib/array/arr_zip.rs
@@ -1,0 +1,45 @@
+use crate::ast::statements::TypeAnnotation;
+use crate::interpreter::{evaluator::Evaluator, values::Value};
+use crate::utils::errors::{Error, Reason};
+use crate::utils::span::Span;
+
+/// Zips two arrays into an array of tuples.
+///
+/// `arr_zip([1, 2, 3], ["a", "b", "c"])` → `[(1, "a"), (2, "b"), (3, "c")]`
+///
+/// Stops at the shorter array (same behaviour as Rust's `zip`).
+pub fn std_arr_zip(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+    if args.len() != 2 {
+        return Err(Error::at(
+            Reason::Runtime,
+            format!("arr_zip: expected 2 arguments, got {}", args.len()),
+            span,
+        ));
+    }
+
+    let (a, b) = match (&args[0], &args[1]) {
+        (Value::Values { items: a, .. }, Value::Values { items: b, .. }) => (a, b),
+        _ => {
+            return Err(Error::at(
+                Reason::Runtime,
+                format!(
+                    "arr_zip: expected two arrays, got {} and {}",
+                    args[0].type_name(),
+                    args[1].type_name()
+                ),
+                span,
+            ));
+        }
+    };
+
+    let items = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| Value::Tuple(vec![x.clone(), y.clone()]))
+        .collect();
+
+    Ok(Value::Values {
+        items_type: TypeAnnotation::Tuple(vec![TypeAnnotation::Null, TypeAnnotation::Null]),
+        items,
+    })
+}

--- a/src/interpreter/stdlib/array/mod.rs
+++ b/src/interpreter/stdlib/array/mod.rs
@@ -39,6 +39,7 @@ mod arr_sort;
 mod arr_sort_by;
 mod arr_sum;
 mod arr_unique;
+mod arr_zip;
 
 pub const KEYWORDS: &[&str] = &[
     "arr_push",
@@ -74,6 +75,7 @@ pub const KEYWORDS: &[&str] = &[
     "arr_sort_by",
     "arr_flat_map",
     "arr_for_each",
+    "arr_zip",
 ];
 
 pub fn module() -> Module {
@@ -111,4 +113,5 @@ pub fn module() -> Module {
         .with_function("arr_sort_by", arr_sort_by::std_arr_sort_by)
         .with_function("arr_flat_map", arr_flat_map::std_arr_flat_map)
         .with_function("arr_for_each", arr_for_each::std_arr_for_each)
+        .with_raw_function("arr_zip", arr_zip::std_arr_zip)
 }


### PR DESCRIPTION
## What does this PR do?
add `arr_zip` function to `std::array`

## Related issue
Closes #39

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
