### PR TITLE
125 global clone fix

### DIFF
--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -43,7 +43,10 @@ pub enum EnvironmentItem {
 
 /// The tree-walking interpreter, carrying all runtime state.
 pub struct Evaluator {
+    /// Global scope, addressed at the outermost depth
+    pub globals: Vec<EnvironmentItem>,
     /// The environment stack - each frame is a scope; innermost is last.
+    /// Holds only local call frames
     pub environment: Vec<Vec<EnvironmentItem>>,
     /// Source file for Ariadne error rendering; `None` in embedded/test contexts.
     pub source_file: Option<SourceFile>,
@@ -76,7 +79,8 @@ impl Default for Evaluator {
 impl Evaluator {
     pub fn new() -> Self {
         Self {
-            environment: vec![vec![]],
+            globals: vec![],
+            environment: vec![],
             source_file: None,
             root_module: Module::new(""),
             return_value: None,
@@ -645,7 +649,7 @@ impl Evaluator {
             if params.len() != args.len() {
                 return Err(self.err(
                     format!(
-                        "function '' expects {} argument(s), got {}",
+                        "function expects {} argument(s), got {}",
                         params.len(),
                         args.len()
                     ),
@@ -653,14 +657,9 @@ impl Evaluator {
                 ));
             }
 
-            let saved_env = std::mem::take(&mut self.environment);
+            let saved_env = std::mem::replace(&mut self.environment, captured_env);
             let saved_return = self.return_value.take();
 
-            if captured_env.is_empty() {
-                self.environment = vec![saved_env[0].clone()]
-            } else {
-                self.environment = captured_env;
-            }
             self.push_scope();
 
             for (slot, (_, arg)) in params.iter().zip(args).enumerate() {
@@ -677,9 +676,7 @@ impl Evaluator {
 
             let result = self.return_value.take().unwrap_or(Value::Null);
 
-            let updated_global = self.environment[0].clone();
             self.environment = saved_env;
-            self.environment[0] = updated_global;
             self.return_value = saved_return;
 
             if let Some(expected) = &return_type
@@ -689,7 +686,7 @@ impl Evaluator {
                 if !Self::types_compatible(&actual, expected) {
                     return Err(self.err(
                         format!(
-                            "function '' declared to return {:?} but returned {:?}",
+                            "function declared to return {:?} but returned {:?}",
                             expected, actual
                         ),
                         span,

--- a/src/interpreter/evaluator_types/index_assign.rs
+++ b/src/interpreter/evaluator_types/index_assign.rs
@@ -80,11 +80,19 @@ impl Evaluator {
             )
         };
 
-        let env_idx = self.environment.len().saturating_sub(1 + depth);
-        let e = self.err(format!("no scope at depth {}", depth), span);
-        let e2 = self.err(format!("undefined slot {} at depth {}", slot, depth), span);
-        let frame = self.environment.get_mut(env_idx).ok_or(e)?;
-        let entry = frame.get_mut(slot).ok_or(e2)?;
+        // `depth >= environment.len()` means the target lives in the global
+        // scope, addressed via `self.globals` rather than the local frame
+        // stack. See `scopes.rs` for the same convention.
+        let entry: &mut EnvironmentItem = if depth >= self.environment.len() {
+            let e2 = self.err(format!("undefined slot {} at depth {}", slot, depth), span);
+            self.globals.get_mut(slot).ok_or(e2)?
+        } else {
+            let env_idx = self.environment.len() - 1 - depth;
+            let e = self.err(format!("no scope at depth {}", depth), span);
+            let e2 = self.err(format!("undefined slot {} at depth {}", slot, depth), span);
+            let frame = self.environment.get_mut(env_idx).ok_or(e)?;
+            frame.get_mut(slot).ok_or(e2)?
+        };
 
         match entry {
             EnvironmentItem::PItem(p) => {

--- a/src/interpreter/scopes.rs
+++ b/src/interpreter/scopes.rs
@@ -3,6 +3,10 @@
 //! The environment is a `Vec<Vec<EnvironmentItem>>` - a stack of frames.
 //! Each frame is a flat vec of slots indexed by the resolver's slot numbers.
 //! Depth 0 = current frame, depth 1 = one scope up, etc.
+//!
+//! Globals live in a separate `self.globals` field, addressed when `depth`
+//! points past the end of the local `environment` stack. This keeps globals
+//! from ever needing to be cloned in/out on function calls.
 
 use crate::{
     ast::statements::TypeAnnotation,
@@ -40,8 +44,15 @@ impl Evaluator {
     /// Reads the value at `(depth, slot)` in the environment.
     ///
     /// `depth` counts from the innermost frame outward (0 = current).
+    /// `depth >= environment.len()` means the target is the global scope.
     pub fn get_value(&self, depth: usize, slot: usize, span: Span) -> Result<Value, Error> {
-        let idx = self.environment.len().saturating_sub(1 + depth);
+        if depth >= self.environment.len() {
+            return match self.globals.get(slot) {
+                Some(EnvironmentItem::PItem(p)) => Ok(p.value.clone()),
+                None => Err(self.err(format!("undefined variable at ({}, {})", depth, slot), span)),
+            };
+        }
+        let idx = self.environment.len() - 1 - depth;
         match self.environment.get(idx).and_then(|f| f.get(slot)) {
             Some(EnvironmentItem::PItem(p)) => Ok(p.value.clone()),
             None => Err(self.err(format!("undefined variable at ({}, {})", depth, slot), span)),
@@ -58,6 +69,18 @@ impl Evaluator {
         type_annotation: TypeAnnotation,
         span: Span,
     ) -> Result<(), Error> {
+        if self.environment.is_empty() {
+            Self::ensure_slot(
+                &mut self.globals,
+                slot,
+                EnvironmentItem::PItem(PItem {
+                    value,
+                    type_annotation,
+                    is_const: false,
+                }),
+            );
+            return Ok(());
+        }
         let e = self.err("no active scope", span);
         let frame = self.environment.last_mut().ok_or(e)?;
         Self::ensure_slot(
@@ -72,6 +95,22 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Inserts a mutable value at `slot` in the global scope.
+    ///
+    /// Used for top-level `dec` declarations, which live in `self.globals`
+    /// rather than the local `environment` stack.
+    pub fn insert_global(&mut self, slot: usize, value: Value, type_annotation: TypeAnnotation) {
+        Self::ensure_slot(
+            &mut self.globals,
+            slot,
+            EnvironmentItem::PItem(PItem {
+                value,
+                type_annotation,
+                is_const: false,
+            }),
+        );
+    }
+
     /// Inserts an immutable (const) value at `slot` in the current frame.
     ///
     /// Returns an error if the slot already holds a const.
@@ -82,6 +121,18 @@ impl Evaluator {
         type_annotation: TypeAnnotation,
         span: Span,
     ) -> Result<(), Error> {
+        if self.environment.is_empty() {
+            Self::ensure_slot(
+                &mut self.globals,
+                slot,
+                EnvironmentItem::PItem(PItem {
+                    value,
+                    type_annotation,
+                    is_const: true,
+                }),
+            );
+            return Ok(());
+        }
         let e = self.err("no active scope", span);
         let frame = self.environment.last_mut().ok_or(e)?;
         if let Some(EnvironmentItem::PItem(p)) = frame.get(slot)
@@ -101,7 +152,37 @@ impl Evaluator {
         Ok(())
     }
 
+    /// Inserts an immutable (const) value at `slot` in the global scope.
+    ///
+    /// Used for top-level `const` declarations. Returns an error if the slot
+    /// already holds a const.
+    pub fn insert_const_global(
+        &mut self,
+        slot: usize,
+        value: Value,
+        type_annotation: TypeAnnotation,
+        span: Span,
+    ) -> Result<(), Error> {
+        if let Some(EnvironmentItem::PItem(p)) = self.globals.get(slot)
+            && p.is_const
+        {
+            return Err(self.err(format!("slot {} is already a constant", slot), span));
+        }
+        Self::ensure_slot(
+            &mut self.globals,
+            slot,
+            EnvironmentItem::PItem(PItem {
+                value,
+                type_annotation,
+                is_const: true,
+            }),
+        );
+        Ok(())
+    }
+
     /// Overwrites the value at `(depth, slot)`, enforcing type compatibility and immutability.
+    ///
+    /// `depth >= environment.len()` means the target is the global scope.
     pub fn assign_value(
         &mut self,
         depth: usize,
@@ -110,9 +191,47 @@ impl Evaluator {
         value_type: TypeAnnotation,
         span: Span,
     ) -> Result<(), Error> {
+        if depth >= self.environment.len() {
+            let e2 = self.err(format!("undefined slot {} at depth {}", slot, depth), span);
+            let entry = self.globals.get_mut(slot).ok_or(e2)?;
+            return match entry {
+                EnvironmentItem::PItem(p) => {
+                    if p.is_const {
+                        return Err(self.err("cannot assign to constant", span));
+                    }
+                    let declared = p.type_annotation.clone();
+                    let types_match = matches!(value, Value::Null)
+                        || match (&declared, &value_type) {
+                            (TypeAnnotation::Array(_), TypeAnnotation::Array(inner))
+                                if **inner == TypeAnnotation::Null =>
+                            {
+                                true
+                            }
+                            (TypeAnnotation::Array(a), TypeAnnotation::Array(_))
+                                if **a == TypeAnnotation::Null =>
+                            {
+                                true
+                            }
+                            _ => Evaluator::types_compatible(&value_type, &declared),
+                        };
+                    if !types_match {
+                        return Err(self.err(
+                            format!(
+                                "type mismatch: cannot assign {:?} to {:?}",
+                                value_type, declared
+                            ),
+                            span,
+                        ));
+                    }
+                    p.value = value;
+                    Ok(())
+                }
+            };
+        }
+
         let e = self.err(format!("no scope at depth {}", depth), span);
         let e2 = self.err(format!("undefined slot {} at depth {}", slot, depth), span);
-        let idx = self.environment.len().saturating_sub(1 + depth);
+        let idx = self.environment.len() - 1 - depth;
         let frame = self.environment.get_mut(idx).ok_or(e)?;
         let entry = frame.get_mut(slot).ok_or(e2)?;
         match entry {
@@ -153,7 +272,12 @@ impl Evaluator {
     /// Looks up a variable by name via the resolver - used only in tests.
     pub fn get_value_raw(&self, name: &str) -> Option<Value> {
         let (depth, slot) = self.resolver.resolve_name(name)?;
-        let idx = self.environment.len().saturating_sub(1 + depth);
+        if depth >= self.environment.len() {
+            return match self.globals.get(slot)? {
+                crate::interpreter::evaluator::EnvironmentItem::PItem(p) => Some(p.value.clone()),
+            };
+        }
+        let idx = self.environment.len() - 1 - depth;
         match self.environment.get(idx)?.get(slot)? {
             crate::interpreter::evaluator::EnvironmentItem::PItem(p) => Some(p.value.clone()),
         }
@@ -161,7 +285,12 @@ impl Evaluator {
 
     /// Returns the declared [`TypeAnnotation`] of the slot at `(depth, slot)`, if it exists.
     pub fn get_declared_type(&self, depth: usize, slot: usize) -> Option<TypeAnnotation> {
-        let idx = self.environment.len().saturating_sub(1 + depth);
+        if depth >= self.environment.len() {
+            return match self.globals.get(slot)? {
+                EnvironmentItem::PItem(p) => Some(p.type_annotation.clone()),
+            };
+        }
+        let idx = self.environment.len() - 1 - depth;
         match self.environment.get(idx)?.get(slot)? {
             EnvironmentItem::PItem(p) => Some(p.type_annotation.clone()),
         }


### PR DESCRIPTION
## What does this PR do?
Add `globals` field to evaluator

## Perf (i guess)
```bash
# before fix
❯ time ~/Downloads/rl\(1\) run x.rl
~/Downloads/rl\(1\) run x.rl  105.28s user 0.00s system 99% cpu 1:45.78 total

 # after fix
❯ time rl run x.rl
rl run x.rl  40.61s user 0.00s system 99% cpu 40.799 total
```

while not much but will retest after #124 and might change how `value` works or something similiar

## Related issue
Closes #125

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
