### PR TITLE
Perf/p item

### DIFF
--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -15,6 +15,8 @@
 //! bindings at the type level via separate variants (`Int` vs `CInt`, etc.).
 //!
 //! [`Resolver`]: crate::resolver
+use std::rc::Rc;
+
 use crate::ast::ExprId;
 use crate::utils::span::Span;
 
@@ -267,8 +269,8 @@ pub enum TypeAnnotation {
     /// Absence of a type - used as the default return type when none is annotated.
     Null,
 
-    Tuple(Vec<TypeAnnotation>),
-    CTuple(Vec<TypeAnnotation>),
+    Tuple(Rc<Vec<TypeAnnotation>>),
+    CTuple(Rc<Vec<TypeAnnotation>>),
 
     Error,
     CError,

--- a/src/checker/statements/expression.rs
+++ b/src/checker/statements/expression.rs
@@ -1,6 +1,8 @@
 //! Expression type checking - walks every [`ExpressionKind`] variant and
 //! returns the static [`CheckType`] of the expression.
 
+use std::rc::Rc;
+
 use crate::{
     ast::{ExprId, nodes::ExpressionKind, statements::TypeAnnotation},
     checker::{TypeChecker, structs::CheckType},
@@ -274,7 +276,7 @@ impl TypeChecker {
                         Self::to_type_annotation(&t)
                     })
                     .collect();
-                CheckType::Known(TypeAnnotation::Tuple(types))
+                CheckType::Known(TypeAnnotation::Tuple(Rc::new(types)))
             }
             ExpressionKind::ErrorLiteral(inner) => {
                 let inner_type = self.check_expression(inner);

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
+use crate::interpreter::values::FunctionData;
 use crate::lexer::tokentypes::TokenType;
 use crate::resolver::Resolver;
 use crate::{
@@ -613,12 +614,12 @@ impl Evaluator {
                 let start = total.saturating_sub(capture_depth);
                 let captured_env: Vec<Vec<EnvironmentItem>> = self.environment[start..].to_vec();
 
-                Ok(Value::Function {
+                Ok(Value::Function(Rc::new(FunctionData {
                     params: Rc::new(params),
                     body: Rc::new(body),
                     return_type,
                     captured_env,
-                })
+                })))
             }
 
             ExpressionKind::Identifier(name) => {
@@ -713,35 +714,29 @@ impl Evaluator {
         args: Vec<Value>,
         span: Span,
     ) -> Result<Value, Error> {
-        if let Value::Function {
-            params,
-            body,
-            return_type,
-            captured_env,
-        } = func
-        {
-            if params.len() != args.len() {
+        if let Value::Function(data) = func {
+            if data.params.len() != args.len() {
                 return Err(self.err(
                     format!(
                         "function expects {} argument(s), got {}",
-                        params.len(),
+                        data.params.len(),
                         args.len()
                     ),
                     span,
                 ));
             }
 
-            let saved_env = std::mem::replace(&mut self.environment, captured_env);
+            let saved_env = std::mem::replace(&mut self.environment, data.captured_env.clone());
             let saved_return = self.return_value.take();
 
             self.push_scope();
 
-            for (slot, (_, arg)) in params.iter().zip(args).enumerate() {
+            for (slot, (_, arg)) in data.params.iter().zip(args).enumerate() {
                 let arg_type = Self::infer_type(&arg, false);
                 self.insert_value(slot, arg, arg_type, span)?;
             }
 
-            for statement in &*body {
+            for statement in &*data.body {
                 self.evaluate_statement(statement)?;
                 if self.return_value.is_some() {
                     break;
@@ -753,7 +748,7 @@ impl Evaluator {
             self.environment = saved_env;
             self.return_value = saved_return;
 
-            if let Some(expected) = &return_type
+            if let Some(expected) = &data.return_type
                 && *expected != TypeAnnotation::Null
             {
                 let actual = Self::infer_type(&result, false);

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -230,9 +230,9 @@ impl Evaluator {
                 let inner: Vec<TypeAnnotation> =
                     items.iter().map(|v| Self::infer_type(v, false)).collect();
                 if is_const {
-                    TypeAnnotation::CTuple(inner)
+                    TypeAnnotation::CTuple(Rc::new(inner))
                 } else {
-                    TypeAnnotation::Tuple(inner)
+                    TypeAnnotation::Tuple(Rc::new(inner))
                 }
             }
             Value::Error(_) => {

--- a/src/interpreter/stdlib/array/arr_all.rs
+++ b/src/interpreter/stdlib/array/arr_all.rs
@@ -20,7 +20,7 @@ pub fn std_arr_all(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_all() expected function or lambda found {}",
@@ -28,15 +28,13 @@ pub fn std_arr_all(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Bool)) {
         return Err(eval.err(
             format!(
                 "arr_all() expected function or lambda with Bool return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_any.rs
+++ b/src/interpreter/stdlib/array/arr_any.rs
@@ -20,7 +20,7 @@ pub fn std_arr_any(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_any() expected function or lambda found {}",
@@ -28,15 +28,13 @@ pub fn std_arr_any(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Bool)) {
         return Err(eval.err(
             format!(
                 "arr_any() expected function or lambda with Bool return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_filter.rs
+++ b/src/interpreter/stdlib/array/arr_filter.rs
@@ -24,7 +24,7 @@ pub fn std_arr_filter(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_filter() expected function or lambda found {}",
@@ -32,15 +32,13 @@ pub fn std_arr_filter(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Bool)) {
         return Err(eval.err(
             format!(
                 "arr_filter() expected function or lambda with Bool return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_find.rs
+++ b/src/interpreter/stdlib/array/arr_find.rs
@@ -20,7 +20,7 @@ pub fn std_arr_find(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_find() expected function or lambda found {}",
@@ -28,15 +28,13 @@ pub fn std_arr_find(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Bool)) {
         return Err(eval.err(
             format!(
                 "arr_find() expected function or lambda with Bool return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_find_index.rs
+++ b/src/interpreter/stdlib/array/arr_find_index.rs
@@ -24,7 +24,7 @@ pub fn std_arr_find_index(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_find_index() expected function or lambda found {}",
@@ -32,15 +32,13 @@ pub fn std_arr_find_index(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Bool))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Bool)) {
         return Err(eval.err(
             format!(
                 "arr_find_index() expected function or lambda with Bool return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_flat_map.rs
+++ b/src/interpreter/stdlib/array/arr_flat_map.rs
@@ -24,7 +24,7 @@ pub fn std_arr_flat_map(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_flat_map() expected function or lambda found {}",
@@ -32,15 +32,13 @@ pub fn std_arr_flat_map(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Array(_)))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Array(_))) {
         return Err(eval.err(
             format!(
                 "arr_flat_map() expected function or lambda with Array return type found {:?}",
-                return_type
+                data.return_type
             ),
             span,
         ));

--- a/src/interpreter/stdlib/array/arr_for_each.rs
+++ b/src/interpreter/stdlib/array/arr_for_each.rs
@@ -24,7 +24,7 @@ pub fn std_arr_for_each(
             ));
         }
     };
-    if !matches!(function, Value::Function { .. }) {
+    let Value::Function(data) = &function else {
         return Err(eval.err(
             format!(
                 "arr_for_each() expected function or lambda found {}",
@@ -32,17 +32,15 @@ pub fn std_arr_for_each(
             ),
             span,
         ));
-    }
+    };
 
-    if let Value::Function { return_type, .. } = function.clone()
-        && !matches!(return_type, Some(TypeAnnotation::Null))
-    {
+    if !matches!(data.return_type, Some(TypeAnnotation::Null)) {
         return Err(eval.err(
             format!(
                 "arr_for_each() expected function or lambda with no (or null) return type found {:?}",
-                return_type
+                data.return_type
             ),
-            span
+            span,
         ));
     }
 

--- a/src/interpreter/stdlib/array/arr_zip.rs
+++ b/src/interpreter/stdlib/array/arr_zip.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::ast::statements::TypeAnnotation;
 use crate::interpreter::{evaluator::Evaluator, values::Value};
 use crate::utils::errors::{Error, Reason};
@@ -39,7 +41,10 @@ pub fn std_arr_zip(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Va
         .collect();
 
     Ok(Value::Values {
-        items_type: TypeAnnotation::Tuple(vec![TypeAnnotation::Null, TypeAnnotation::Null]),
+        items_type: TypeAnnotation::Tuple(Rc::new(vec![
+            TypeAnnotation::Null,
+            TypeAnnotation::Null,
+        ])),
         items,
     })
 }

--- a/src/interpreter/stdlib/rl/lex.rs
+++ b/src/interpreter/stdlib/rl/lex.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::ast::statements::TypeAnnotation;
 use crate::interpreter::stdlib::common::vi;
 use crate::interpreter::{
@@ -30,11 +32,11 @@ pub fn func(_: &mut Evaluator, value: Value) -> Value {
         })
         .collect();
 
-    let items_type = TypeAnnotation::Tuple(vec![
+    let items_type = TypeAnnotation::Tuple(Rc::new(vec![
         TypeAnnotation::String,
         TypeAnnotation::String,
         TypeAnnotation::Int,
-    ]);
+    ]));
 
     vok!(Value::Values { items_type, items })
 }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     ast::statements::{FunctionAttribute, MatchPattern, Statement, StatementKind, TypeAnnotation},
-    interpreter::{evaluator::Evaluator, values::Value},
+    interpreter::{
+        evaluator::Evaluator,
+        values::{FunctionData, Value},
+    },
     lexer::tokenizer::Tokenizer,
     parser::parser_logic::Parser,
     utils::{errors::Error, source::SourceFile, span::Span},
@@ -499,12 +502,12 @@ impl Evaluator {
                 name,
                 ..
             } => {
-                let func = Value::Function {
+                let func = Value::Function(Rc::new(FunctionData {
                     params: Rc::new(params.clone()),
                     body: Rc::new(body.clone()),
                     return_type: Some(return_type.clone()),
                     captured_env: vec![],
-                };
+                }));
                 self.fn_names.insert(name.clone(), *slot);
                 self.insert_value(
                     *slot,

--- a/src/interpreter/values.rs
+++ b/src/interpreter/values.rs
@@ -31,14 +31,7 @@ pub enum Value {
     Null,
 
     /// A first-class function or lambda value, carrying its closure environment.
-    Function {
-        params: Rc<Vec<Param>>,
-        body: Rc<Vec<Statement>>,
-        /// Declared return type; `None` for lambdas without an annotation.
-        return_type: Option<TypeAnnotation>,
-        /// The captured environment frames at the point of lambda definition.
-        captured_env: Vec<Vec<EnvironmentItem>>,
-    },
+    Function(Rc<FunctionData>),
 
     /// A heterogeneous tuple of values.
     Tuple(Vec<Value>),
@@ -46,6 +39,17 @@ pub enum Value {
     Error(Box<Value>),
     Ok(Box<Value>),
     Err(Box<Value>),
+}
+
+/// Payload for `Value::Function`
+#[derive(Debug, Clone, PartialEq)]
+pub struct FunctionData {
+    pub params: Rc<Vec<Param>>,
+    pub body: Rc<Vec<Statement>>,
+    /// Declared return type; `None` for lambdas without an annotation.
+    pub return_type: Option<TypeAnnotation>,
+    /// The captured environment frames at the point of lambda definition.
+    pub captured_env: Vec<Vec<EnvironmentItem>>,
 }
 
 impl Value {
@@ -90,9 +94,9 @@ impl fmt::Display for Value {
                 write!(f, "[{}]", formatted.join(", "))
             }
             Value::Null => write!(f, "null"),
-            Value::Function { params, .. } => {
+            Value::Function(data) => {
                 let mut params_name = vec![];
-                for param in params.iter() {
+                for param in data.params.iter() {
                     params_name.push(param.param_name.clone());
                 }
                 write!(f, "<fn({})>", params_name.join(", "))

--- a/src/parser/statements/const_declaration.rs
+++ b/src/parser/statements/const_declaration.rs
@@ -11,6 +11,8 @@
 //! CONST int X, string Y = (1, "hi")
 //! ```
 
+use std::rc::Rc;
+
 use crate::{
     ast::statements::{Statement, StatementKind, TypeAnnotation},
     lexer::tokentypes::TokenType,
@@ -81,7 +83,7 @@ impl Parser {
                 return Ok(Statement::new(
                     StatementKind::ConstantDeclaration {
                         name,
-                        type_annotation: TypeAnnotation::CTuple(types),
+                        type_annotation: TypeAnnotation::CTuple(Rc::new(types)),
                         value,
                     },
                     span,

--- a/src/parser/statements/variable_declaration.rs
+++ b/src/parser/statements/variable_declaration.rs
@@ -9,6 +9,8 @@
 //! dec int x, string y = (1, "hi")
 //! ```
 
+use std::rc::Rc;
+
 use crate::{
     ast::statements::{Statement, StatementKind, TypeAnnotation},
     lexer::tokentypes::TokenType,
@@ -76,7 +78,7 @@ impl Parser {
                 return Ok(Statement::new(
                     StatementKind::VariableDeclaration {
                         name,
-                        type_annotation: TypeAnnotation::Tuple(types),
+                        type_annotation: TypeAnnotation::Tuple(Rc::new(types)),
                         value,
                     },
                     span,

--- a/src/parser/utils/mod.rs
+++ b/src/parser/utils/mod.rs
@@ -1,4 +1,6 @@
 mod parse_type;
+use std::rc::Rc;
+
 use crate::{
     ast::statements::TypeAnnotation,
     lexer::tokentypes::TokenType,
@@ -164,7 +166,7 @@ impl Parser {
                 if !self.match_type(&[TokenType::RightParen]) {
                     return Err(self.err("expected `)` after tuple types", self.peek_span()));
                 }
-                Ok(TypeAnnotation::Tuple(inner))
+                Ok(TypeAnnotation::Tuple(Rc::new(inner)))
             }
             TokenType::Error => {
                 self.advance();

--- a/src/parser/utils/parse_type.rs
+++ b/src/parser/utils/parse_type.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::{
     ast::statements::TypeAnnotation, lexer::tokentypes::TokenType, parser::parser_logic::Parser,
     utils::errors::Error,
@@ -71,7 +73,7 @@ impl Parser {
                             );
                         }
                     }
-                    TypeAnnotation::Tuple(inner)
+                    TypeAnnotation::Tuple(Rc::new(inner))
                 }
                 TokenType::Result => {
                     self.advance();
@@ -134,7 +136,7 @@ impl Parser {
                             );
                         }
                     }
-                    TypeAnnotation::CTuple(inner)
+                    TypeAnnotation::CTuple(Rc::new(inner))
                 }
                 TokenType::Result => {
                     self.advance();

--- a/tests/interpreter/std/arr_zip.rs
+++ b/tests/interpreter/std/arr_zip.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use rl_lang::ast::statements::TypeAnnotation;
 use rl_lang::interpreter::values::Value;
 
@@ -17,7 +19,10 @@ dec arr[(int, string)] z = arr_zip(a, b)
     assert_eq!(
         ev.get_value_raw("z"),
         Some(Value::Values {
-            items_type: TypeAnnotation::Tuple(vec![TypeAnnotation::Null, TypeAnnotation::Null,]),
+            items_type: TypeAnnotation::Tuple(Rc::new(vec![
+                TypeAnnotation::Null,
+                TypeAnnotation::Null,
+            ])),
             items: vec![
                 Value::Tuple(vec![Value::Integer(1), Value::String("one".to_string())]),
                 Value::Tuple(vec![Value::Integer(2), Value::String("two".to_string())]),
@@ -41,7 +46,10 @@ dec arr[(int, int)] z = arr_zip(a, b)
     assert_eq!(
         ev.get_value_raw("z"),
         Some(Value::Values {
-            items_type: TypeAnnotation::Tuple(vec![TypeAnnotation::Null, TypeAnnotation::Null,]),
+            items_type: TypeAnnotation::Tuple(Rc::new(vec![
+                TypeAnnotation::Null,
+                TypeAnnotation::Null,
+            ])),
             items: vec![
                 Value::Tuple(vec![Value::Integer(10), Value::Integer(1)]),
                 Value::Tuple(vec![Value::Integer(20), Value::Integer(2)]),
@@ -140,7 +148,10 @@ dec arr[(int, string)] z = arr_zip(a, b)
     assert_eq!(
         ev.get_value_raw("z"),
         Some(Value::Values {
-            items_type: TypeAnnotation::Tuple(vec![TypeAnnotation::Null, TypeAnnotation::Null,]),
+            items_type: TypeAnnotation::Tuple(Rc::new(vec![
+                TypeAnnotation::Null,
+                TypeAnnotation::Null,
+            ])),
             items: vec![Value::Tuple(vec![
                 Value::Integer(42),
                 Value::String("hi".to_string()),


### PR DESCRIPTION
## What does this PR do?
Reduces `PItem` size by doing the following:
- Extract `Function` data into `FunctionData` (which reduces the size of `Value` enum thus reduce the `PItem` size)
- Use `Rc` in `TypeAnnotation` (reduces the size as well)

`perf` points to some other stuff i should address later
