### PR TITLE
Feat/package command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
 use clap::{Parser, Subcommand};
 use rl_lang::docs;
 use rl_lang::tooling::new::create_project;
+use rl_lang::tooling::package::{find_embedded, package};
 use std::path::PathBuf;
 
 #[cfg(feature = "lsp")]
@@ -69,9 +70,29 @@ enum Commands {
     /// Start the LSP server
     #[cfg(feature = "lsp")]
     Lsp,
+
+    /// Package a .rl file into a self-contained binary
+    Package {
+        /// Path to the .rl source file
+        file: PathBuf,
+        /// Output binary path
+        #[arg(short, long, default_value = "program")]
+        output: String,
+    },
 }
 
 fn main() {
+    // expriemental
+    if let Some(source) = find_embedded() {
+        let sf = SourceFile::new("program", source);
+        let tokens = lexing_loop(sf.clone());
+        let statements = parsing_loop(sf.clone(), tokens);
+        if cfg!(feature = "eval") {
+            eval_loop(sf, statements);
+        }
+        return;
+    }
+
     let cli = Cli::parse();
 
     match cli.command {
@@ -220,5 +241,13 @@ fn main() {
                 std::process::exit(1);
             }
         },
+
+        Commands::Package { file, output } => {
+            let path = file.to_str().unwrap_or_else(|| {
+                eprintln!("error: invalid file path");
+                std::process::exit(1);
+            });
+            package(path, &output);
+        }
     }
 }

--- a/src/tooling/mod.rs
+++ b/src/tooling/mod.rs
@@ -4,3 +4,4 @@
 //! - [`dev`] - project manifest parsing (`rl.toml`)
 pub mod dev;
 pub mod new;
+pub mod package;

--- a/src/tooling/package.rs
+++ b/src/tooling/package.rs
@@ -15,11 +15,13 @@
 //! The magic + length are appended *after* the source so detection only
 //! needs to read the last few bytes — no full scan required.
 
+use std::collections::HashSet;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
 const MAGIC: &[u8] = b"\x00RL_PACKAGE_V1\x00";
-const MAGIC_LEN: usize = 15; // b"\x00RL_PACKAGE_V1\x00".len()
-const FOOTER_LEN: usize = MAGIC_LEN + 8; // magic + u64
+const MAGIC_LEN: usize = 15;
+const FOOTER_LEN: usize = MAGIC_LEN + 8;
 
 /// Searches the running binary's own bytes for an embedded rl program.
 ///
