### PR TITLE
Refactor/add function attribute enum

### DIFF
--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -159,7 +159,7 @@ pub enum StatementKind {
         return_type: TypeAnnotation,
         body: Vec<Statement>,
         /// `true` when the function is marked with `!#[entry]`.
-        is_entry: bool,
+        attribute: FunctionAttribute,
     },
     /// Resolver-annotated function declaration. `slot` is the function's
     /// index in the current environment frame.
@@ -169,7 +169,7 @@ pub enum StatementKind {
         params: Vec<Param>,
         return_type: TypeAnnotation,
         body: Vec<Statement>,
-        is_entry: bool,
+        attribute: FunctionAttribute,
     },
     /// A `return expr` or bare `return` statement.
     Return(Option<Expression>),
@@ -217,6 +217,14 @@ pub enum StatementKind {
 pub enum MatchPattern {
     Literal(Expression),
     Wildcard,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FunctionAttribute {
+    Entry,
+    Init,
+    Final,
+    Test,
 }
 
 /// The type of a variable, constant, or parameter binding.

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -159,7 +159,7 @@ pub enum StatementKind {
         return_type: TypeAnnotation,
         body: Vec<Statement>,
         /// `true` when the function is marked with `!#[entry]`.
-        attribute: FunctionAttribute,
+        attribute: Option<FunctionAttribute>,
     },
     /// Resolver-annotated function declaration. `slot` is the function's
     /// index in the current environment frame.
@@ -169,7 +169,7 @@ pub enum StatementKind {
         params: Vec<Param>,
         return_type: TypeAnnotation,
         body: Vec<Statement>,
-        attribute: FunctionAttribute,
+        attribute: Option<FunctionAttribute>,
     },
     /// A `return expr` or bare `return` statement.
     Return(Option<Expression>),

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -1,7 +1,7 @@
 //! Statement evaluation - the main dispatch loop and control flow primitives.
 
 use crate::{
-    ast::statements::{MatchPattern, Statement, StatementKind, TypeAnnotation},
+    ast::statements::{FunctionAttribute, MatchPattern, Statement, StatementKind, TypeAnnotation},
     interpreter::{evaluator::Evaluator, values::Value},
     lexer::tokenizer::Tokenizer,
     parser::parser_logic::Parser,
@@ -673,25 +673,41 @@ impl Evaluator {
         let mut main_entry: Option<(Span, usize)> = None;
 
         for statement in statements {
-            if let StatementKind::FunctionDeclaration { name, is_entry, .. }
-            | StatementKind::ResolvedFunctionDeclaration { name, is_entry, .. } = &statement.kind
+            if let StatementKind::FunctionDeclaration {
+                name, attribute, ..
+            }
+            | StatementKind::ResolvedFunctionDeclaration {
+                name, attribute, ..
+            } = &statement.kind
             {
                 let slot = match &statement.kind {
                     StatementKind::ResolvedFunctionDeclaration { slot, .. } => Some(*slot),
                     _ => None,
                 };
-                if *is_entry {
-                    if explicit_entry.is_some() {
-                        return Err(self.err("multiple !#[entry] functions found", statement.span));
+
+                match attribute {
+                    Some(FunctionAttribute::Entry) => {
+                        if explicit_entry.is_some() {
+                            return Err(
+                                self.err("multiple !#[entry] functions found", statement.span)
+                            );
+                        }
+                        if let Some(s) = slot {
+                            explicit_entry = Some((statement.span, s));
+                        }
                     }
-                    if let Some(s) = slot {
-                        explicit_entry = Some((statement.span, s));
+
+                    Some(FunctionAttribute::Init) => {}
+                    Some(FunctionAttribute::Final) => {}
+                    Some(FunctionAttribute::Test) => {}
+
+                    &None => {
+                        if name == "main"
+                            && let Some(s) = slot
+                        {
+                            main_entry = Some((statement.span, s));
+                        }
                     }
-                }
-                if name == "main"
-                    && let Some(s) = slot
-                {
-                    main_entry = Some((statement.span, s));
                 }
             }
         }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -671,6 +671,9 @@ impl Evaluator {
     pub fn evaluate_program(&mut self, statements: &[Statement]) -> Result<(), Error> {
         let mut explicit_entry: Option<(Span, usize)> = None;
         let mut main_entry: Option<(Span, usize)> = None;
+        let mut inits: Vec<(Span, usize)> = vec![];
+        let mut finals: Vec<(Span, usize)> = vec![];
+        let mut tests: Vec<(Span, usize)> = vec![];
 
         for statement in statements {
             if let StatementKind::FunctionDeclaration {
@@ -697,9 +700,21 @@ impl Evaluator {
                         }
                     }
 
-                    Some(FunctionAttribute::Init) => {}
-                    Some(FunctionAttribute::Final) => {}
-                    Some(FunctionAttribute::Test) => {}
+                    Some(FunctionAttribute::Init) => {
+                        if let Some(s) = slot {
+                            inits.push((statement.span, s))
+                        }
+                    }
+                    Some(FunctionAttribute::Final) => {
+                        if let Some(s) = slot {
+                            finals.push((statement.span, s))
+                        }
+                    }
+                    Some(FunctionAttribute::Test) => {
+                        if let Some(s) = slot {
+                            tests.push((statement.span, s))
+                        }
+                    }
 
                     &None => {
                         if name == "main"
@@ -713,6 +728,10 @@ impl Evaluator {
         }
 
         let entry = explicit_entry.or(main_entry);
+        let has_tests = !tests.is_empty();
+        let has_inits = !inits.is_empty();
+        let has_finals = !finals.is_empty();
+
         let Some((entry_span, entry_slot)) = entry else {
             for statement in statements {
                 self.evaluate_statement(statement)?;
@@ -737,8 +756,35 @@ impl Evaluator {
                 _ => {}
             }
         }
+
+        // order goes tests -> inits -> entry -> finals
+        if has_tests {
+            for test_func in tests {
+                let (func_span, func_slot) = test_func;
+                let func = self.get_value(0, func_slot, func_span)?;
+                self.call_value(func, vec![], func_span)?;
+            }
+        }
+
+        if has_inits {
+            for init_func in inits {
+                let (func_span, func_slot) = init_func;
+                let func = self.get_value(0, func_slot, func_span)?;
+                self.call_value(func, vec![], func_span)?;
+            }
+        }
+
         let func = self.get_value(0, entry_slot, entry_span)?;
         self.call_value(func, vec![], entry_span)?;
+
+        if has_finals {
+            for final_func in finals {
+                let (func_span, func_slot) = final_func;
+                let func = self.get_value(0, func_slot, func_span)?;
+                self.call_value(func, vec![], func_span)?;
+            }
+        }
+
         Ok(())
     }
 

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -13,7 +13,7 @@
 //! preceded by a `!#[entry]` attribute, marking it as the program entry point.
 
 use crate::{
-    ast::statements::{Param, Statement, StatementKind, TypeAnnotation},
+    ast::statements::{FunctionAttribute, Param, Statement, StatementKind, TypeAnnotation},
     lexer::tokentypes::TokenType,
     parser::parser_logic::Parser,
     utils::{errors::Error, span::Span},
@@ -44,7 +44,11 @@ impl Parser {
     /// [`parse_statement_to_ast`]: Parser::parse_statement_to_ast
     /// [`parse_entry_attribute`]: Parser::parse_entry_attribute
     /// [`parse_block`]: Parser::parse_block
-    pub fn parse_function(&mut self, start: Span, is_entry: bool) -> Result<Statement, Error> {
+    pub fn parse_function(
+        &mut self,
+        start: Span,
+        attribute: FunctionAttribute,
+    ) -> Result<Statement, Error> {
         let name = match self.peek() {
             TokenType::Identifier(n) => {
                 self.advance();
@@ -93,7 +97,7 @@ impl Parser {
                 params,
                 return_type,
                 body,
-                is_entry,
+                attribute,
             },
             span,
         ))

--- a/src/parser/statements/function_declaration.rs
+++ b/src/parser/statements/function_declaration.rs
@@ -47,7 +47,7 @@ impl Parser {
     pub fn parse_function(
         &mut self,
         start: Span,
-        attribute: FunctionAttribute,
+        attribute: Option<FunctionAttribute>,
     ) -> Result<Statement, Error> {
         let name = match self.peek() {
             TokenType::Identifier(n) => {

--- a/src/parser/statements/mod.rs
+++ b/src/parser/statements/mod.rs
@@ -20,7 +20,7 @@ mod while_statement;
 use crate::{
     ast::{
         nodes::{Expression, ExpressionKind},
-        statements::{Statement, StatementKind},
+        statements::{FunctionAttribute, Statement, StatementKind},
     },
     lexer::tokentypes::TokenType,
     parser::parser_logic::Parser,
@@ -110,7 +110,7 @@ impl Parser {
                 self.advance();
                 #[cfg(feature = "debug")]
                 log::info!("found 'fn' while parsing");
-                self.parse_function(start, false)
+                self.parse_function(start, None)
             }
 
             TokenType::BangHash => {
@@ -205,22 +205,43 @@ impl Parser {
         if !self.match_type(&[TokenType::LeftBracket]) {
             return Err(self.err("expected `[` after `!#`", self.peek_span()));
         }
-        match self.peek() {
+
+        while self.match_type(&[TokenType::Newline]) {}
+
+        let attribute = match self.peek() {
             TokenType::Identifier(name) if name == "entry" => {
                 self.advance();
+                FunctionAttribute::Entry
             }
-            _ => return Err(self.err("expected `entry` attribute", self.peek_span())),
-        }
+            TokenType::Identifier(name) if name == "init" => {
+                self.advance();
+                FunctionAttribute::Init
+            }
+            TokenType::Identifier(name) if name == "final" => {
+                self.advance();
+                FunctionAttribute::Final
+            }
+            TokenType::Identifier(name) if name == "test" => {
+                self.advance();
+                FunctionAttribute::Test
+            }
+            _ => return Err(self.err("expected valid attribute", self.peek_span())),
+        };
+
+        while self.match_type(&[TokenType::Newline]) {}
+
         if !self.match_type(&[TokenType::RightBracket]) {
             return Err(self.err("expected `]` after entry attribute", self.peek_span()));
         }
+
         while self.match_type(&[TokenType::Newline]) {}
+
         if !self.match_type(&[TokenType::Fn]) {
             return Err(self.err(
-                "expected function declaration after `!#[entry]`",
+                "expected function declaration after `!#[<attribute>]`",
                 self.peek_span(),
             ));
         }
-        self.parse_function(start, true)
+        self.parse_function(start, Some(attribute))
     }
 }

--- a/src/resolver/statements.rs
+++ b/src/resolver/statements.rs
@@ -105,7 +105,7 @@ impl Resolver {
                 params,
                 return_type,
                 body,
-                is_entry,
+                attribute,
             } => {
                 let slot = self.declare(name.clone());
                 self.push_scope();
@@ -120,7 +120,7 @@ impl Resolver {
                     params,
                     return_type,
                     body,
-                    is_entry,
+                    attribute,
                 }
             }
             StatementKind::ForEach {

--- a/tests/parser/fns_lambdas.rs
+++ b/tests/parser/fns_lambdas.rs
@@ -1,7 +1,7 @@
 use rl_lang::{
     ast::{
         nodes::{Expression, ExpressionKind},
-        statements::{Param, Statement, StatementKind, TypeAnnotation},
+        statements::{FunctionAttribute, Param, Statement, StatementKind, TypeAnnotation},
     },
     utils::span::Span,
 };
@@ -19,7 +19,7 @@ fn fn_simple() {
                 param_type: TypeAnnotation::Int,
             }],
             return_type: TypeAnnotation::Null,
-            is_entry: false,
+            attribute: None,
             body: vec![Statement::new(
                 StatementKind::Return(Some(Expression::new(
                     ExpressionKind::Identifier("x".to_string()),
@@ -50,7 +50,7 @@ fn fn_fn_param() {
                 },
             ],
             return_type: TypeAnnotation::Null,
-            is_entry: false,
+            attribute: None,
             body: vec![Statement::new(
                 StatementKind::Return(Some(Expression::new(
                     ExpressionKind::Call {
@@ -104,9 +104,11 @@ fn dec_fn_lambda() {
 fn entry_attribute_marks_function() {
     let statements = common::parse("!#[entry]\nfn start () {return 1}");
     match &statements[0].kind {
-        StatementKind::FunctionDeclaration { name, is_entry, .. } => {
+        StatementKind::FunctionDeclaration {
+            name, attribute, ..
+        } => {
             assert_eq!(name, "start");
-            assert!(*is_entry);
+            assert_eq!(*attribute, Some(FunctionAttribute::Entry));
         }
         other => panic!("expected function declaration, got {:?}", other),
     }


### PR DESCRIPTION
## What does this PR do?
Add new attributes `test`, `init` , `final`
Now programs runs in this order
`test functions -> init functions -> entry function -> final functions`
program can have no tests , no inits and no finals or have any of them

the test functions should be separated later or kept as feature idk


## Related issue
Closes #67

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
