### PR TITLE
Refactor/index assign

### DIFF
--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -11,6 +11,7 @@ use crate::{
         nodes::{Expression, ExpressionKind},
         statements::TypeAnnotation,
     },
+    interpreter::evaluator_types::addressing::{get_indices_as_vec, try_get_root_addr},
     interpreter::{
         native::{IntoNativeFn, Module},
         stdlib,
@@ -313,85 +314,90 @@ impl Evaluator {
             ExpressionKind::Float(f) => Value::Float(*f),
             ExpressionKind::Character(c) => Value::Char(*c),
             ExpressionKind::Index { target, index } => {
-                let arr = self.evaluate(target)?;
-                self.check_not_null(&arr, target.span)?;
-                let idx = self.evaluate(index)?;
-                self.check_not_null(&idx, index.span)?;
-                match (&arr, &idx) {
-                    (Value::Values { items, .. }, Value::Integer(i)) => {
-                        let i_usize = *i as usize;
-                        if i_usize >= items.len() {
-                            return Err(self
-                                .err(
-                                    format!("index {} out of bounds (len {})", i, items.len()),
-                                    expression.span,
-                                )
-                                .with_label(
-                                    target.span,
-                                    format!("this array has length {}", items.len()),
-                                ));
+                if let Some((depth, slot)) = try_get_root_addr(expression) {
+                    let indices = get_indices_as_vec(expression, self, expression.span)?;
+                    self.index_read(depth, slot, &indices, expression.span)?
+                } else {
+                    let arr = self.evaluate(target)?;
+                    self.check_not_null(&arr, target.span)?;
+                    let idx = self.evaluate(index)?;
+                    self.check_not_null(&idx, index.span)?;
+                    match (&arr, &idx) {
+                        (Value::Values { items, .. }, Value::Integer(i)) => {
+                            let i_usize = *i as usize;
+                            if i_usize >= items.len() {
+                                return Err(self
+                                    .err(
+                                        format!("index {} out of bounds (len {})", i, items.len()),
+                                        expression.span,
+                                    )
+                                    .with_label(
+                                        target.span,
+                                        format!("this array has length {}", items.len()),
+                                    ));
+                            }
+                            items[i_usize].clone()
                         }
-                        items[i_usize].clone()
-                    }
-                    (Value::Values { items, .. }, Value::Byte(b)) => {
-                        let b_usize = *b as usize;
-                        if b_usize >= items.len() {
-                            return Err(self
-                                .err(
-                                    format!("index {} out of bounds (len {})", b, items.len()),
-                                    expression.span,
-                                )
-                                .with_label(
-                                    target.span,
-                                    format!("this array has length {}", items.len()),
-                                ));
+                        (Value::Values { items, .. }, Value::Byte(b)) => {
+                            let b_usize = *b as usize;
+                            if b_usize >= items.len() {
+                                return Err(self
+                                    .err(
+                                        format!("index {} out of bounds (len {})", b, items.len()),
+                                        expression.span,
+                                    )
+                                    .with_label(
+                                        target.span,
+                                        format!("this array has length {}", items.len()),
+                                    ));
+                            }
+                            items[b_usize].clone()
                         }
-                        items[b_usize].clone()
-                    }
 
-                    (Value::Tuple(items), Value::Integer(i)) => {
-                        let i_usize = *i as usize;
-                        if i_usize >= items.len() {
-                            return Err(self
-                                .err(
-                                    format!(
-                                        "tuple index {} out of bounds (len {})",
-                                        i,
-                                        items.len()
-                                    ),
-                                    expression.span,
-                                )
-                                .with_label(
-                                    target.span,
-                                    format!("this tuple has {} elements", items.len()),
-                                ));
+                        (Value::Tuple(items), Value::Integer(i)) => {
+                            let i_usize = *i as usize;
+                            if i_usize >= items.len() {
+                                return Err(self
+                                    .err(
+                                        format!(
+                                            "tuple index {} out of bounds (len {})",
+                                            i,
+                                            items.len()
+                                        ),
+                                        expression.span,
+                                    )
+                                    .with_label(
+                                        target.span,
+                                        format!("this tuple has {} elements", items.len()),
+                                    ));
+                            }
+                            items[i_usize].clone()
                         }
-                        items[i_usize].clone()
-                    }
-                    (Value::Tuple(items), Value::Byte(b)) => {
-                        let b_usize = *b as usize;
-                        if b_usize >= items.len() {
-                            return Err(self
-                                .err(
-                                    format!(
-                                        "tuple index {} out of bounds (len {})",
-                                        b,
-                                        items.len()
-                                    ),
-                                    expression.span,
-                                )
-                                .with_label(
-                                    target.span,
-                                    format!("this tuple has {} elements", items.len()),
-                                ));
+                        (Value::Tuple(items), Value::Byte(b)) => {
+                            let b_usize = *b as usize;
+                            if b_usize >= items.len() {
+                                return Err(self
+                                    .err(
+                                        format!(
+                                            "tuple index {} out of bounds (len {})",
+                                            b,
+                                            items.len()
+                                        ),
+                                        expression.span,
+                                    )
+                                    .with_label(
+                                        target.span,
+                                        format!("this tuple has {} elements", items.len()),
+                                    ));
+                            }
+                            items[b_usize].clone()
                         }
-                        items[b_usize].clone()
-                    }
-                    _ => {
-                        return Err(self
-                            .err("invalid index operation", expression.span)
-                            .with_label(target.span, format!("this is {}", arr.type_name()))
-                            .with_label(index.span, format!("this is {}", idx.type_name())));
+                        _ => {
+                            return Err(self
+                                .err("invalid index operation", expression.span)
+                                .with_label(target.span, format!("this is {}", arr.type_name()))
+                                .with_label(index.span, format!("this is {}", idx.type_name())));
+                        }
                     }
                 }
             }

--- a/src/interpreter/evaluator_types/addressing.rs
+++ b/src/interpreter/evaluator_types/addressing.rs
@@ -1,0 +1,39 @@
+use crate::{
+    ast::nodes::{Expression, ExpressionKind},
+    interpreter::{
+        evaluator::{EnvironmentItem, Evaluator},
+        values::Value,
+    },
+    utils::{errors::Error, span::Span},
+};
+
+pub fn get_root_addr(expression: &Expression) -> (usize, usize) {
+    match &expression.kind {
+        ExpressionKind::ResolvedIdentifier { depth, slot, .. } => (*depth, *slot),
+        ExpressionKind::Index { target, .. } => get_root_addr(target),
+        _ => unreachable!("index_assign: unexpected root expression"),
+    }
+}
+
+pub fn get_indices_as_vec(
+    expression: &Expression,
+    evaluator: &mut Evaluator,
+    span: Span,
+) -> Result<Vec<usize>, Error> {
+    match &expression.kind {
+        ExpressionKind::ResolvedIdentifier { .. } => Ok(vec![]),
+        ExpressionKind::Index { target, index } => {
+            let mut indices = get_indices_as_vec(target, evaluator, span)?;
+            if let Value::Integer(i) = evaluator.evaluate(index)? {
+                if i < 0 {
+                    return Err(evaluator.err(format!("index cannot be negative: {}", i), span));
+                }
+                indices.push(i as usize);
+            }
+
+            Ok(indices)
+        }
+        _ => unreachable!(),
+    }
+}
+

--- a/src/interpreter/evaluator_types/addressing.rs
+++ b/src/interpreter/evaluator_types/addressing.rs
@@ -49,3 +49,48 @@ pub fn get_indices_as_vec(
     }
 }
 
+impl Evaluator {
+    pub fn slot_ref(&self, depth: usize, slot: usize) -> Option<&EnvironmentItem> {
+        if depth >= self.environment.len() {
+            self.globals.get(slot)
+        } else {
+            let idx = self.environment.len() - 1 - depth;
+            self.environment.get(idx)?.get(slot)
+        }
+    }
+    pub fn slot_mut(&mut self, depth: usize, slot: usize) -> Option<&mut EnvironmentItem> {
+        if depth >= self.environment.len() {
+            self.globals.get_mut(slot)
+        } else {
+            let idx = self.environment.len() - 1 - depth;
+            self.environment.get_mut(idx)?.get_mut(slot)
+        }
+    }
+
+    /// Reads a `value` by walking indices from the root `(depth, slot)`,
+    /// borrowing at every step and cloning only the single final element
+    /// avoids cloning the whole container just to read one item out of it.
+    pub fn index_read(
+        &self,
+        depth: usize,
+        slot: usize,
+        indices: &[usize],
+        span: Span,
+    ) -> Result<Value, Error> {
+        let entry = self.slot_ref(depth, slot).ok_or_else(|| {
+            self.err(format!("undefined variable at ({}, {})", depth, slot), span)
+        })?;
+        let EnvironmentItem::PItem(p) = entry;
+
+        let mut current = &p.value;
+        for &i in indices {
+            current = match current {
+                Value::Values { items, .. } => items.get(i),
+                Value::Tuple(items) => items.get(i),
+                _ => None,
+            }
+            .ok_or_else(|| self.err(format!("index {} out of bounds", i), span))?;
+        }
+        Ok(current.clone())
+    }
+}

--- a/src/interpreter/evaluator_types/addressing.rs
+++ b/src/interpreter/evaluator_types/addressing.rs
@@ -15,6 +15,18 @@ pub fn get_root_addr(expression: &Expression) -> (usize, usize) {
     }
 }
 
+/// Non-panicking variant of `get_root_addr`, for call sites (like Index
+/// reads) where the target may not be addressable - e.g. foo()[0].
+/// Returns `None` instead of panicking so the caller can fall back to
+/// normal evaluation.
+pub fn try_get_root_addr(expression: &Expression) -> Option<(usize, usize)> {
+    match &expression.kind {
+        ExpressionKind::ResolvedIdentifier { depth, slot, .. } => Some((*depth, *slot)),
+        ExpressionKind::Index { target, .. } => try_get_root_addr(target),
+        _ => None,
+    }
+}
+
 pub fn get_indices_as_vec(
     expression: &Expression,
     evaluator: &mut Evaluator,

--- a/src/interpreter/evaluator_types/index_assign.rs
+++ b/src/interpreter/evaluator_types/index_assign.rs
@@ -8,12 +8,10 @@
 //! structure mutably to perform the assignment, enforcing type compatibility and bounds.
 
 use crate::{
-    ast::{
-        nodes::{Expression, ExpressionKind},
-        statements::TypeAnnotation,
-    },
+    ast::{nodes::Expression, statements::TypeAnnotation},
     interpreter::{
         evaluator::{EnvironmentItem, Evaluator},
+        evaluator_types::addressing::{get_indices_as_vec, get_root_addr},
         values::Value,
     },
     utils::{errors::Error, span::Span},
@@ -29,39 +27,6 @@ impl Evaluator {
     ) -> Result<Value, Error> {
         let idx = self.evaluate(index)?;
         let val = self.evaluate(value)?;
-
-        fn get_root_addr(expression: &Expression) -> (usize, usize) {
-            match &expression.kind {
-                ExpressionKind::ResolvedIdentifier { depth, slot, .. } => (*depth, *slot),
-                ExpressionKind::Index { target, .. } => get_root_addr(target),
-                _ => unreachable!("index_assign: unexpected root expression"),
-            }
-        }
-
-        fn get_indices_as_vec(
-            expression: &Expression,
-            evaluator: &mut Evaluator,
-            span: Span,
-        ) -> Result<Vec<usize>, Error> {
-            match &expression.kind {
-                ExpressionKind::ResolvedIdentifier { .. } => Ok(vec![]),
-                ExpressionKind::Index { target, index } => {
-                    let mut indices = get_indices_as_vec(target, evaluator, span)?;
-                    if let Value::Integer(i) = evaluator.evaluate(index)? {
-                        if i < 0 {
-                            return Err(
-                                evaluator.err(format!("index cannot be negative: {}", i), span)
-                            );
-                        }
-                        indices.push(i as usize);
-                    }
-
-                    Ok(indices)
-                }
-                _ => unreachable!(),
-            }
-        }
-
         let (depth, slot) = get_root_addr(target);
         let mut indices = get_indices_as_vec(target, self, span)?;
         if let Value::Integer(i) = idx {

--- a/src/interpreter/evaluator_types/mod.rs
+++ b/src/interpreter/evaluator_types/mod.rs
@@ -1,3 +1,4 @@
 //! Extra expression evaluation helpers that live outside the main `evaluator.rs`
 //! to keep it from becoming too large.
+pub mod addressing;
 mod index_assign;


### PR DESCRIPTION
## What does this PR do?
instead of reading the whole cloned container now it reads the address of value in array directly

## What changed
so for this code here

```rl
fn make_adder(int n) -> fn {
    return fn(int x) -> int { return x + n }
}

dec arr[fn] adders = []
dec int i = 0
while i < 1000 {
    adders = std::array::arr_push(adders, make_adder(i))
    i = i + 1
}

dec int iterations = 0
while iterations < 5000 {
    dec int j = 0
    while j < 1000 {
        dec fn f = adders[j]
        j = j + 1
    }
    iterations = iterations + 1
}
```

before applying the fix the result was... not good basically
`rl run x.rl  621.44s user 0.20s system 99% cpu 10:25.62 total`

now it is
`rl run x.rl  3.35s user 0.00s system 99% cpu 3.369 total`

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
