### PR TITLE
fix resolver picking the first match

### DIFF
--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -70,7 +70,7 @@ impl Resolver {
     /// that scope. Returns `None` if the name is not declared in any scope.
     pub fn resolve_name(&self, name: &str) -> Option<(usize, usize)> {
         for (depth, frame) in self.scopes.iter().rev().enumerate() {
-            if let Some(slot) = frame.iter().position(|n| n == name) {
+            if let Some(slot) = frame.iter().rposition(|n| n == name) {
                 return Some((depth, slot));
             }
         }


### PR DESCRIPTION
## What does this PR do?
fix #164 

the first behaviour was 
search for the first match then use its slot

now it search for the first match in reverse 
so the latest redeclaration slot is what resolver give

## Related issue
Closes #164

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
