### PR TITLE
Feat/std http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +90,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +122,12 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -157,10 +175,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "ciborium"
@@ -247,6 +281,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -445,6 +488,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +595,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +656,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "icu_collections"
@@ -867,6 +943,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1202,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rl-lang"
 version = "0.1.4"
 dependencies = [
@@ -1128,9 +1228,11 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "tiny_http",
  "tokio",
  "toml",
  "tower-lsp",
+ "ureq",
 ]
 
 [[package]]
@@ -1144,6 +1246,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1237,6 +1374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1409,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1330,6 +1479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1504,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]
@@ -1580,6 +1747,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1865,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1918,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1878,6 +2094,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde_json = "1"
 clap = { version = "4.6.1", features = ["derive"] }
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
+tiny_http = "0.12"
+ureq = "2"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/examples/http_server/rl.toml
+++ b/examples/http_server/rl.toml
@@ -1,0 +1,5 @@
+[project]
+name = "http_server"
+rl-version = "0.1.4"
+version = "0.0.1"
+entry = "src/main.rl"

--- a/examples/http_server/src/main.rl
+++ b/examples/http_server/src/main.rl
@@ -1,0 +1,84 @@
+get println from std::io
+get http_server_start, http_server_recv, http_request_method, http_request_url, http_respond from std::http
+get result_unwrap, is_err, result_unwrap_err from std::res
+get time_now, format_time_str, format_date_str from std::time
+get split, index_of, slice, format from std::str
+get len, arr_range from std::array
+
+fn path_only(string url) -> string {
+    dec int q = index_of(url, "?")
+    if (q == -1) {
+        return url
+    }
+    return slice(url, 0, q)
+}
+
+fn query_param(string url, string key) -> string {
+    dec int q = index_of(url, "?")
+    if (q == -1) {
+        return ""
+    }
+    dec string query = slice(url, q + 1, len(url))
+    dec arr[string] pairs = split(query, "&")
+    dec arr[int] range = arr_range(0, pairs.len(), 1)
+
+    for i in range {
+        dec string pair = pairs[i]
+        dec int eq = index_of(pair, "=")
+        if (eq == -1) {
+            continue
+        }
+        if (slice(pair, 0, eq) == key) {
+            return slice(pair, eq + 1, len(pair))
+        }
+    }
+    return ""
+}
+
+fn main() {
+    dec result[int] start_result = http_server_start("127.0.0.1:8080")
+    if (is_err(start_result)) {
+        println("could not start server:")
+        println(result_unwrap_err(start_result))
+        return
+    }
+
+    dec int server = result_unwrap(start_result)
+    dec int hits = 0
+    println("serving on http://127.0.0.1:8080  (Ctrl+C to stop)")
+
+    while (true) {
+        dec int req = result_unwrap(http_server_recv(server))
+        dec string method = result_unwrap(http_request_method(req))
+        dec string url = result_unwrap(http_request_url(req))
+        dec string path = path_only(url)
+
+        hits = hits + 1
+        println(format("{} {} (hit #{})", method, path, hits))
+
+        if (path == "/") {
+            dec string body = format(
+                "welcome to my rl-lang server\ndate: {}\ntime: {}\nhits so far: {}\n",
+                result_unwrap(format_date_str(time_now())),
+                result_unwrap(format_time_str(time_now())),
+                hits
+            )
+            result_unwrap(http_respond(req, 200, body, "text/plain"))
+        } else if (path == "/time") {
+            dec string body = format("{}\n", result_unwrap(format_time_str(time_now())))
+            result_unwrap(http_respond(req, 200, body, "text/plain"))
+        } else if (path == "/hits") {
+            dec string body = format("{}\n", hits)
+            result_unwrap(http_respond(req, 200, body, "text/plain"))
+        } else if (path == "/echo") {
+            dec string msg = query_param(url, "msg")
+            if (msg == "") {
+                result_unwrap(http_respond(req, 400, "missing ?msg= query param\n", "text/plain"))
+            } else {
+                result_unwrap(http_respond(req, 200, format("{}\n", msg), "text/plain"))
+            }
+        } else {
+            result_unwrap(http_respond(req, 404, "not found\n", "text/plain"))
+        }
+    }
+}

