### PR TITLE
Fix/tuple destruct parser

### DIFF
--- a/src/parser/statements/const_declaration.rs
+++ b/src/parser/statements/const_declaration.rs
@@ -104,6 +104,11 @@ impl Parser {
                 | TokenType::Char
                 | TokenType::Fn
                 | TokenType::Error
+                | TokenType::Array
+                | TokenType::Map
+                | TokenType::Set
+                | TokenType::Result
+                | TokenType::Identifier(_)
         ) {
             let saved = self.current;
             while self.match_type(&[TokenType::Newline]) {}
@@ -152,25 +157,19 @@ impl Parser {
                     span,
                 ));
             } else {
-                while self.match_type(&[TokenType::Newline]) {}
-                if !self.match_type(&[TokenType::Assign]) {
-                    return Err(self.err("expected = after name", self.peek_span()));
-                }
-                while self.match_type(&[TokenType::Newline]) {}
-                let value = self.parse_expression()?;
-                let value_id = self.ast_arena.exprs.get(value);
-                let span = start.join(value_id.span);
-                return Ok(Statement::new(
-                    StatementKind::ConstantDeclaration {
-                        name: first_name,
-                        type_annotation: first_type,
-                        value,
-                    },
-                    span,
-                ));
+                self.current = saved;
+                return self.parse_const_declartion_single(start);
             }
         }
 
+        self.parse_const_declartion_single(start)
+    }
+
+    /// Parses a single (non-destructure) `CONST` declaration: map, set,
+    /// array, or scalar. Assumes the destructure/tuple-type possibilities
+    /// have already been ruled out (or the parser position has been rewound
+    /// past a failed destructure attempt) by the caller.
+    fn parse_const_declartion_single(&mut self, start: Span) -> Result<Statement, Error> {
         // -- map: CONST map[K,V] NAME = {...} --
         if self.match_type(&[TokenType::Map]) && self.peek() == TokenType::LeftBracket {
             self.advance();

--- a/src/parser/statements/variable_declaration.rs
+++ b/src/parser/statements/variable_declaration.rs
@@ -99,6 +99,11 @@ impl Parser {
                 | TokenType::Char
                 | TokenType::Fn
                 | TokenType::Error
+                | TokenType::Array
+                | TokenType::Map
+                | TokenType::Set
+                | TokenType::Result
+                | TokenType::Identifier(_)
         ) {
             let saved = self.current;
             while self.match_type(&[TokenType::Newline]) {}
@@ -149,25 +154,19 @@ impl Parser {
                     span,
                 ));
             } else {
-                while self.match_type(&[TokenType::Newline]) {}
-                if !self.match_type(&[TokenType::Assign]) {
-                    return Err(self.err("expected `=` after name", self.peek_span()));
-                }
-                while self.match_type(&[TokenType::Newline]) {}
-                let value = self.parse_expression()?;
-                let value_id = self.ast_arena.exprs.get(value);
-                let span = start.join(value_id.span);
-                return Ok(Statement::new(
-                    StatementKind::VariableDeclaration {
-                        name: first_name,
-                        type_annotation: first_type,
-                        value,
-                    },
-                    span,
-                ));
+                self.current = saved;
+                return self.parse_variable_declartion_single(start);
             }
         }
 
+        self.parse_variable_declartion_single(start)
+    }
+
+    /// Parses a single (non-destructure) `dec` declaration: map, set, array,
+    /// or scalar. Assumes the destructure/tuple-type possibilities have
+    /// already been ruled out (or the parser position has been rewound past
+    /// a failed destructure attempt) by the caller.
+    fn parse_variable_declartion_single(&mut self, start: Span) -> Result<Statement, Error> {
         // -- map: dec map[K,V] name = {...} --
         if self.match_type(&[TokenType::Map]) && self.peek() == TokenType::LeftBracket {
             self.advance();

--- a/src/parser/utils/parse_type.rs
+++ b/src/parser/utils/parse_type.rs
@@ -85,12 +85,21 @@ impl Parser {
                 TokenType::LeftParen => {
                     self.advance();
                     let mut inner = vec![];
-                    while !self.match_type(&[TokenType::RightParen]) {
-                        let item_type = self.parse_type(true)?;
-                        inner.push(item_type);
-                        if !self.match_type(&[TokenType::Comma]) {
+                    while self.match_type(&[TokenType::Newline]) {}
+                    if !self.match_type(&[TokenType::RightParen]) {
+                        inner.push(self.parse_type(true)?);
+                        while self.match_type(&[TokenType::Newline]) {}
+                        while self.match_type(&[TokenType::Comma]) {
+                            while self.match_type(&[TokenType::Newline]) {}
+                            if self.peek() == TokenType::RightParen {
+                                break;
+                            }
+                            inner.push(self.parse_type(true)?);
+                            while self.match_type(&[TokenType::Newline]) {}
+                        }
+                        if !self.match_type(&[TokenType::RightParen]) {
                             return Err(
-                                self.err("expected `,` between tuple types", self.peek_span())
+                                self.err("expected `,` or `)` in tuple type", self.peek_span())
                             );
                         }
                     }
@@ -177,12 +186,21 @@ impl Parser {
                 TokenType::LeftParen => {
                     self.advance();
                     let mut inner = vec![];
-                    while !self.match_type(&[TokenType::RightParen]) {
-                        let item_type = self.parse_type(false)?;
-                        inner.push(item_type);
-                        if !self.match_type(&[TokenType::Comma]) {
+                    while self.match_type(&[TokenType::Newline]) {}
+                    if !self.match_type(&[TokenType::RightParen]) {
+                        inner.push(self.parse_type(false)?);
+                        while self.match_type(&[TokenType::Newline]) {}
+                        while self.match_type(&[TokenType::Comma]) {
+                            while self.match_type(&[TokenType::Newline]) {}
+                            if self.peek() == TokenType::RightParen {
+                                break;
+                            }
+                            inner.push(self.parse_type(false)?);
+                            while self.match_type(&[TokenType::Newline]) {}
+                        }
+                        if !self.match_type(&[TokenType::RightParen]) {
                             return Err(
-                                self.err("expected `,` between tuple types", self.peek_span())
+                                self.err("expected `,` or `)` in tuple type", self.peek_span())
                             );
                         }
                     }


### PR DESCRIPTION
## What does this PR do?
Patches tuples destruction when doing something like this
```rl
    dec arr[(int, int)] frame, arr[(int, int)] body = get_size(max_x, max_y)
```
