### PR TITLE
add read_bytes function that returns arr[bytes]

### DIFF
--- a/src/interpreter/stdlib/io/mod.rs
+++ b/src/interpreter/stdlib/io/mod.rs
@@ -12,6 +12,7 @@ mod eprint;
 mod input;
 mod print;
 mod println;
+mod read_bytes;
 mod read_file;
 mod read_lines;
 mod write_file;
@@ -30,6 +31,7 @@ pub const KEYWORDS: &[&str] = &[
     "print",
     "println",
     "eprint",
+    "read_bytes",
 ];
 
 pub fn module() -> Module {
@@ -45,4 +47,5 @@ pub fn module() -> Module {
         .with_raw_function("print", print::std_print)
         .with_raw_function("println", println::std_println)
         .with_function("eprint", eprint::std_eprint)
+        .with_function("read_bytes", read_bytes::func)
 }

--- a/src/interpreter/stdlib/io/plan.md
+++ b/src/interpreter/stdlib/io/plan.md
@@ -1,3 +1,0 @@
-# io
-
-- `read_bytes(path)` too expensive to implement with current setup will implement after adding byte type

--- a/src/interpreter/stdlib/io/read_bytes.rs
+++ b/src/interpreter/stdlib/io/read_bytes.rs
@@ -1,0 +1,23 @@
+use crate::{
+    ast::statements::TypeAnnotation,
+    interpreter::{evaluator::Evaluator, values::Value},
+    utils::{errors::Error, span::Span},
+};
+
+pub fn func(eval: &mut Evaluator, file: String, span: Span) -> Result<Value, Error> {
+    let data = std::fs::read(&file)
+        .map_err(|e| {
+            eval.err(
+                format!("read_bytes(): failed to read \"{}\": {}", file, e),
+                span,
+            )
+        })?
+        .into_iter()
+        .map(Value::Byte)
+        .collect::<Vec<Value>>();
+
+    Ok(Value::Values {
+        items_type: TypeAnnotation::Byte,
+        items: data,
+    })
+}


### PR DESCRIPTION
## What does this PR do?
add new function for `std::io` that returns an array of bytes for given file path `arr[bytes]`

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
