### PR TITLE
Fix/make modules aware of imported records and tags

### DIFF
--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -37,10 +37,7 @@ use crate::{
         span::Span,
     },
 };
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::{collections::HashMap, path::PathBuf};
 pub use structs::TypeChecker;
 
 impl Default for TypeChecker {
@@ -67,7 +64,7 @@ impl TypeChecker {
             hovers: Vec::new(),
             base_dir: None,
             importing: Vec::new(),
-            imported: HashSet::new(),
+            imported: HashMap::new(),
             ast_arena: Ast::new(),
             records: HashMap::new(),
             tags: HashMap::new(),

--- a/src/checker/statements/statement.rs
+++ b/src/checker/statements/statement.rs
@@ -1,7 +1,7 @@
 //! Statement type checking - walks every [`StatementKind`] variant,
 //! declares names into scope, and validates control flow constraints.
 
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use crate::{
     ast::statements::{MatchPattern, StatementKind, TypeAnnotation},
@@ -520,9 +520,11 @@ impl TypeChecker {
                 self.error("continue outside of loop", statement.span);
             }
 
-            // runtime job maybe revisting later
-            StatementKind::ImportFile { path } | StatementKind::ImportFileNamed { path, .. } => {
-                self.import_module(path, statement.span);
+            StatementKind::ImportFile { path } => {
+                self.import_module(path, None, statement.span);
+            }
+            StatementKind::ImportFileNamed { path, names } => {
+                self.import_module(path, Some(names), statement.span);
             }
             StatementKind::Import { .. } => {}
 
@@ -604,7 +606,7 @@ impl TypeChecker {
         }
     }
 
-    fn import_module(&mut self, path: &[String], span: Span) {
+    fn import_module(&mut self, path: &[String], names: Option<&[String]>, span: Span) {
         let import_name = format!("{}.rl", path.join("/"));
         let import_path = match &self.base_dir {
             Some(dir) => dir.join(&import_name),
@@ -619,9 +621,41 @@ impl TypeChecker {
             self.error(format!("import cycle detected: {}", path.join("::")), span);
             return;
         }
-        if self.imported.contains(&canonical) {
-            return;
-        }
+
+        let prior: Option<HashSet<String>> = self.imported.get(&canonical).cloned().flatten();
+        let missing: Option<Vec<String>> = match self.imported.get(&canonical) {
+            Some(None) => return,
+            Some(Some(already)) => match names {
+                None => None,
+                Some(requested) => {
+                    let missing: Vec<String> = requested
+                        .iter()
+                        .filter(|n| !already.contains(*n))
+                        .cloned()
+                        .collect();
+                    if missing.is_empty() {
+                        return;
+                    }
+                    Some(missing)
+                }
+            },
+            None => names.map(<[String]>::to_vec),
+        };
+
+        let new_cache_entry: Option<HashSet<String>> = match &missing {
+            None => None,
+            Some(added) => {
+                let mut set = prior.unwrap_or_default();
+                set.extend(added.iter().cloned());
+                Some(set)
+            }
+        };
+        let wanted = |name: &String| -> bool {
+            match &missing {
+                None => true, // whole module
+                Some(only) => only.contains(name),
+            }
+        };
 
         let Ok(source_text) = std::fs::read_to_string(&import_path) else {
             self.error(
@@ -669,7 +703,7 @@ impl TypeChecker {
                     params,
                     return_type,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Function {
@@ -684,7 +718,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(type_annotation.clone()),
@@ -696,7 +730,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(type_annotation.clone()),
@@ -708,7 +742,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(TypeAnnotation::Array(Box::new(type_annotation.clone()))),
@@ -720,7 +754,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(TypeAnnotation::CArray(Box::new(type_annotation.clone()))),
@@ -733,7 +767,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(TypeAnnotation::Set(Box::new(type_annotation.clone()))),
@@ -745,7 +779,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(TypeAnnotation::CSet(Box::new(type_annotation.clone()))),
@@ -758,7 +792,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(type_annotation.clone()),
@@ -770,7 +804,7 @@ impl TypeChecker {
                     name,
                     type_annotation,
                     ..
-                } => {
+                } if wanted(name) => {
                     self.declare(
                         name.clone(),
                         CheckType::Known(type_annotation.clone()),
@@ -779,9 +813,28 @@ impl TypeChecker {
                     );
                 }
 
-                StatementKind::ImportFile { path: nested }
-                | StatementKind::ImportFileNamed { path: nested, .. } => {
-                    self.import_module(nested, stmt.span);
+                StatementKind::RecordDeclaration { name, fields } if wanted(name) => {
+                    self.records.insert(name.clone(), fields.clone());
+                }
+                StatementKind::TagDeclaration { name, variants } if wanted(name) => {
+                    self.tags.insert(name.clone(), variants.clone());
+                }
+
+                StatementKind::ImportFile { path: nested } => {
+                    self.import_module(nested, None, stmt.span);
+                }
+                StatementKind::ImportFileNamed {
+                    path: nested,
+                    names: nested_names,
+                } => {
+                    self.import_module(nested, Some(nested_names), stmt.span);
+                }
+
+                StatementKind::RecordDeclaration { name, fields } => {
+                    self.records.insert(name.clone(), fields.clone());
+                }
+                StatementKind::TagDeclaration { name, variants } => {
+                    self.tags.insert(name.clone(), variants.clone());
                 }
 
                 _ => {}
@@ -790,6 +843,6 @@ impl TypeChecker {
 
         self.ast_arena = prev_ast;
         self.importing.pop();
-        self.imported.insert(canonical);
+        self.imported.insert(canonical, new_cache_entry);
     }
 }

--- a/src/checker/structs.rs
+++ b/src/checker/structs.rs
@@ -32,7 +32,7 @@ pub struct TypeChecker {
     pub hovers: Vec<(Span, String)>,
     pub base_dir: Option<PathBuf>,
     pub importing: Vec<PathBuf>,
-    pub imported: HashSet<PathBuf>,
+    pub imported: HashMap<PathBuf, Option<HashSet<String>>>,
     pub ast_arena: Ast,
     /// Maps `record` type names to their declared `(field name, field type)` list.
     pub records: HashMap<String, Vec<(String, TypeAnnotation)>>,

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -21,7 +21,11 @@ use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Posi
 /// positions short-circuit early before running the parser and type-checker.
 pub fn run_hover(source: &str, position: Position, uri: &Url) -> Option<Hover> {
     let offset = position_to_offset(source, position);
-    let file = SourceFile::new("buffer", source.to_string());
+    let file_name = uri
+        .to_file_path()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "buffer".to_string());
+    let file = SourceFile::new(file_name, source.to_string());
 
     let tokens = Tokenizer::lex(file.clone()).ok()?;
 

--- a/src/lsp/hover.rs
+++ b/src/lsp/hover.rs
@@ -30,9 +30,17 @@ pub fn run_hover(source: &str, position: Position, uri: &Url) -> Option<Hover> {
     let token_span = find_identifier_span_at(&tokens, offset)?;
 
     let (ast, statements) = Parser::parse(tokens, file.clone()).ok()?;
+
+    let base_dir = uri
+        .to_file_path()
+        .ok()
+        .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
     let mut checker = TypeChecker::new()
         .with_source_file(file)
-        .with_ast_arena(ast);
+        .with_ast_arena(ast)
+        .with_base_dir(base_dir);
     if let Ok(doc_path) = uri.to_file_path()
         && let Some(doc_dir) = doc_path.parent()
     {

--- a/src/lsp/pipeline.rs
+++ b/src/lsp/pipeline.rs
@@ -17,7 +17,11 @@ use tower_lsp::lsp_types::{Diagnostic, Url};
 /// [`TypeChecker`] walks the same AST without executing anything, so it is
 /// always safe to run on in-progress or even non-terminating source.
 pub fn run_pipeline(source: &str, uri: &Url) -> Vec<Diagnostic> {
-    let file = SourceFile::new("buffer", source.to_string());
+    let file_name = uri
+        .to_file_path()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "buffer".to_string());
+    let file = SourceFile::new(file_name, source.to_string());
 
     let tokens = match Tokenizer::lex(file.clone()) {
         Ok(t) => t,

--- a/src/lsp/pipeline.rs
+++ b/src/lsp/pipeline.rs
@@ -29,9 +29,16 @@ pub fn run_pipeline(source: &str, uri: &Url) -> Vec<Diagnostic> {
         Err(e) => return vec![error_to_diagnostic(source, &e)],
     };
 
+    let base_dir = uri
+        .to_file_path()
+        .ok()
+        .and_then(|p| p.parent().map(std::path::Path::to_path_buf))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+
     let mut checker = TypeChecker::new()
         .with_source_file(file)
-        .with_ast_arena(ast);
+        .with_ast_arena(ast)
+        .with_base_dir(base_dir);
     if let Ok(doc_path) = uri.to_file_path()
         && let Some(doc_dir) = doc_path.parent()
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,9 +259,14 @@ fn main() {
             #[cfg(feature = "eval")]
             {
                 use rl_lang::checker::TypeChecker;
+                let base_dir = file
+                    .parent()
+                    .map(std::path::Path::to_path_buf)
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
                 let mut checker = TypeChecker::new()
                     .with_source_file(source)
-                    .with_ast_arena(ast);
+                    .with_ast_arena(ast)
+                    .with_base_dir(base_dir);
                 let errors = checker.check(&statements);
                 if errors.is_empty() {
                     println!("ok");

--- a/src/parser/statements/import_statement.rs
+++ b/src/parser/statements/import_statement.rs
@@ -36,6 +36,43 @@ use crate::{
 };
 
 impl Parser {
+    fn get_imported_type_names(&mut self, path: &[String], only: Option<&[String]>) {
+        let import_name = format!("{}.rl", path.join("/"));
+        let file_path = std::path::Path::new(self.source_file.name.as_ref())
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new(""))
+            .join(&import_name);
+
+        let Ok(source_text) = std::fs::read_to_string(&file_path) else {
+            return;
+        };
+        let source_file = crate::utils::source::SourceFile::new(
+            file_path.to_string_lossy().as_ref().to_string(),
+            source_text,
+        );
+        let Ok(tokens) = crate::lexer::tokenizer::Tokenizer::lex(source_file.clone()) else {
+            return;
+        };
+        let Ok((_, stmts)) = Parser::parse(tokens, source_file) else {
+            return;
+        };
+
+        for stmt in &stmts {
+            let (name, set): (&String, &mut std::collections::HashSet<String>) = match &stmt.kind {
+                StatementKind::RecordDeclaration { name, .. } => (name, &mut self.record_names),
+                StatementKind::TagDeclaration { name, .. } => (name, &mut self.tag_names),
+                _ => continue,
+            };
+            let wanted = match only {
+                Some(names) => names.contains(name),
+                None => true,
+            };
+            if wanted {
+                set.insert(name.clone());
+            }
+        }
+    }
+
     /// Parses a `get` import statement.
     ///
     /// Called after `get` has been consumed. Dispatches on the tokens that
@@ -93,6 +130,7 @@ impl Parser {
                     span,
                 ))
             } else {
+                self.get_imported_type_names(&segments, None);
                 Ok(Statement::new(
                     StatementKind::ImportFile { path: segments },
                     span,
@@ -103,10 +141,9 @@ impl Parser {
         // single-segment file import: get mymodule
         if !matches!(self.peek(), TokenType::Comma | TokenType::From) {
             let span = start.join(self.previous_span());
-            return Ok(Statement::new(
-                StatementKind::ImportFile { path: vec![first] },
-                span,
-            ));
+            let path = vec![first];
+            self.get_imported_type_names(&path, None);
+            return Ok(Statement::new(StatementKind::ImportFile { path }, span));
         }
 
         // named imports: get add, sub from …
@@ -150,6 +187,7 @@ impl Parser {
         if is_std {
             Ok(Statement::new(StatementKind::Import { names, path }, span))
         } else {
+            self.get_imported_type_names(&path, Some(&names));
             Ok(Statement::new(
                 StatementKind::ImportFileNamed { path, names },
                 span,

--- a/src/resolver/statements.rs
+++ b/src/resolver/statements.rs
@@ -386,6 +386,10 @@ impl Resolver {
                         | StatementKind::ConstantArray { name, .. } => names.contains(name),
                         StatementKind::Map { name, .. }
                         | StatementKind::ConstantMap { name, .. } => names.contains(name),
+                        StatementKind::Set { name, .. }
+                        | StatementKind::ConstantSet { name, .. } => names.contains(name),
+                        StatementKind::RecordDeclaration { name, .. }
+                        | StatementKind::TagDeclaration { name, .. } => names.contains(name),
                         _ => false,
                     })
                     .collect();


### PR DESCRIPTION
## What does this PR do?
Update the `check` command to start at the file-to-be-checked directory to validate imports
Allow `set`, `record` and `tag` declaration to pass through the resolver
Update `import_module` in parser to recognize `record` and `tag`
Update checker to filter correctly
Update `LSP` to start checking in same file directory
