### PR TITLE
Change function value to use rc

### DIFF
--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -1,5 +1,6 @@
 //! Core evaluator - expression evaluation, function calls, and the runtime state.
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
@@ -548,8 +549,8 @@ impl Evaluator {
                 let captured_env: Vec<Vec<EnvironmentItem>> = self.environment[start..].to_vec();
 
                 Value::Function {
-                    params: params.clone(),
-                    body: body.clone(),
+                    params: Rc::new(params.clone()),
+                    body: Rc::new(body.clone()),
                     return_type: return_type.clone(),
                     captured_env,
                 }
@@ -667,7 +668,7 @@ impl Evaluator {
                 self.insert_value(slot, arg, arg_type, span)?;
             }
 
-            for statement in &body {
+            for statement in &*body {
                 self.evaluate_statement(statement)?;
                 if self.return_value.is_some() {
                     break;

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -7,8 +7,8 @@ use crate::{
     parser::parser_logic::Parser,
     utils::{errors::Error, source::SourceFile, span::Span},
 };
-use std::path::Path;
 use std::sync::Arc;
+use std::{path::Path, rc::Rc};
 
 impl Evaluator {
     /// Evaluates a single statement, mutating the environment and control-flow flags.
@@ -495,8 +495,8 @@ impl Evaluator {
                 ..
             } => {
                 let func = Value::Function {
-                    params: params.clone(),
-                    body: body.clone(),
+                    params: Rc::new(params.clone()),
+                    body: Rc::new(body.clone()),
                     return_type: Some(return_type.clone()),
                     captured_env: vec![],
                 };

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::statements::{Param, Statement, TypeAnnotation},
     interpreter::evaluator::EnvironmentItem,
 };
-use std::fmt;
+use std::{fmt, rc::Rc};
 
 /// A runtime value produced by evaluating an rl expression.
 #[derive(Debug, Clone, PartialEq)]
@@ -29,15 +29,17 @@ pub enum Value {
     },
     /// The absence of a value - equivalent to `null` in rl source.
     Null,
+
     /// A first-class function or lambda value, carrying its closure environment.
     Function {
-        params: Vec<Param>,
-        body: Vec<Statement>,
+        params: Rc<Vec<Param>>,
+        body: Rc<Vec<Statement>>,
         /// Declared return type; `None` for lambdas without an annotation.
         return_type: Option<TypeAnnotation>,
         /// The captured environment frames at the point of lambda definition.
         captured_env: Vec<Vec<EnvironmentItem>>,
     },
+
     /// A heterogeneous tuple of values.
     Tuple(Vec<Value>),
     /// An error value wrapping any non-error value.
@@ -90,7 +92,7 @@ impl fmt::Display for Value {
             Value::Null => write!(f, "null"),
             Value::Function { params, .. } => {
                 let mut params_name = vec![];
-                for param in params {
+                for param in params.iter() {
                     params_name.push(param.param_name.clone());
                 }
                 write!(f, "<fn({})>", params_name.join(", "))


### PR DESCRIPTION
## What does this PR do?
add `Rc` to function in `Value`s  to reduce `clone` cost

## Related issue
#125

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
