### PR TITLE
Perf/skip scope if no decl

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -212,7 +212,9 @@ fn remap_stmt_kind(kind: &mut StatementKind, offset: u32, target_arena_id: u32) 
             remap_stmts(body, offset, target_arena_id);
         }
 
-        ConditionalBranch { condition, body } => {
+        ConditionalBranch {
+            condition, body, ..
+        } => {
             if let Some(id) = condition {
                 remap_id(id, offset, target_arena_id);
             }

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -148,6 +148,10 @@ pub enum StatementKind {
     ConditionalBranch {
         condition: Option<ExprId>,
         body: Vec<Statement>,
+        /// Precomputed by the resolver
+        /// true if `body` declares any local variable/constant
+        /// and therefore needs its own scope frame
+        needs_scope: bool,
     },
     /// A full if / else-if / else chain.
     Conditional {

--- a/src/checker/statements/statement.rs
+++ b/src/checker/statements/statement.rs
@@ -258,7 +258,9 @@ impl TypeChecker {
             StatementKind::Range(_) => {}
 
             // if - else if - else
-            StatementKind::ConditionalBranch { condition, body } => {
+            StatementKind::ConditionalBranch {
+                condition, body, ..
+            } => {
                 // is there condition? or is it else?
                 if let Some(cond) = condition {
                     // is the condition bool?

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -448,7 +448,11 @@ impl Evaluator {
                 }
             }
 
-            StatementKind::ConditionalBranch { condition, body } => match condition {
+            StatementKind::ConditionalBranch {
+                condition,
+                body,
+                needs_scope,
+            } => match condition {
                 Some(condition) => {
                     let condition_span = self.resolver.ast_arena.exprs.get(*condition).span;
                     let v = self.evaluate(*condition)?;
@@ -464,14 +468,18 @@ impl Evaluator {
                                 ));
                         }
                     }
-                    self.push_scope();
+                    if *needs_scope {
+                        self.push_scope();
+                    }
                     for statement in body {
                         self.evaluate_statement(statement)?;
                         if self.return_value.is_some() || self.is_breaking || self.is_continuing {
                             break;
                         }
                     }
-                    self.pop_scope();
+                    if *needs_scope {
+                        self.pop_scope();
+                    }
                 }
                 _ => {
                     for statement in body {
@@ -614,13 +622,19 @@ impl Evaluator {
     /// branch was taken (condition was true or it was an `else`).
     fn evaluate_branch(&mut self, statement: &Statement) -> Result<bool, Error> {
         match &statement.kind {
-            StatementKind::ConditionalBranch { condition, body } => match condition {
+            StatementKind::ConditionalBranch {
+                condition,
+                body,
+                needs_scope,
+            } => match condition {
                 Some(condition) => {
                     let condition_span = self.resolver.ast_arena.exprs.get(*condition).span;
                     let v = self.evaluate(*condition)?;
                     match v {
                         Value::Bool(true) => {
-                            self.push_scope();
+                            if *needs_scope {
+                                self.push_scope();
+                            }
                             for statement in body {
                                 self.evaluate_statement(statement)?;
                                 if self.return_value.is_some()
@@ -630,7 +644,9 @@ impl Evaluator {
                                     break;
                                 }
                             }
-                            self.pop_scope();
+                            if *needs_scope {
+                                self.pop_scope();
+                            }
                             Ok(true)
                         }
                         Value::Bool(false) => Ok(false),
@@ -643,17 +659,22 @@ impl Evaluator {
                     }
                 }
                 None => {
-                    self.push_scope();
+                    if *needs_scope {
+                        self.push_scope();
+                    }
                     for statement in body {
                         self.evaluate_statement(statement)?;
                         if self.return_value.is_some() || self.is_breaking || self.is_continuing {
                             break;
                         }
                     }
-                    self.pop_scope();
+                    if *needs_scope {
+                        self.pop_scope();
+                    }
                     Ok(true)
                 }
             },
+
             StatementKind::Conditional {
                 if_branch,
                 else_branch,

--- a/src/parser/statements/if_statement.rs
+++ b/src/parser/statements/if_statement.rs
@@ -51,6 +51,7 @@ impl Parser {
             StatementKind::ConditionalBranch {
                 condition: Some(if_condition),
                 body: if_body,
+                needs_scope: true,
             },
             if_branch_span,
         );
@@ -74,6 +75,7 @@ impl Parser {
                     StatementKind::ConditionalBranch {
                         condition: None,
                         body: else_body,
+                        needs_scope: true,
                     },
                     span,
                 )))

--- a/src/resolver/statements.rs
+++ b/src/resolver/statements.rs
@@ -206,30 +206,35 @@ impl Resolver {
                     else_branch,
                 }
             }
+
             StatementKind::ConditionalBranch {
                 condition, body, ..
             } => {
                 let condition = condition.map(|e| self.resolve_expression(e));
-                self.push_scope();
-                let body = self.resolve_statements(body);
-                self.pop_scope();
                 let needs_scope = body.iter().any(|s| {
                     matches!(
                         s.kind,
-                        StatementKind::ResolvedVariableDeclaration { .. }
-                            | StatementKind::ResolvedConstantDeclaration { .. }
-                            | StatementKind::ResolvedArray { .. }
-                            | StatementKind::ResolvedConstantArray { .. }
-                            | StatementKind::ResolvedFunctionDeclaration { .. }
+                        StatementKind::VariableDeclaration { .. }
+                            | StatementKind::ConstantDeclaration { .. }
+                            | StatementKind::Array { .. }
+                            | StatementKind::ConstantArray { .. }
+                            | StatementKind::FunctionDeclaration { .. }
                     )
                 });
-
+                if needs_scope {
+                    self.push_scope();
+                }
+                let body = self.resolve_statements(body);
+                if needs_scope {
+                    self.pop_scope();
+                }
                 StatementKind::ConditionalBranch {
                     condition,
                     body,
                     needs_scope,
                 }
             }
+
             StatementKind::Return(expr) => {
                 StatementKind::Return(expr.map(|e| self.resolve_expression(e)))
             }

--- a/src/resolver/statements.rs
+++ b/src/resolver/statements.rs
@@ -206,12 +206,29 @@ impl Resolver {
                     else_branch,
                 }
             }
-            StatementKind::ConditionalBranch { condition, body } => {
+            StatementKind::ConditionalBranch {
+                condition, body, ..
+            } => {
                 let condition = condition.map(|e| self.resolve_expression(e));
                 self.push_scope();
                 let body = self.resolve_statements(body);
                 self.pop_scope();
-                StatementKind::ConditionalBranch { condition, body }
+                let needs_scope = body.iter().any(|s| {
+                    matches!(
+                        s.kind,
+                        StatementKind::ResolvedVariableDeclaration { .. }
+                            | StatementKind::ResolvedConstantDeclaration { .. }
+                            | StatementKind::ResolvedArray { .. }
+                            | StatementKind::ResolvedConstantArray { .. }
+                            | StatementKind::ResolvedFunctionDeclaration { .. }
+                    )
+                });
+
+                StatementKind::ConditionalBranch {
+                    condition,
+                    body,
+                    needs_scope,
+                }
             }
             StatementKind::Return(expr) => {
                 StatementKind::Return(expr.map(|e| self.resolve_expression(e)))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -158,6 +158,7 @@ pub fn assert_branch(
         StatementKind::ConditionalBranch {
             condition: cond,
             body,
+            ..
         } => {
             match (cond, condition) {
                 (Some(id), Some((inner_kind, inner_span, group_span))) => {

--- a/tests/parser/flow_if.rs
+++ b/tests/parser/flow_if.rs
@@ -198,7 +198,9 @@ fn if_nested() {
         } => {
             assert_eq!(if_branch.span, Span::new(0, 37));
             match &if_branch.kind {
-                StatementKind::ConditionalBranch { condition, body } => {
+                StatementKind::ConditionalBranch {
+                    condition, body, ..
+                } => {
                     let condition = condition.expect("expected condition");
                     common::assert_grouping(
                         &ast,


### PR DESCRIPTION
## What does this PR 
Perf: skip scope push/pop for branches with no local declarations

Benchmark: rl run x.rl (recursive fib), perf stat -e instructions,cycles,task-clock, n=10 runs per branch.

| Branch | Mean task-clock (ms) | Std dev (ms) | Mean cycles | Mean instructions |
|---|---|---|---|---|
| dev (baseline) | 8128.1 | 464.9 | 30,654,262,298 | 80,720,064,394 |
| perf/skip-scope-if-no-decl | 7653.4 | 265.6 | 30,161,243,089 | 79,749,548,229 |
| Δ (improvement) | -474.7 ms (-5.84%) | tighter variance (-42.9%) | -1.61% | -1.20% |