@@ -65,7 +67,7 @@ pub fn package(source_path: &str, output_path: &str) {
 }
 
 fn try_package(source_path: &str, output_path: &str) -> std::io::Result<()> {
-    let source = std::fs::read_to_string(source_path)?;
+    let source = bundle(source_path)?;
     let self_bytes = std::fs::read(std::env::current_exe()?)?;
 
     let mut out = std::fs::File::create(output_path)?;
@@ -83,4 +85,57 @@ fn try_package(source_path: &str, output_path: &str) -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+fn bundle(entry_path: &str) -> std::io::Result<String> {
+    let mut visited = HashSet::new();
+    bundle_inner(Path::new(entry_path), &mut visited)
+}
+
+fn bundle_inner(path: &Path, visited: &mut HashSet<PathBuf>) -> std::io::Result<String> {
+    let canonical = path.canonicalize()?;
+    if visited.contains(&canonical) {
+        return Ok(String::new());
+    }
+    visited.insert(canonical.clone());
+
+    let source = std::fs::read_to_string(path)?;
+    let base_dir = path.parent().unwrap_or(Path::new("."));
+    let mut output = String::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+
+        if let Some(rest) = trimmed.strip_prefix("get ") {
+            // extract the file name from either form:
+            // "get csv"  ->  file_part = "csv"
+            // "get x, y from csv"  ->  file_part = "csv"
+            let file_part = if let Some(from_idx) = rest.find(" from ") {
+                rest[from_idx + 6..].trim()
+            } else {
+                rest.trim()
+            };
+
+            // only inline local files, not std::
+            if !file_part.contains("::") {
+                let rel: PathBuf = file_part.split('/').collect();
+                let file_path = base_dir.join(rel).with_extension("rl");
+                match bundle_inner(&file_path, visited) {
+                    Ok(inlined) => {
+                        output.push_str(&inlined);
+                        output.push('\n');
+                        continue;
+                    }
+                    Err(e) => {
+                        eprintln!("warning: could not bundle '{}': {}", file_path.display(), e);
+                    }
+                }
+            }
+        }
+
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    Ok(output)
 }

--- a/src/tooling/package.rs
+++ b/src/tooling/package.rs
@@ -1,0 +1,86 @@
+//! rl package - bundle a .rl program into a self-contained binary.
+//!
+//! Copies the rl binary itself, then appends the source text and a
+//! magic footer so the copy can detect and run the embedded program at
+//! startup without any arguments.
+//!
+//! # Binary layout after packaging
+//!
+//! [ original rl binary bytes ]
+//! [ rl source text (UTF-8)   ]
+//! [ magic marker: \x00RL_PACKAGE_V1\x00 ]
+//! [ source length: u64 little-endian    ]
+//!
+//!
+//! The magic + length are appended *after* the source so detection only
+//! needs to read the last few bytes — no full scan required.
+
+use std::io::Write;
+
+const MAGIC: &[u8] = b"\x00RL_PACKAGE_V1\x00";
+const MAGIC_LEN: usize = 16; // b"\x00RL_PACKAGE_V1\x00".len()
+const FOOTER_LEN: usize = MAGIC_LEN + 8; // magic + u64
+
+/// Searches the running binary's own bytes for an embedded rl program.
+///
+/// Returns Some(source) if this binary was produced by rl package,
+/// or None if it is a plain rl binary.
+pub fn find_embedded() -> Option<String> {
+    let path = std::env::current_exe().ok()?;
+    let bytes = std::fs::read(path).ok()?;
+
+    if bytes.len() < FOOTER_LEN {
+        return None;
+    }
+
+    // read length from the final 8 bytes
+    let len_start = bytes.len() - 8;
+    let len = u64::from_le_bytes(bytes[len_start..].try_into().ok()?) as usize;
+
+    // verify magic sits just before the length
+    let magic_start = len_start.checked_sub(MAGIC_LEN)?;
+    if &bytes[magic_start..len_start] != MAGIC {
+        return None;
+    }
+
+    // source sits just before the magic
+    let source_start = magic_start.checked_sub(len)?;
+    let source_end = magic_start;
+
+    String::from_utf8(bytes[source_start..source_end].to_vec()).ok()
+}
+
+/// Packages source_path into a self-contained binary at output_path.
+///
+/// Copies the running rl binary verbatim, then appends the rl source
+/// and the magic footer. The output is made executable on Unix.
+///
+/// Prints an error and exits with code 1 on any failure.
+pub fn package(source_path: &str, output_path: &str) {
+    if let Err(e) = try_package(source_path, output_path) {
+        eprintln!("error: packaging failed: {}", e);
+        std::process::exit(1);
+    }
+    println!("packaged '{}' -> '{}'", source_path, output_path);
+}
+
+fn try_package(source_path: &str, output_path: &str) -> std::io::Result<()> {
+    let source = std::fs::read_to_string(source_path)?;
+    let self_bytes = std::fs::read(std::env::current_exe()?)?;
+
+    let mut out = std::fs::File::create(output_path)?;
+    out.write_all(&self_bytes)?;
+    out.write_all(source.as_bytes())?;
+    out.write_all(MAGIC)?;
+    out.write_all(&(source.len() as u64).to_le_bytes())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(output_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(output_path, perms)?;
+    }
+
+    Ok(())
+}

--- a/src/tooling/package.rs
+++ b/src/tooling/package.rs
@@ -18,7 +18,7 @@
 use std::io::Write;
 
 const MAGIC: &[u8] = b"\x00RL_PACKAGE_V1\x00";
-const MAGIC_LEN: usize = 16; // b"\x00RL_PACKAGE_V1\x00".len()
+const MAGIC_LEN: usize = 15; // b"\x00RL_PACKAGE_V1\x00".len()
 const FOOTER_LEN: usize = MAGIC_LEN + 8; // magic + u64
 
 /// Searches the running binary's own bytes for an embedded rl program.


### PR DESCRIPTION
## What does this PR do?
Add way to run programs written in `rl` without the runtime

**How does it work**
the `rl package` command copies the bytes of the binary (please do not `cargo run package` resulting binary would be 50mb+ and low performance compared to `rl package`)
and append a magic identifier then appends the source code data 
it searches for import external file keywords to append said file as well

**usage**
```bash
rl package main.rl
```

> [!IMPORTANT]
> this is experimental feature  
 