--- a/src/docs/entries/mod.rs
+++ b/src/docs/entries/mod.rs
@@ -26,6 +26,7 @@ pub fn stdlib_entries() -> Vec<&'static StdEntry> {
         &stdlib::rl::RL,
         &stdlib::debug::DEBUG,
         &stdlib::net::NET,
+        &stdlib::http::HTTP,
     ]
 }
 

--- a/src/docs/entries/stdlib/http/http_get.rs
+++ b/src/docs/entries/stdlib/http/http_get.rs
@@ -1,0 +1,17 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_GET: FnEntry = FnEntry {
+    signature: "http_get(url)",
+    description: "performs an HTTP GET request, returning `(status, body)`; non-2xx statuses are still a successful result, not an error",
+    example: r#"
+get std::http::http_get
+
+dec (int, string) resp = result_unwrap(http_get("https://example.com"))"#,
+    expected_output: None,
+    returns: "Result[(int, string)]",
+    errors: Some(
+        "Err(string) on a transport failure (DNS, connection, timeout) - not on non-2xx status",
+    ),
+    see_also: &["http_post", "http_request"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_post.rs
+++ b/src/docs/entries/stdlib/http/http_post.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_POST: FnEntry = FnEntry {
+    signature: "http_post(url, body, content_type?)",
+    description: "performs an HTTP POST request with the given body, returning `(status, response_body)`",
+    example: r#"
+get std::http::http_post
+
+dec (int, string) resp = result_unwrap(http_post("https://example.com/api", "{}", "application/json"))"#,
+    expected_output: None,
+    returns: "Result[(int, string)]",
+    errors: Some("Err(string) on a transport failure - not on non-2xx status"),
+    see_also: &["http_get", "http_request"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_request.rs
+++ b/src/docs/entries/stdlib/http/http_request.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_REQUEST: FnEntry = FnEntry {
+    signature: "http_request(method, url, body?, headers?)",
+    description: "generic HTTP request covering any verb (PUT/DELETE/PATCH/HEAD/etc.); `headers` is an array of (string, string) tuples",
+    example: r#"
+get std::http::http_request
+
+dec (int, string) resp = result_unwrap(http_request("DELETE", "https://example.com/api/1", null, [("Authorization", "Bearer xyz")]))"#,
+    expected_output: None,
+    returns: "Result[(int, string)]",
+    errors: Some("Err(string) on a transport failure - not on non-2xx status"),
+    see_also: &["http_get", "http_post"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_request_body.rs
+++ b/src/docs/entries/stdlib/http/http_request_body.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_REQUEST_BODY: FnEntry = FnEntry {
+    signature: "http_request_body(req)",
+    description: "reads the request body as a string; the body can only be read once",
+    example: r#"
+get std::http::http_request_body
+
+dec string body = result_unwrap(http_request_body(req))"#,
+    expected_output: None,
+    returns: "Result[string]",
+    errors: Some("Err(string) on a read error"),
+    see_also: &["http_request_header"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_request_header.rs
+++ b/src/docs/entries/stdlib/http/http_request_header.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_REQUEST_HEADER: FnEntry = FnEntry {
+    signature: "http_request_header(req, name)",
+    description: "looks up a request header by name (case-insensitive)",
+    example: r#"
+get std::http::http_request_header
+
+http_request_header(req, "Content-Type")"#,
+    expected_output: None,
+    returns: "Result[string]",
+    errors: Some("Err(string) when the header isn't present"),
+    see_also: &["http_request_body"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_request_method.rs
+++ b/src/docs/entries/stdlib/http/http_request_method.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_REQUEST_METHOD: FnEntry = FnEntry {
+    signature: "http_request_method(req)",
+    description: "returns the HTTP method of a request (e.g. \"GET\", \"POST\")",
+    example: r#"
+get std::http::http_request_method
+
+http_request_method(req)"#,
+    expected_output: None,
+    returns: "Result[string]",
+    errors: None,
+    see_also: &["http_request_url"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_request_url.rs
+++ b/src/docs/entries/stdlib/http/http_request_url.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_REQUEST_URL: FnEntry = FnEntry {
+    signature: "http_request_url(req)",
+    description: "returns the requested path, including query string",
+    example: r#"
+get std::http::http_request_url
+
+http_request_url(req)"#,
+    expected_output: None,
+    returns: "Result[string]",
+    errors: None,
+    see_also: &["http_request_method"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_respond.rs
+++ b/src/docs/entries/stdlib/http/http_respond.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_RESPOND: FnEntry = FnEntry {
+    signature: "http_respond(req, status, body, content_type?)",
+    description: "sends a response for `req` and consumes the request handle; using the handle again afterward errors",
+    example: r#"
+get std::http::http_respond
+
+http_respond(req, 200, "hello world", "text/plain")"#,
+    expected_output: None,
+    returns: "Result[null]",
+    errors: Some("Err(string) on a write/send failure"),
+    see_also: &["http_server_recv"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_server_recv.rs
+++ b/src/docs/entries/stdlib/http/http_server_recv.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_SERVER_RECV: FnEntry = FnEntry {
+    signature: "http_server_recv(server)",
+    description: "blocks until the next request arrives, returning a request handle",
+    example: r#"
+get std::http::http_server_recv
+
+dec int req = result_unwrap(http_server_recv(server))"#,
+    expected_output: None,
+    returns: "Result[int]",
+    errors: Some("Err(string) on a server error"),
+    see_also: &["http_server_try_recv", "http_respond"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_server_start.rs
+++ b/src/docs/entries/stdlib/http/http_server_start.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_SERVER_START: FnEntry = FnEntry {
+    signature: "http_server_start(addr)",
+    description: "starts an HTTP server bound to \"host:port\" and returns a server handle",
+    example: r#"
+get std::http::http_server_start
+
+dec int server = result_unwrap(http_server_start("0.0.0.0:8080"))"#,
+    expected_output: None,
+    returns: "Result[int]",
+    errors: Some("Err(string) if the address can't be bound"),
+    see_also: &["http_server_recv", "http_server_stop"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_server_stop.rs
+++ b/src/docs/entries/stdlib/http/http_server_stop.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_SERVER_STOP: FnEntry = FnEntry {
+    signature: "http_server_stop(server)",
+    description: "stops and closes an HTTP server handle",
+    example: r#"
+get std::http::http_server_stop
+
+http_server_stop(server)"#,
+    expected_output: None,
+    returns: "Result[null]",
+    errors: None,
+    see_also: &["http_server_start"],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/stdlib/http/http_server_try_recv.rs
+++ b/src/docs/entries/stdlib/http/http_server_try_recv.rs
@@ -1,0 +1,15 @@
+use crate::docs::entry::FnEntry;
+
+pub static HTTP_SERVER_TRY_RECV: FnEntry = FnEntry {
+    signature: "http_server_try_recv(server)",
+    description: "non-blocking variant of http_server_recv; returns null immediately if no request is pending",
+    example: r#"
+get std::http::http_server_try_recv
+
+dec int req_or_null = result_unwrap(http_server_try_recv(server))"#,
+    expected_output: None,
+    returns: "Result[int]",
+    errors: Some("Err(string) on a server error"),
+    see_also: &["http_server_recv"],
+    since: None,
+};

--- a/src/docs/entries/stdlib/http/mod.rs
+++ b/src/docs/entries/stdlib/http/mod.rs
@@ -1,0 +1,37 @@
+use crate::docs::entry::{FnEntry, StdEntry};
+
+mod http_get;
+mod http_post;
+mod http_request;
+mod http_request_body;
+mod http_request_header;
+mod http_request_method;
+mod http_request_url;
+mod http_respond;
+mod http_server_recv;
+mod http_server_start;
+mod http_server_stop;
+mod http_server_try_recv;
+
+pub static HTTP: StdEntry = StdEntry {
+    name: "http",
+    description: "a minimal HTTP server (tiny_http) and blocking HTTP client (ureq)",
+    functions: FUNCTIONS,
+    since: None,
+    unstable: false,
+};
+
+static FUNCTIONS: &[&FnEntry] = &[
+    &http_server_start::HTTP_SERVER_START,
+    &http_server_recv::HTTP_SERVER_RECV,
+    &http_server_try_recv::HTTP_SERVER_TRY_RECV,
+    &http_request_method::HTTP_REQUEST_METHOD,
+    &http_request_url::HTTP_REQUEST_URL,
+    &http_request_header::HTTP_REQUEST_HEADER,
+    &http_request_body::HTTP_REQUEST_BODY,
+    &http_respond::HTTP_RESPOND,
+    &http_server_stop::HTTP_SERVER_STOP,
+    &http_get::HTTP_GET,
+    &http_post::HTTP_POST,
+    &http_request::HTTP_REQUEST,
+];

--- a/src/docs/entries/stdlib/mod.rs
+++ b/src/docs/entries/stdlib/mod.rs
@@ -3,6 +3,7 @@ pub mod array;
 pub mod bitwise;
 pub mod debug;
 pub mod fs;
+pub mod http;
 pub mod io;
 pub mod math;
 pub mod math_consts;

--- a/src/interpreter/evaluator.rs
+++ b/src/interpreter/evaluator.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use crate::interpreter::stdlib::http::HttpHandle;
 use crate::interpreter::stdlib::net::NetHandle;
 use crate::interpreter::stdlib::random::xoshiro::Xoshiro256;
 use crate::interpreter::values::FunctionData;
@@ -75,13 +76,17 @@ pub struct Evaluator {
     /// anywhere else; everything reads/writes through `self.resolver.ast_arena`.
     pub resolver: Resolver,
     /// Maps top-level function names to their environment slot for `call_path` shortcut.
-    pub fn_names: std::collections::HashMap<String, usize>,
+    pub fn_names: HashMap<String, usize>,
     // for diffrent calls
     pub user_args_offset: usize,
     /// Side-table of native networking resources (`std::net`), keyed by handle id.
-    pub net_handles: std::collections::HashMap<i64, NetHandle>,
+    pub net_handles: HashMap<i64, NetHandle>,
     /// Next handle id to hand out for `std::net` resources; only ever increments.
     pub net_next_handle: i64,
+    /// Side-table of native HTTP resources (`std::http`), keyed by handle id.
+    pub http_handles: HashMap<i64, HttpHandle>,
+    /// Next handle id to hand out for `std::http` resources; only ever increments.
+    pub http_next_handle: i64,
 }
 
 impl Default for Evaluator {
@@ -108,6 +113,8 @@ impl Evaluator {
             user_args_offset: 1,
             net_handles: HashMap::new(),
             net_next_handle: 1,
+            http_handles: HashMap::new(),
+            http_next_handle: 1,
         }
     }
 
@@ -158,7 +165,8 @@ impl Evaluator {
                 .with_module(stdlib::terminal::module())
                 .with_module(stdlib::rl::module())
                 .with_module(stdlib::debug::module())
-                .with_module(stdlib::net::module()),
+                .with_module(stdlib::net::module())
+                .with_module(stdlib::http::module()),
         )
     }
 
@@ -830,6 +838,7 @@ impl Evaluator {
                 .chain(stdlib::rl::KEYWORDS)
                 .chain(stdlib::debug::KEYWORDS)
                 .chain(stdlib::net::KEYWORDS)
+                .chain(stdlib::http::KEYWORDS)
                 .copied();
             if let Some(suggestion) = closest_match(last, candidates) {
                 err = err.with_help(format!("did you mean `{}`?", suggestion));

--- a/src/interpreter/stdlib/common.rs
+++ b/src/interpreter/stdlib/common.rs
@@ -19,6 +19,28 @@ pub fn check_arity(args: &[Value], expected: usize, name: &str, span: Span) -> R
     Ok(())
 }
 
+pub fn check_arity_range(
+    args: &[Value],
+    expected_from: usize,
+    expected_to: usize,
+    name: &str,
+    span: Span,
+) -> Result<(), Error> {
+    let len = args.len();
+    if !(expected_from..expected_to).contains(&len) {
+        let message = format!(
+            "{}: expected from {} to {} arg(s), got {}",
+            name,
+            expected_from,
+            expected_to,
+            args.len()
+        );
+
+        return Err(Error::at(Reason::Runtime, message, span));
+    }
+    Ok(())
+}
+
 pub fn check_type(value: &Value, expected: &str, name: &str) -> Result<(), String> {
     match (value, expected) {
         (Value::Bool(_), "bool")

--- a/src/interpreter/stdlib/http/common.rs
+++ b/src/interpreter/stdlib/http/common.rs
@@ -1,0 +1,32 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{verr, vi, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+
+pub fn ureq_result_to_value(url: &str, result: Result<ureq::Response, ureq::Error>) -> Value {
+    match result {
+        Ok(response) => {
+            let status = response.status() as i64;
+            let body = response.into_string().unwrap_or_default();
+            vok!(Value::Tuple(vec![vi!(status), vs!(body)]))
+        }
+        Err(ureq::Error::Status(code, response)) => {
+            let body = response.into_string().unwrap_or_default();
+            vok!(Value::Tuple(vec![vi!(code as i64), vs!(body)]))
+        }
+        Err(e) => {
+            verr!(vs!(format!("{}: {}", url, e)))
+        }
+    }
+}
+
+pub fn insert_handle(eval: &mut Evaluator, handle: HttpHandle) -> i64 {
+    let id = eval.http_next_handle;
+    eval.http_next_handle += 1;
+    eval.http_handles.insert(id, handle);
+    id
+}

--- a/src/interpreter/stdlib/http/http_get.rs
+++ b/src/interpreter/stdlib/http/http_get.rs
@@ -1,0 +1,8 @@
+use crate::interpreter::{
+    evaluator::Evaluator, stdlib::http::common::ureq_result_to_value, values::Value,
+};
+
+pub fn func(_: &mut Evaluator, url: String) -> Value {
+    let result = ureq::get(&url).call();
+    ureq_result_to_value(&url, result)
+}

--- a/src/interpreter/stdlib/http/http_post.rs
+++ b/src/interpreter/stdlib/http/http_post.rs
@@ -1,0 +1,40 @@
+use crate::{
+    interpreter::{
+        evaluator::Evaluator,
+        stdlib::{
+            common::{check_arity_range, extract_string, verr, vs},
+            http::common::ureq_result_to_value,
+        },
+        values::Value,
+    },
+    utils::{errors::Error, span::Span},
+};
+
+pub fn func(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+    check_arity_range(&args, 2, 3, "http_post", span)?;
+
+    let url = match extract_string(args[0].clone(), "http_post") {
+        Ok(s) => s,
+        Err(e) => return Ok(verr!(vs!(format!("http_post: {e}")))),
+    };
+    let body = match extract_string(args[1].clone(), "http_post") {
+        Ok(s) => s,
+        Err(e) => return Ok(verr!(vs!(format!("http_post: {e}")))),
+    };
+
+    let content_type = match args.get(2) {
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => {
+            return Ok(verr!(vs!(format!(
+                "http_post: expects a string content_type, got {}",
+                other.type_name()
+            ))));
+        }
+        None => "text/plain".to_string(),
+    };
+
+    let result = ureq::post(&url)
+        .set("Content-Type", &content_type)
+        .send_string(&body);
+    Ok(ureq_result_to_value(&url, result))
+}

--- a/src/interpreter/stdlib/http/http_request.rs
+++ b/src/interpreter/stdlib/http/http_request.rs
@@ -1,0 +1,68 @@
+use crate::{
+    interpreter::{
+        evaluator::Evaluator,
+        stdlib::{
+            common::{check_arity_range, extract_string, verr, vs},
+            http::common::ureq_result_to_value,
+        },
+        values::Value,
+    },
+    utils::{errors::Error, span::Span},
+};
+
+pub fn func(_: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+    check_arity_range(&args, 2, 4, "http_request", span)?;
+
+    let method = match extract_string(args[0].clone(), "http_request") {
+        Ok(s) => s,
+        Err(e) => return Ok(verr!(vs!(format!("http_request: {e}")))),
+    };
+    let url = match extract_string(args[1].clone(), "http_request") {
+        Ok(s) => s,
+        Err(e) => return Ok(verr!(vs!(format!("http_request: {e}")))),
+    };
+    let body = match args.get(2) {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(other) => {
+            return Ok(verr!(vs!(format!(
+                "http_request: expects a string body, got {}",
+                other.type_name()
+            ))));
+        }
+        None => None,
+    };
+
+    let mut request = ureq::request(&method, &url);
+    if let Some(Value::Values { items, .. }) = args.get(3) {
+        for item in items {
+            match item {
+                Value::Tuple(pair) if pair.len() == 2 => {
+                    if let (Value::String(name), Value::String(value)) = (&pair[0], &pair[1]) {
+                        request = request.set(name, value);
+                        continue;
+                    }
+                    return Ok(verr!(vs!(
+                        "http_request: expects headers as an array of (string, string) tuples"
+                            .to_string()
+                    )));
+                }
+                _ => {
+                    return Ok(verr!(vs!(
+                        "http_request: expects headers as an array of (string, string) tuples"
+                            .to_string()
+                    )));
+                }
+            }
+        }
+    } else if args.get(3).is_some() {
+        return Ok(verr!(vs!(
+            "http_request: expects headers as an array of (string, string) tuples".to_string()
+        )));
+    }
+
+    let result = match &body {
+        Some(b) => request.send_string(b),
+        None => request.call(),
+    };
+    Ok(ureq_result_to_value(&url, result))
+}

--- a/src/interpreter/stdlib/http/http_request_body.rs
+++ b/src/interpreter/stdlib/http/http_request_body.rs
@@ -1,0 +1,36 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_request_body") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_request_body: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+    let request = match eval.http_handles.get_mut(&id) {
+        Some(HttpHandle::Request(request)) => request,
+        Some(_) => {
+            return verr!(vs!(format!(
+                "http_request_body(): handle {} is not a request",
+                id
+            )));
+        }
+        None => return verr!(vs!(format!("http_request_body(): unknown handle {}", id))),
+    };
+
+    let mut body = String::new();
+    match request.as_reader().read_to_string(&mut body) {
+        Ok(_) => vok!(vs!(body)),
+        Err(e) => verr!(vs!(format!("http_request_body(): {}", e))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_request_header.rs
+++ b/src/interpreter/stdlib/http/http_request_header.rs
@@ -1,0 +1,40 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value, name: String) -> Value {
+    let id = match extract_number(id, "http_request_header") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_request_header: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+    let request = match eval.http_handles.get(&id) {
+        Some(HttpHandle::Request(request)) => request,
+        Some(_) => {
+            return verr!(vs!(format!(
+                "http_request_header: handle {} is not a request",
+                id
+            )));
+        }
+        None => {
+            return verr!(vs!(format!("http_request_header: unknown handle {}", id)));
+        }
+    };
+    let found = request
+        .headers()
+        .iter()
+        .find(|h| h.field.to_string().eq_ignore_ascii_case(&name))
+        .map(|h| h.value.to_string());
+    match found {
+        Some(value) => vok!(vs!(value)),
+        None => verr!(vs!(format!("http_request_header: no \"{}\" header", name))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_request_method.rs
+++ b/src/interpreter/stdlib/http/http_request_method.rs
@@ -1,0 +1,28 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_request_method") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_request_method: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+
+    match eval.http_handles.get(&id) {
+        Some(HttpHandle::Request(request)) => vok!(vs!(request.method().to_string())),
+        Some(_) => verr!(vs!(format!(
+            "http_request_method: handle {} is not a request",
+            id
+        ))),
+        None => verr!(vs!(format!("http_request_method: unknown handle {}", id))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_request_url.rs
+++ b/src/interpreter/stdlib/http/http_request_url.rs
@@ -1,0 +1,28 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_request_url") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_request_url: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+
+    match eval.http_handles.get(&id) {
+        Some(HttpHandle::Request(request)) => vok!(vs!(request.url().to_string())),
+        Some(_) => verr!(vs!(format!(
+            "http_request_url: handle {} is not a request",
+            id
+        ))),
+        None => verr!(vs!(format!("http_request_url: unknown handle {}", id))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_respond.rs
+++ b/src/interpreter/stdlib/http/http_respond.rs
@@ -1,0 +1,74 @@
+use crate::{
+    interpreter::{
+        evaluator::Evaluator,
+        stdlib::{
+            common::{check_arity_range, extract_number, extract_string, verr, vok, vs},
+            http::HttpHandle,
+        },
+        values::Value,
+    },
+    utils::{errors::Error, span::Span},
+};
+
+pub fn func(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
+    check_arity_range(&args, 3, 4, "http_post", span)?;
+
+    let id = match extract_number(args[0].clone(), "http_respond") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return Ok(verr!(vs!(
+                "http_respond: id handle cannot be negative".to_string()
+            )));
+        }
+        Err(e) => return Ok(verr!(vs!(format!("{}", e)))),
+    };
+
+    let status = match &args[1] {
+        Value::Integer(n) if (100..=599).contains(n) => *n as u16,
+        other => {
+            return Ok(verr!(vs!(format!(
+                "http_respond: expects a valid HTTP status int, got {}",
+                other.type_name()
+            ))));
+        }
+    };
+
+    let body = match extract_string(args[1].clone(), "http_respond") {
+        Ok(s) => s,
+        Err(e) => return Ok(verr!(vs!(format!("{e}")))),
+    };
+    let content_type = match args.get(3) {
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(other) => {
+            return Ok(verr!(vs!(format!(
+                "http_respond: expects a string content_type, got {}",
+                other.type_name()
+            ))));
+        }
+        None => None,
+    };
+
+    let request = match eval.http_handles.remove(&id) {
+        Some(HttpHandle::Request(request)) => request,
+        Some(other) => {
+            eval.http_handles.insert(id, other);
+            return Ok(verr!(vs!(format!(
+                "http_respond: handle {} is not a request",
+                id
+            ))));
+        }
+        None => return Ok(verr!(vs!(format!("http_respond: unknown handle {}", id)))),
+    };
+
+    let mut response = tiny_http::Response::from_string(body).with_status_code(status);
+    if let Some(ct) = content_type {
+        if let Ok(header) = tiny_http::Header::from_bytes(&b"Content-Type"[..], ct.as_bytes()) {
+            response = response.with_header(header);
+        }
+    }
+
+    match request.respond(response) {
+        Ok(()) => Ok(vok!(Value::Null)),
+        Err(e) => Ok(verr!(vs!(format!("http_respond: {}", e)))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_respond.rs
+++ b/src/interpreter/stdlib/http/http_respond.rs
@@ -61,11 +61,10 @@ pub fn func(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value,
     };
 
     let mut response = tiny_http::Response::from_string(body).with_status_code(status);
-    if let Some(ct) = content_type {
-        if let Ok(header) = tiny_http::Header::from_bytes(&b"Content-Type"[..], ct.as_bytes()) {
+    if let Some(ct) = content_type
+        && let Ok(header) = tiny_http::Header::from_bytes(&b"Content-Type"[..], ct.as_bytes()) {
             response = response.with_header(header);
         }
-    }
 
     match request.respond(response) {
         Ok(()) => Ok(vok!(Value::Null)),

--- a/src/interpreter/stdlib/http/http_server_recv.rs
+++ b/src/interpreter/stdlib/http/http_server_recv.rs
@@ -1,0 +1,36 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vi, vok, vs},
+        http::{HttpHandle, common::insert_handle},
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_server_recv") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_server_recv: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+    let server = match eval.http_handles.get(&id) {
+        Some(HttpHandle::Server(server)) => server,
+        Some(_) => {
+            return verr!(vs!(format!(
+                "http_server_recv(): handle {} is not a server",
+                id
+            )));
+        }
+        None => return verr!(vs!(format!("http_server_recv(): unknown handle {}", id))),
+    };
+    match server.recv() {
+        Ok(request) => {
+            let req_id = insert_handle(eval, HttpHandle::Request(request));
+            vok!(vi!(req_id))
+        }
+        Err(e) => verr!(vs!(format!("http_server_recv(): {}", e))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_server_start.rs
+++ b/src/interpreter/stdlib/http/http_server_start.rs
@@ -1,0 +1,17 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{verr, vi, vok, vs},
+        http::{HttpHandle, common::insert_handle},
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, addr: String) -> Value {
+    match tiny_http::Server::http(&addr) {
+        Ok(server) => {
+            let id = insert_handle(eval, HttpHandle::Server(server));
+            vok!(vi!(id))
+        }
+        Err(e) => verr!(vs!(format!("http_server_start(\"{}\"): {}", addr, e))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_server_stop.rs
+++ b/src/interpreter/stdlib/http/http_server_stop.rs
@@ -1,0 +1,30 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vnl, vok, vs},
+        http::HttpHandle,
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_server_stop") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_server_stop: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+    match eval.http_handles.get(&id) {
+        Some(HttpHandle::Server(_)) => {
+            eval.http_handles.remove(&id);
+            vok!(vnl!())
+        }
+        Some(_) => verr!(vs!(format!(
+            "http_server_stop: handle {} is not a server",
+            id
+        ))),
+        None => verr!(vs!(format!("http_server_stop: unknown handle {}", id))),
+    }
+}

--- a/src/interpreter/stdlib/http/http_server_try_recv.rs
+++ b/src/interpreter/stdlib/http/http_server_try_recv.rs
@@ -1,0 +1,40 @@
+use crate::interpreter::{
+    evaluator::Evaluator,
+    stdlib::{
+        common::{extract_number, verr, vi, vnl, vok, vs},
+        http::{HttpHandle, common::insert_handle},
+    },
+    values::Value,
+};
+pub fn func(eval: &mut Evaluator, id: Value) -> Value {
+    let id = match extract_number(id, "http_server_try_recv") {
+        Ok(a) if a as i64 >= 0 => a as i64,
+        Ok(_) => {
+            return verr!(vs!(
+                "http_server_try_recv: id handle cannot be negative".to_string()
+            ));
+        }
+        Err(e) => return verr!(vs!(format!("{}", e))),
+    };
+
+    let server = match eval.http_handles.get(&id) {
+        Some(HttpHandle::Server(server)) => server,
+        Some(_) => {
+            return verr!(vs!(format!(
+                "http_server_try_recv(): handle {} is not a server",
+                id
+            )));
+        }
+        None => {
+            return verr!(vs!(format!("http_server_try_recv: unknown handle {}", id)));
+        }
+    };
+    match server.try_recv() {
+        Ok(Some(request)) => {
+            let req_id = insert_handle(eval, HttpHandle::Request(request));
+            vok!(vi!(req_id))
+        }
+        Ok(None) => vok!(vnl!()),
+        Err(e) => verr!(vs!(format!("http_server_try_recv: {}", e))),
+    }
+}

--- a/src/interpreter/stdlib/http/mod.rs
+++ b/src/interpreter/stdlib/http/mod.rs
@@ -1,1 +1,54 @@
+//! `std::http` - a minimal HTTP server (`tiny_http`) and client (`ureq`).
 
+use crate::interpreter::native::Module;
+
+mod common;
+mod http_get;
+mod http_post;
+mod http_request;
+mod http_request_body;
+mod http_request_header;
+mod http_request_method;
+mod http_request_url;
+mod http_respond;
+mod http_server_recv;
+mod http_server_start;
+mod http_server_stop;
+mod http_server_try_recv;
+
+pub const KEYWORDS: &[&str] = &[
+    "http_server_start",
+    "http_server_recv",
+    "http_server_try_recv",
+    "http_request_method",
+    "http_request_url",
+    "http_request_header",
+    "http_request_body",
+    "http_respond",
+    "http_server_stop",
+    "http_get",
+    "http_post",
+    "http_request",
+];
+
+/// A single native HTTP resource, stored behind an `int` handle.
+pub enum HttpHandle {
+    Server(tiny_http::Server),
+    Request(tiny_http::Request),
+}
+
+pub fn module() -> Module {
+    Module::new("http")
+        .with_function("http_server_start", http_server_start::func)
+        .with_function("http_server_recv", http_server_recv::func)
+        .with_function("http_server_try_recv", http_server_try_recv::func)
+        .with_function("http_request_method", http_request_method::func)
+        .with_function("http_request_url", http_request_url::func)
+        .with_function("http_request_header", http_request_header::func)
+        .with_function("http_request_body", http_request_body::func)
+        .with_raw_function("http_respond", http_respond::func)
+        .with_function("http_server_stop", http_server_stop::func)
+        .with_function("http_get", http_get::func)
+        .with_raw_function("http_post", http_post::func)
+        .with_raw_function("http_request", http_request::func)
+}

--- a/src/interpreter/stdlib/mod.rs
+++ b/src/interpreter/stdlib/mod.rs
@@ -5,6 +5,7 @@ pub mod bitwise;
 mod common;
 pub mod debug;
 pub mod fs;
+pub mod http;
 pub mod io;
 pub mod len;
 pub mod math;


### PR DESCRIPTION
## What does this PR do?
Adds new module to std: `http` with the following functions
- `http_server_start`
- `http_server_recv`
- `http_server_try_recv`
- `http_request_method`
- `http_request_url`
- `http_request_header`
- `http_request_body`
- `http_respond`
- `http_server_stop`
- `http_get`
- `http_post`
- `http_request`

## Related issue
Closes #147 

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
