### PR TITLE
Refactor/str module

### DIFF
--- a/src/interpreter/stdlib/string/char_at.rs
+++ b/src/interpreter/stdlib/string/char_at.rs
@@ -1,28 +1,21 @@
 use crate::{
     interpreter::evaluator::Evaluator,
-    utils::{errors::Error, span::Span},
+    interpreter::stdlib::common::{vc, verr, vok, vs},
+    interpreter::values::Value,
 };
 
-pub fn std_char_at(
-    eval: &mut Evaluator,
-    string: String,
-    index: i64,
-    span: Span,
-) -> Result<char, Error> {
+pub fn std_char_at(_: &mut Evaluator, string: String, index: i64) -> Value {
     if index < 0 {
-        return Err(eval.err(format!("index cannot be negative: {}", index), span));
+        return verr!(vs!(format!("index cannot be negative: {}", index)));
     }
     let mut chars = string.chars();
     let chars_count = chars.clone().count();
     if index as usize >= chars_count {
-        Err(eval.err(
-            format!(
-                "index out of bounds string length is {} , used {}",
-                chars_count, index
-            ),
-            span,
-        ))
+        verr!(vs!(format!(
+            "index out of bounds string length is {} , used {}",
+            chars_count, index
+        )))
     } else {
-        Ok(chars.nth(index as usize).unwrap())
+        vok!(vc!(chars.nth(index as usize).unwrap()))
     }
 }

--- a/src/interpreter/stdlib/string/join.rs
+++ b/src/interpreter/stdlib/string/join.rs
@@ -1,14 +1,10 @@
 use crate::{
-    interpreter::{evaluator::Evaluator, values::Value},
-    utils::{errors::Error, span::Span},
+    interpreter::evaluator::Evaluator,
+    interpreter::stdlib::common::{verr, vok, vs},
+    interpreter::values::Value,
 };
 
-pub fn std_join(
-    eval: &mut Evaluator,
-    strings_array: Value,
-    delim: String,
-    span: Span,
-) -> Result<Value, Error> {
+pub fn std_join(_: &mut Evaluator, strings_array: Value, delim: String) -> Value {
     match strings_array {
         Value::Values { items: array, .. } => {
             let mut strings: Vec<String> = vec![];
@@ -21,19 +17,15 @@ pub fn std_join(
                     Value::Char(c) => strings.push(c.to_string()),
                     Value::Null => strings.push("null".to_string()),
                     Value::Function { .. } => {
-                        return Err(eval.err(
-                            "functions/lambdas/enclosures are not supported via join()".to_string(),
-                            span,
+                        return verr!(vs!(
+                            "functions/lambdas/enclosures are not supported via join()".to_string()
                         ));
                     }
                     _ => {}
                 }
             }
-            Ok(Value::String(strings.join(&delim)))
+            vok!(vs!(strings.join(&delim)))
         }
-        _ => Err(eval.err(
-            "join() expects an array as first argument".to_string(),
-            span,
-        )),
+        _ => verr!(vs!("join() expects an array as first argument".to_string())),
     }
 }

--- a/src/interpreter/stdlib/string/slice.rs
+++ b/src/interpreter/stdlib/string/slice.rs
@@ -1,29 +1,21 @@
 use crate::{
     interpreter::evaluator::Evaluator,
-    utils::{errors::Error, span::Span},
+    interpreter::stdlib::common::{verr, vok, vs},
+    interpreter::values::Value,
 };
 
-pub fn std_slice(
-    eval: &mut Evaluator,
-    string: String,
-    start: i64,
-    end: i64,
-    span: Span,
-) -> Result<String, Error> {
+pub fn std_slice(_: &mut Evaluator, string: String, start: i64, end: i64) -> Value {
     let chars = string.chars();
     let chars_count = chars.clone().count();
     if start as usize >= chars_count || end as usize > chars_count {
-        return Err(eval.err(
-            format!(
-                "index out of bounds string legth: {}, found start: {} and end: {}",
-                chars_count, start, end
-            ),
-            span,
-        ));
+        return verr!(vs!(format!(
+            "index out of bounds string legth: {}, found start: {} and end: {}",
+            chars_count, start, end
+        )));
     }
 
-    Ok(chars
+    vok!(vs!(chars
         .skip(start as usize)
         .take(end as usize - start as usize)
-        .collect::<String>())
+        .collect::<String>()))
 }

--- a/src/interpreter/utils/statements.rs
+++ b/src/interpreter/utils/statements.rs
@@ -236,7 +236,7 @@ impl Evaluator {
                 let val = self.evaluate(*value)?;
                 let val = match val {
                     Value::Map { entries, .. } => {
-                        for (_, v) in entries.borrow().iter() {
+                        for v in entries.borrow().values() {
                             let actual = Self::infer_type(v, false);
                             if !Self::types_compatible(&actual, &declared_value) {
                                 return Err(self.err(
@@ -279,7 +279,7 @@ impl Evaluator {
                 let val = self.evaluate(*value)?;
                 let val = match val {
                     Value::Map { entries, .. } => {
-                        for (_, v) in entries.borrow().iter() {
+                        for v in entries.borrow().values() {
                             let actual = Self::infer_type(v, false);
                             if !Self::types_compatible(&actual, &declared_value) {
                                 return Err(self.err(

--- a/src/parser/utils/mod.rs
+++ b/src/parser/utils/mod.rs
@@ -51,7 +51,7 @@ impl Parser {
         #[cfg(feature = "debug")]
         log::debug!(
             "returning current token: [{:?}]",
-            &self.tokens[self.current].token
+            self.tokens[self.current].token
         );
         self.tokens[self.current].token.clone()
     }
@@ -64,7 +64,7 @@ impl Parser {
         #[cfg(feature = "debug")]
         log::debug!(
             "returning previous token: [{:?}]",
-            &self.tokens[self.current - 1].token
+            self.tokens[self.current - 1].token
         );
         self.tokens[self.current - 1].token.clone()
     }

--- a/tests/interpreter/stdlib/string.rs
+++ b/tests/interpreter/stdlib/string.rs
@@ -199,7 +199,7 @@ fn char_at() {
     let ev = eval_program(
         r#"
 get char_at from std::str
-dec char x = char_at("hello", 1)
+dec char x = char_at("hello", 1)?
 "#,
     )
     .unwrap();

--- a/tests/interpreter/stdlib/string.rs
+++ b/tests/interpreter/stdlib/string.rs
@@ -211,7 +211,7 @@ fn slice_str() {
     let ev = eval_program(
         r#"
 get slice from std::str
-dec string x = slice("hello world", 6, 11)
+dec string x = slice("hello world", 6, 11)?
 "#,
     )
     .unwrap();
@@ -338,7 +338,7 @@ fn slice_string() {
     let ev = eval_program(
         r#"
 get slice from std::str
-dec string x = slice("hello world", 6, 11)
+dec string x = slice("hello world", 6, 11)?
 "#,
     )
     .unwrap();


### PR DESCRIPTION
@MohamedGonem I have refactored `char_at`, `std_slice` as well as `std_join`.
I haven't yet been able to adapt `std_format` and `std_concat` to the new Value type due to the variadic nature of them.
I am open to suggestions for it.

Note: I havent updated the docs.

This pr can be merged and `std_format` and `std_concat` can be dealt with in a later pr if you want.

## Related Issues
Closes #135 