### PR TITLE
Docs/records and tags

### DIFF
--- a/src/docs/entries/concepts/mod.rs
+++ b/src/docs/entries/concepts/mod.rs
@@ -15,6 +15,8 @@ pub mod r#match;
 pub mod nulls;
 pub mod operators;
 pub mod propagate;
+pub mod records;
+pub mod tags;
 pub mod tooling;
 pub mod tuples;
 pub mod types;

--- a/src/docs/entries/concepts/records/mod.rs
+++ b/src/docs/entries/concepts/records/mod.rs
@@ -1,0 +1,68 @@
+use crate::docs::entry::{ConceptCategory, ConceptEntry, DescriptionEntry, DescriptionKind};
+
+pub static RECORDS: ConceptEntry = ConceptEntry {
+    name: "records",
+    summary: "a named, fixed-shape collection of typed fields, declared once with `record`",
+    descriptions: &[
+        DescriptionEntry {
+            kind: DescriptionKind::Syntax,
+            title: None,
+            description: "declare a record with `record Name { Type field, Type field }`, using the same `Type name` order as function parameters; a trailing comma after the last field is allowed",
+            examples: &["record Point {\n    int x,\n    int y,\n}"],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Syntax,
+            title: Some("constructing a value"),
+            description: "build an instance with `Name { field: value, ... }`; fields can be given in any order but every field must be present, exactly once, with a value matching its declared type",
+            examples: &[
+                "record Point {\n    int x,\n    int y,\n}\n\ndec Point p = Point { x: 1, y: 2 }\ndec Point q = Point { y: 4, x: 3 }",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Explanation,
+            title: Some("reading and writing fields"),
+            description: "access a field with `.field`, and write to it with `.field = value`; field assignment is an expression that evaluates to the assigned value, just like a variable assignment",
+            examples: &[
+                "record Point {\n    int x,\n    int y,\n}\n\ndec Point p = Point { x: 1, y: 2 }\nprintln(p.x)  // 1\np.x = 10\nprintln(p.x)  // 10",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Explanation,
+            title: Some("records as types"),
+            description: "a record name is a type once declared: use it for `dec` bindings, function parameters and return types, or as an array element type",
+            examples: &[
+                "record Point {\n    int x,\n    int y,\n}\n\nfn manhattan(Point p) -> int {\n    return p.x + p.y\n}\n\ndec arr[Point] path = [Point { x: 0, y: 0 }, Point { x: 1, y: 1 }]",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Pitfall,
+            title: Some("declare before use"),
+            description: "a record must be declared earlier in the file than any place that uses it as a literal, a type annotation, or a field type; the parser reads top to bottom and only recognizes `Name { ... }` as a record literal once it has already seen `record Name { ... }`, so there's no forward-referencing between records or from earlier code to a later declaration",
+            examples: &[],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Pitfall,
+            title: Some("records are shared, not copied"),
+            description: "assigning a record value to another variable, or passing it into a function, does not copy its fields - both names refer to the same underlying data, so mutating a field through one is visible through the other; this is different from arrays, which are copied by value",
+            examples: &[
+                "record Point {\n    int x,\n    int y,\n}\n\ndec Point p = Point { x: 1, y: 1 }\ndec Point alias = p\nalias.x = 99\nprintln(p.x)  // 99, not 1",
+            ],
+            expected_output: &[],
+        },
+    ],
+    category: ConceptCategory::Types,
+    prerequisites: &["types"],
+    pitfalls: &[
+        "records must be declared before any use, including as a type in an earlier function's signature",
+        "constructing a record requires every declared field, no more and no less; missing or extra fields are a runtime error",
+        "records have reference semantics - copies alias the same fields, unlike arrays",
+    ],
+    related: &["types", "tags", "arrays", "functions"],
+    related_stdlib: &[],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/concepts/tags/mod.rs
+++ b/src/docs/entries/concepts/tags/mod.rs
@@ -1,0 +1,75 @@
+use crate::docs::entry::{ConceptCategory, ConceptEntry, DescriptionEntry, DescriptionKind};
+
+pub static TAGS: ConceptEntry = ConceptEntry {
+    name: "tags",
+    summary: "a named set of unit variants, declared once with `tag`, for representing one-of-a-kind states",
+    descriptions: &[
+        DescriptionEntry {
+            kind: DescriptionKind::Syntax,
+            title: None,
+            description: "declare a tag with `tag Name { VariantA, VariantB, ... }`, a comma-separated list of variant names; a trailing comma after the last variant is allowed",
+            examples: &["tag Color {\n    Red,\n    Green,\n    Blue,\n}"],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Syntax,
+            title: Some("referencing a variant"),
+            description: "refer to a variant with `Name.Variant`; tags don't carry any associated data, so a variant reference is a complete value on its own",
+            examples: &[
+                "tag Color {\n    Red,\n    Green,\n    Blue,\n}\n\ndec Color c = Color.Green\nprintln(c)  // Green",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Explanation,
+            title: Some("comparing variants"),
+            description: "variants compare with `==` and `!=`; two variants are equal only if they belong to the same tag and are the same variant",
+            examples: &[
+                "tag Color {\n    Red,\n    Green,\n    Blue,\n}\n\ndec Color c = Color.Red\nif c == Color.Red {\n    println(\"stop\")\n}",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Explanation,
+            title: Some("tags with match"),
+            description: "since a variant reference is just a value, `match` can branch on it like any other literal, with `_` as the catch-all arm",
+            examples: &[
+                "tag Color {\n    Red,\n    Green,\n    Blue,\n}\n\ndec Color c = Color.Green\n\nmatch c {\n    Color.Red => { println(\"stop\") }\n    Color.Green => { println(\"go\") }\n    _ => { println(\"caution\") }\n}",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Explanation,
+            title: Some("tags as types"),
+            description: "a tag name is a type once declared: use it for `dec` bindings, function parameters and return types, or as an array element type",
+            examples: &[
+                "tag Color {\n    Red,\n    Green,\n    Blue,\n}\n\nfn describe(Color c) -> string {\n    match c {\n        Color.Red => { return \"stop\" }\n        Color.Green => { return \"go\" }\n        _ => { return \"caution\" }\n    }\n}",
+            ],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Pitfall,
+            title: Some("declare before use"),
+            description: "a tag must be declared earlier in the file than any place that uses it, including `Name.Variant` references and type annotations; the parser only recognizes `Name.Variant` as a tag access once it has already seen `tag Name { ... }` earlier in the file",
+            examples: &[],
+            expected_output: &[],
+        },
+        DescriptionEntry {
+            kind: DescriptionKind::Pitfall,
+            title: Some("no associated data"),
+            description: "unlike enums in some other languages, a tag variant can't carry a value (no `Shape.Circle(radius)`); if a variant needs data attached, pair it with a record field instead of trying to store it on the tag itself",
+            examples: &[],
+            expected_output: &[],
+        },
+    ],
+    category: ConceptCategory::Types,
+    prerequisites: &["types"],
+    pitfalls: &[
+        "tags must be declared before any use, including in an earlier function's signature",
+        "variants carry no data - they're pure labels",
+        "a variant only equals another variant of the exact same tag and name",
+    ],
+    related: &["types", "records", "match"],
+    related_stdlib: &[],
+    since: Some("v0.1.5"),
+};

--- a/src/docs/entries/mod.rs
+++ b/src/docs/entries/mod.rs
@@ -54,6 +54,8 @@ pub fn concept_entries() -> Vec<&'static ConceptEntry> {
         &concepts::r#match::MATCH,
         &concepts::propagate::PROPAGATE,
         &concepts::logical_operators::LOGICAL_OPERATORS,
+        &concepts::records::RECORDS,
+        &concepts::tags::TAGS,
     ]
 }
 


### PR DESCRIPTION
## What does this PR do?
Adds documentation entries for `record`s and `tag`s
