### PR TITLE
Refactor/math

### DIFF
--- a/crates/rl-docs/src/entries/stdlib/math/abs.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/abs.rs
@@ -1,0 +1,16 @@
+use crate::entry::FnEntry;
+
+pub static ABS: FnEntry = FnEntry {
+    signature: "abs(number)",
+    description: "returns the absolute value of number",
+    example: r#"
+get std::math::abs
+
+dec int x = -1
+x.abs()?"#,
+    expected_output: Some("1"),
+    returns: "result[int] or result[float]",
+    errors: Some("Will return error on non-number values"),
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/acos.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/acos.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static ACOS: FnEntry = FnEntry {
+    signature: "acos(x)",
+    description: "arc cosine of x in radians",
+    example: "get std::math::acos\n\nacos(1.0) // 0.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/asin.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/asin.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static ASIN: FnEntry = FnEntry {
+    signature: "asin(x)",
+    description: "arc sine of x in radians",
+    example: "get std::math::asin\n\nasin(1.0) // 1.5707...",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/atan.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/atan.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static ATAN: FnEntry = FnEntry {
+    signature: "atan(x)",
+    description: "arc tangent of x in radians",
+    example: "get std::math::atan\n\natan(1.0) // 0.7853...",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/atan2.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/atan2.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static ATAN2: FnEntry = FnEntry {
+    signature: "atan2(a, b)",
+    description: "arc tangent of a/b using signs to determine quadrant",
+    example: "get std::math::atan2\n\natan2(1.0, 1.0) // 0.7853...",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/ceil.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/ceil.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static CEIL: FnEntry = FnEntry {
+    signature: "ceil(x)",
+    description: "smallest integer greater than or equal to x",
+    example: "get std::math::ceil\n\nceil(2.12) // 3.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/clamp.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/clamp.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static CLAMP: FnEntry = FnEntry {
+    signature: "clamp(x, min, max)",
+    description: "clamps x between min and max, returning min if x < min, max if x > max",
+    example: "get std::math::clamp\n\nclamp(12, 15, 20) // 15",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/cos.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/cos.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static COS: FnEntry = FnEntry {
+    signature: "cos(x)",
+    description: "cosine of x in radians",
+    example: "get std::math::cos\n\ncos(0.0) // 1.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/degrees.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/degrees.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static DEGREES: FnEntry = FnEntry {
+    signature: "degrees(x)",
+    description: "convert radians to degrees",
+    example: "get std::math::degrees\n\ndegrees(3.14159) // 180.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/exp.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/exp.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static EXP: FnEntry = FnEntry {
+    signature: "exp(x)",
+    description: "e raised to the power x",
+    example: "get std::math::exp\n\nexp(1.0) // 2.718...",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/factorial.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/factorial.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static FACTORIAL: FnEntry = FnEntry {
+    signature: "factorial(x)",
+    description: "product of all integers from 1 to x",
+    example: "get std::math::factorial\n\nfactorial(5) // 120",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/fibonacci.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/fibonacci.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static FIBONACCI: FnEntry = FnEntry {
+    signature: "fibonacci(x)",
+    description: "xth fibonacci number",
+    example: "get std::math::fibonacci\n\nfibonacci(7) // 13",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/floor.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/floor.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static FLOOR: FnEntry = FnEntry {
+    signature: "floor(x)",
+    description: "largest integer less than or equal to x",
+    example: "get std::math::floor\n\nfloor(1.23) // 1.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/gcd.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/gcd.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static GCD: FnEntry = FnEntry {
+    signature: "gcd(a, b)",
+    description: "greatest common divisor of a and b",
+    example: "get std::math::gcd\n\ngcd(12, 8) // 4",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/hypot.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/hypot.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static HYPOT: FnEntry = FnEntry {
+    signature: "hypot(a, b)",
+    description: "length of the hypotenuse given two sides: √(a² + b²)",
+    example: "get std::math::hypot\n\nhypot(3.0, 4.0) // 5.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/is_prime.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/is_prime.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static IS_PRIME: FnEntry = FnEntry {
+    signature: "is_prime(x)",
+    description: "true if x is a prime number",
+    example: "get std::math::is_prime\n\nis_prime(7) // true",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/lcm.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/lcm.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static LCM: FnEntry = FnEntry {
+    signature: "lcm(a, b)",
+    description: "least common multiple of a and b",
+    example: "get std::math::lcm\n\nlcm(4, 6) // 12",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/lerp.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/lerp.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static LERP: FnEntry = FnEntry {
+    signature: "lerp(x, y, t)",
+    description: "linear interpolation between x and y by factor t",
+    example: "get std::math::lerp\n\nlerp(0.0, 10.0, 0.5) // 5.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/log.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/log.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static LOG: FnEntry = FnEntry {
+    signature: "log(x, base)",
+    description: "logarithm of x in the given base",
+    example: "get std::math::log\n\nlog(100.0, 10.0) // 2.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/log10.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/log10.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static LOG10: FnEntry = FnEntry {
+    signature: "log10(x)",
+    description: "base-10 logarithm of x",
+    example: "get std::math::log10\n\nlog10(1000.0) // 3.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/log2.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/log2.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static LOG2: FnEntry = FnEntry {
+    signature: "log2(x)",
+    description: "base-2 logarithm of x",
+    example: "get std::math::log2\n\nlog2(8.0) // 3.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/map_range.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/map_range.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MAP_RANGE: FnEntry = FnEntry {
+    signature: "map_range(x, in_min, in_max, out_min, out_max)",
+    description: "re-map x from one range to another",
+    example: "get std::math::map_range\n\nmap_range(5.0, 0.0, 10.0, 0.0, 100.0) // 50.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/max.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/max.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MAX: FnEntry = FnEntry {
+    signature: "max(a, b)",
+    description: "returns the larger of a and b",
+    example: "get std::math::max\n\nmax(4, 6) // 6",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/min.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/min.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MIN: FnEntry = FnEntry {
+    signature: "min(a, b)",
+    description: "returns the smaller of a and b",
+    example: "get std::math::min\n\nmin(4, 6) // 4",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/mod.rs
@@ -1,4 +1,38 @@
 use crate::entry::{FnEntry, StdEntry};
+
+mod abs;
+mod acos;
+mod asin;
+mod atan;
+mod atan2;
+mod ceil;
+mod clamp;
+mod cos;
+mod degrees;
+mod exp;
+mod factorial;
+mod fibonacci;
+mod floor;
+mod gcd;
+mod hypot;
+mod is_prime;
+mod lcm;
+mod lerp;
+mod log;
+mod log10;
+mod log2;
+mod map_range;
+mod max;
+mod min;
+mod modulo;
+mod power;
+mod radians;
+mod round;
+mod sign;
+mod sin;
+mod sqrt;
+mod tan;
+
 pub static MATH: StdEntry = StdEntry {
     name: "math",
     description: "functions for math",
@@ -8,359 +42,36 @@ pub static MATH: StdEntry = StdEntry {
 };
 
 static FUNCTIONS: &[&FnEntry] = &[
-    &ABS, &ACOS, &ASIN, &ATAN, &ATAN2, &CEIL, &CLAMP, &COS, &DEGREES, &EXP, &FACTORIAL, &FIBONACCI,
-    &FLOOR, &GCD, &HYPOT, &IS_PRIME, &LCM, &LERP, &LOG, &LOG2, &LOG10, &MAP_RANGE, &MAX, &MIN,
-    &MOD, &POW, &RADIANS, &ROUND, &SIGN, &SIN, &SQRT, &TAN,
+    &abs::ABS,
+    &acos::ACOS,
+    &asin::ASIN,
+    &atan::ATAN,
+    &atan2::ATAN2,
+    &ceil::CEIL,
+    &clamp::CLAMP,
+    &cos::COS,
+    &degrees::DEGREES,
+    &exp::EXP,
+    &factorial::FACTORIAL,
+    &fibonacci::FIBONACCI,
+    &floor::FLOOR,
+    &gcd::GCD,
+    &hypot::HYPOT,
+    &is_prime::IS_PRIME,
+    &lcm::LCM,
+    &lerp::LERP,
+    &log::LOG,
+    &log2::LOG2,
+    &log10::LOG10,
+    &map_range::MAP_RANGE,
+    &max::MAX,
+    &min::MIN,
+    &modulo::MOD,
+    &power::POW,
+    &radians::RADIANS,
+    &round::ROUND,
+    &sign::SIGN,
+    &sin::SIN,
+    &sqrt::SQRT,
+    &tan::TAN,
 ];
-
-static ABS: FnEntry = FnEntry {
-    signature: "abs(number)",
-    description: "returns the absolute value of number",
-    example: "get std::math::abs\n\ndec int x = -1\nx.abs() // 1",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static ACOS: FnEntry = FnEntry {
-    signature: "acos(x)",
-    description: "arc cosine of x in radians",
-    example: "get std::math::acos\n\nacos(1.0) // 0.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static ASIN: FnEntry = FnEntry {
-    signature: "asin(x)",
-    description: "arc sine of x in radians",
-    example: "get std::math::asin\n\nasin(1.0) // 1.5707...",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static ATAN: FnEntry = FnEntry {
-    signature: "atan(x)",
-    description: "arc tangent of x in radians",
-    example: "get std::math::atan\n\natan(1.0) // 0.7853...",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static ATAN2: FnEntry = FnEntry {
-    signature: "atan2(a, b)",
-    description: "arc tangent of a/b using signs to determine quadrant",
-    example: "get std::math::atan2\n\natan2(1.0, 1.0) // 0.7853...",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static CEIL: FnEntry = FnEntry {
-    signature: "ceil(x)",
-    description: "smallest integer greater than or equal to x",
-    example: "get std::math::ceil\n\nceil(2.12) // 3.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static CLAMP: FnEntry = FnEntry {
-    signature: "clamp(x, min, max)",
-    description: "clamps x between min and max, returning min if x < min, max if x > max",
-    example: "get std::math::clamp\n\nclamp(12, 15, 20) // 15",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static COS: FnEntry = FnEntry {
-    signature: "cos(x)",
-    description: "cosine of x in radians",
-    example: "get std::math::cos\n\ncos(0.0) // 1.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static DEGREES: FnEntry = FnEntry {
-    signature: "degrees(x)",
-    description: "convert radians to degrees",
-    example: "get std::math::degrees\n\ndegrees(3.14159) // 180.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static EXP: FnEntry = FnEntry {
-    signature: "exp(x)",
-    description: "e raised to the power x",
-    example: "get std::math::exp\n\nexp(1.0) // 2.718...",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static FACTORIAL: FnEntry = FnEntry {
-    signature: "factorial(x)",
-    description: "product of all integers from 1 to x",
-    example: "get std::math::factorial\n\nfactorial(5) // 120",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static FIBONACCI: FnEntry = FnEntry {
-    signature: "fibonacci(x)",
-    description: "xth fibonacci number",
-    example: "get std::math::fibonacci\n\nfibonacci(7) // 13",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static FLOOR: FnEntry = FnEntry {
-    signature: "floor(x)",
-    description: "largest integer less than or equal to x",
-    example: "get std::math::floor\n\nfloor(1.23) // 1.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static GCD: FnEntry = FnEntry {
-    signature: "gcd(a, b)",
-    description: "greatest common divisor of a and b",
-    example: "get std::math::gcd\n\ngcd(12, 8) // 4",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static HYPOT: FnEntry = FnEntry {
-    signature: "hypot(a, b)",
-    description: "length of the hypotenuse given two sides: √(a² + b²)",
-    example: "get std::math::hypot\n\nhypot(3.0, 4.0) // 5.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static IS_PRIME: FnEntry = FnEntry {
-    signature: "is_prime(x)",
-    description: "true if x is a prime number",
-    example: "get std::math::is_prime\n\nis_prime(7) // true",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static LCM: FnEntry = FnEntry {
-    signature: "lcm(a, b)",
-    description: "least common multiple of a and b",
-    example: "get std::math::lcm\n\nlcm(4, 6) // 12",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static LERP: FnEntry = FnEntry {
-    signature: "lerp(x, y, t)",
-    description: "linear interpolation between x and y by factor t",
-    example: "get std::math::lerp\n\nlerp(0.0, 10.0, 0.5) // 5.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static LOG: FnEntry = FnEntry {
-    signature: "log(x, base)",
-    description: "logarithm of x in the given base",
-    example: "get std::math::log\n\nlog(100.0, 10.0) // 2.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static LOG2: FnEntry = FnEntry {
-    signature: "log2(x)",
-    description: "base-2 logarithm of x",
-    example: "get std::math::log2\n\nlog2(8.0) // 3.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static LOG10: FnEntry = FnEntry {
-    signature: "log10(x)",
-    description: "base-10 logarithm of x",
-    example: "get std::math::log10\n\nlog10(1000.0) // 3.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static MAP_RANGE: FnEntry = FnEntry {
-    signature: "map_range(x, in_min, in_max, out_min, out_max)",
-    description: "re-map x from one range to another",
-    example: "get std::math::map_range\n\nmap_range(5.0, 0.0, 10.0, 0.0, 100.0) // 50.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static MAX: FnEntry = FnEntry {
-    signature: "max(a, b)",
-    description: "returns the larger of a and b",
-    example: "get std::math::max\n\nmax(4, 6) // 6",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static MIN: FnEntry = FnEntry {
-    signature: "min(a, b)",
-    description: "returns the smaller of a and b",
-    example: "get std::math::min\n\nmin(4, 6) // 4",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static MOD: FnEntry = FnEntry {
-    signature: "mod(a, b)",
-    description: "remainder of a divided by b",
-    example: "get std::math::mod\n\nmod(10, 3) // 1",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static POW: FnEntry = FnEntry {
-    signature: "pow(a, b)",
-    description: "raises a to the power of b",
-    example: "get std::math::pow\n\npow(2, 2) // 4.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static RADIANS: FnEntry = FnEntry {
-    signature: "radians(x)",
-    description: "convert degrees to radians",
-    example: "get std::math::radians\n\nradians(180.0) // 3.14159...",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static ROUND: FnEntry = FnEntry {
-    signature: "round(x)",
-    description: "rounds x to the nearest integer",
-    example: "get std::math::round\n\nround(2.2) // 2.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static SIGN: FnEntry = FnEntry {
-    signature: "sign(x)",
-    description: "returns -1, 0, or 1 based on the sign of x",
-    example: "get std::math::sign\n\nsign(-5) // -1",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static SIN: FnEntry = FnEntry {
-    signature: "sin(x)",
-    description: "sine of x in radians",
-    example: "get std::math::sin\n\nsin(0.0) // 0.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static SQRT: FnEntry = FnEntry {
-    signature: "sqrt(x)",
-    description: "square root of x",
-    example: "get std::math::sqrt\n\nsqrt(4) // 2.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};
-
-static TAN: FnEntry = FnEntry {
-    signature: "tan(x)",
-    description: "tangent of x in radians",
-    example: "get std::math::tan\n\ntan(0.0) // 0.0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
-};

--- a/crates/rl-docs/src/entries/stdlib/math/modulo.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/modulo.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MOD: FnEntry = FnEntry {
+    signature: "mod(a, b)",
+    description: "remainder of a divided by b",
+    example: "get std::math::mod\n\nmod(10, 3) // 1",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/power.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/power.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static POW: FnEntry = FnEntry {
+    signature: "pow(a, b)",
+    description: "raises a to the power of b",
+    example: "get std::math::pow\n\npow(2, 2) // 4.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/radians.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/radians.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static RADIANS: FnEntry = FnEntry {
+    signature: "radians(x)",
+    description: "convert degrees to radians",
+    example: "get std::math::radians\n\nradians(180.0) // 3.14159...",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/round.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/round.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static ROUND: FnEntry = FnEntry {
+    signature: "round(x)",
+    description: "rounds x to the nearest integer",
+    example: "get std::math::round\n\nround(2.2) // 2.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/sign.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/sign.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static SIGN: FnEntry = FnEntry {
+    signature: "sign(x)",
+    description: "returns -1, 0, or 1 based on the sign of x",
+    example: "get std::math::sign\n\nsign(-5) // -1",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/sin.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/sin.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static SIN: FnEntry = FnEntry {
+    signature: "sin(x)",
+    description: "sine of x in radians",
+    example: "get std::math::sin\n\nsin(0.0) // 0.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/sqrt.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/sqrt.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static SQRT: FnEntry = FnEntry {
+    signature: "sqrt(x)",
+    description: "square root of x",
+    example: "get std::math::sqrt\n\nsqrt(4) // 2.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/math/tan.rs
+++ b/crates/rl-docs/src/entries/stdlib/math/tan.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static TAN: FnEntry = FnEntry {
+    signature: "tan(x)",
+    description: "tangent of x in radians",
+    example: "get std::math::tan\n\ntan(0.0) // 0.0",
+    expected_output: None,
+    returns: "",
+    errors: None,
+    see_also: &[],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-interpreter/src/stdlib/math/abs.rs
+++ b/crates/rl-interpreter/src/stdlib/math/abs.rs
@@ -1,14 +1,17 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
 /// returns the absolute value of number
-pub fn std_abs(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_abs(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Integer(i.abs())),
-        Value::Float(f) => Ok(Value::Float(f.abs())),
-        other => Err(eval.err(
-            format!("abs() expects a number, got {}", other.type_name()),
-            span,
-        )),
+        Value::Integer(i) => vok!(vi!(i.abs())),
+        Value::Float(f) => vok!(vf!(f.abs())),
+        other => verr!(vs!(format!(
+            "abs() expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/ceil.rs
+++ b/crates/rl-interpreter/src/stdlib/math/ceil.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_ceil(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_ceil(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Integer(i)),
-        Value::Float(f) => Ok(Value::Float(f.ceil())),
-        other => Err(eval.err(
-            format!("ceil() expects a number, got {}", other.type_name()),
-            span,
-        )),
+        Value::Integer(i) => vok!(vi!(i)),
+        Value::Float(f) => vok!(vf!(f.ceil())),
+        other => verr!(vs!(format!(
+            "ceil() expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/clamp.rs
+++ b/crates/rl-interpreter/src/stdlib/math/clamp.rs
@@ -1,28 +1,22 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_clamp(
-    eval: &mut Evaluator,
-    value: Value,
-    min: Value,
-    max: Value,
-    span: Span,
-) -> Result<Value, Error> {
+pub fn std_clamp(_: &mut Evaluator, value: Value, min: Value, max: Value) -> Value {
     match (value, min, max) {
         (Value::Integer(value), Value::Integer(low), Value::Integer(high)) => {
-            Ok(Value::Integer(value.clamp(low, high)))
+            vok!(vi!(value.clamp(low, high)))
         }
         (Value::Float(value), Value::Float(low), Value::Float(high)) => {
-            Ok(Value::Float(value.clamp(low, high)))
+            vok!(vf!(value.clamp(low, high)))
         }
-        (value, min, max) => Err(eval.err(
-            format!(
-                "clamp() expects a number, got ({}, {}, {})",
-                value.type_name(),
-                min.type_name(),
-                max.type_name()
-            ),
-            span,
-        )),
+        (value, min, max) => verr!(vs!(format!(
+            "clamp expects a number, got ({}, {}, {})",
+            value.type_name(),
+            min.type_name(),
+            max.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/floor.rs
+++ b/crates/rl-interpreter/src/stdlib/math/floor.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_floor(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_floor(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Integer(i)),
-        Value::Float(f) => Ok(Value::Float(f.floor())),
-        other => Err(eval.err(
-            format!("floor() expects a number, got {}", other.type_name()),
-            span,
-        )),
+        Value::Integer(i) => vok!(vi!(i)),
+        Value::Float(f) => vok!(vf!(f.floor())),
+        other => verr!(vs!(format!(
+            "floor expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/log.rs
+++ b/crates/rl-interpreter/src/stdlib/math/log.rs
@@ -1,20 +1,20 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vok, vs},
+    values::Value,
+};
 
-pub fn std_log(eval: &mut Evaluator, a: Value, base: Value, span: Span) -> Result<Value, Error> {
+pub fn std_log(_: &mut Evaluator, a: Value, base: Value) -> Value {
     match (a, base) {
-        (Value::Integer(i), Value::Integer(base)) => Ok(Value::Float((i as f64).log(base as f64))),
-        (Value::Float(f), Value::Float(base)) => Ok(Value::Float(f.log(base))),
-        (Value::Float(f), Value::Integer(base)) => Ok(Value::Float(f.log(base as f64))),
-        (Value::Integer(i), Value::Float(base)) => Ok(Value::Float((i as f64).log(base))),
+        (Value::Integer(i), Value::Integer(base)) => vok!(vf!((i as f64).log(base as f64))),
+        (Value::Float(f), Value::Float(base)) => vok!(vf!(f.log(base))),
+        (Value::Float(f), Value::Integer(base)) => vok!(vf!(f.log(base as f64))),
+        (Value::Integer(i), Value::Float(base)) => vok!(vf!((i as f64).log(base))),
 
-        (a, base) => Err(eval.err(
-            format!(
-                "log() expects a number, got ({}, {})",
-                a.type_name(),
-                base.type_name()
-            ),
-            span,
-        )),
+        (a, base) => verr!(vs!(format!(
+            "log expects a number, got ({}, {})",
+            a.type_name(),
+            base.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/log10.rs
+++ b/crates/rl-interpreter/src/stdlib/math/log10.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vok, vs},
+    values::Value,
+};
 
-pub fn std_log10(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_log10(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Float((i as f64).log10())),
-        Value::Float(f) => Ok(Value::Float(f.log10())),
-        other => Err(eval.err(
-            format!("log10() expects a number, got {}", other.type_name()),
-            span,
-        )),
+        Value::Integer(i) => vok!(vf!((i as f64).log10())),
+        Value::Float(f) => vok!(vf!(f.log10())),
+        other => verr!(vs!(format!(
+            "log10 expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/log2.rs
+++ b/crates/rl-interpreter/src/stdlib/math/log2.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vok, vs},
+    values::Value,
+};
 
-pub fn std_log2(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_log2(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Float((i as f64).log2())),
-        Value::Float(f) => Ok(Value::Float(f.log2())),
-        other => Err(eval.err(
-            format!("log2() expects a number, got {}", other.type_name()),
-            span,
-        )),
+        Value::Integer(i) => vok!(vf!((i as f64).log2())),
+        Value::Float(f) => vok!(vf!(f.log2())),
+        other => verr!(vs!(format!(
+            "log2 expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/max.rs
+++ b/crates/rl-interpreter/src/stdlib/math/max.rs
@@ -1,17 +1,17 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_max(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
+pub fn std_max(_: &mut Evaluator, a: Value, b: Value) -> Value {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.max(b))),
-        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.max(b))),
-        (a, b) => Err(eval.err(
-            format!(
-                "max() expects a number, got ({}, {})",
-                a.type_name(),
-                b.type_name()
-            ),
-            span,
-        )),
+        (Value::Integer(a), Value::Integer(b)) => vok!(vi!(a.max(b))),
+        (Value::Float(a), Value::Float(b)) => vok!(vf!(a.max(b))),
+        (a, b) => verr!(vs!(format!(
+            "max expects a number, got ({}, {})",
+            a.type_name(),
+            b.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/min.rs
+++ b/crates/rl-interpreter/src/stdlib/math/min.rs
@@ -1,17 +1,17 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_min(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
+pub fn std_min(_: &mut Evaluator, a: Value, b: Value) -> Value {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a.min(b))),
-        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.min(b))),
-        (a, b) => Err(eval.err(
-            format!(
-                "min() expects a number, got ({}, {})",
-                a.type_name(),
-                b.type_name()
-            ),
-            span,
-        )),
+        (Value::Integer(a), Value::Integer(b)) => vok!(vi!(a.min(b))),
+        (Value::Float(a), Value::Float(b)) => vok!(vf!(a.min(b))),
+        (a, b) => verr!(vs!(format!(
+            "min expects a number, got ({}, {})",
+            a.type_name(),
+            b.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/mod.rs
+++ b/crates/rl-interpreter/src/stdlib/math/mod.rs
@@ -47,7 +47,7 @@ pub fn module() -> Module {
         .with_function("sin", sin::std_sin)
         .with_function("cos", cos::std_cos)
         .with_function("tan", tan::std_tan)
-        .with_raw_function("pow", power::std_pow)
+        .with_function("pow", power::std_pow)
         .with_function("mod", modulo::std_mod)
         .with_function("abs", abs::std_abs)
         .with_function("ceil", ceil::std_ceil)

--- a/crates/rl-interpreter/src/stdlib/math/modulo.rs
+++ b/crates/rl-interpreter/src/stdlib/math/modulo.rs
@@ -1,29 +1,19 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_mod(eval: &mut Evaluator, a: Value, b: Value, span: Span) -> Result<Value, Error> {
-    let a = normalize_numeric(a);
-    let b = normalize_numeric(b);
-
+pub fn std_mod(_: &mut Evaluator, a: Value, b: Value) -> Value {
     match (a, b) {
-        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(a % b)),
-        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a % b)),
-        (Value::Integer(a), Value::Float(b)) => Ok(Value::Float(a as f64 % b)),
-        (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a % b as f64)),
-        (a, b) => Err(eval.err(
-            format!(
-                "mod() expects a number, got ({}, {})",
-                a.type_name(),
-                b.type_name()
-            ),
-            span,
-        )),
-    }
-}
-
-fn normalize_numeric(v: Value) -> Value {
-    match v {
-        Value::Byte(b) => Value::Integer(b as i64),
-        other => other,
+        (Value::Integer(a), Value::Integer(b)) => vok!(vi!(a % b)),
+        (Value::Float(a), Value::Float(b)) => vok!(vf!(a % b)),
+        (Value::Integer(a), Value::Float(b)) => vok!(vf!(a as f64 % b)),
+        (Value::Float(a), Value::Integer(b)) => vok!(vf!(a % b as f64)),
+        (a, b) => verr!(vs!(format!(
+            "mod expects a number, got ({}, {})",
+            a.type_name(),
+            b.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/power.rs
+++ b/crates/rl-interpreter/src/stdlib/math/power.rs
@@ -1,35 +1,18 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_pow(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
-    if args.len() != 2 {
-        return Err(eval.err(
-            format!("pow() expects 2 arguments, got {}", args.len()),
-            span,
-        ));
-    }
-    let mut iter = args.into_iter();
-    let base = normalize_numeric(iter.next().unwrap());
-    let exponent = normalize_numeric(iter.next().unwrap());
-
+pub fn std_pow(_: &mut Evaluator, base: Value, exponent: Value) -> Value {
     match (base, exponent) {
         (Value::Integer(a), Value::Integer(b)) => {
             let b = b as u32;
-            Ok(Value::Integer(a.pow(b)))
+            vok!(vi!(a.pow(b)))
         }
-        (Value::Integer(a), Value::Float(b)) => Ok(Value::Float((a as f64).powf(b))),
-        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a.powf(b))),
-        (Value::Float(a), Value::Integer(b)) => Ok(Value::Float(a.powi(b as i32))),
-        _ => Err(eval.err("pow() expects numeric arguments".to_string(), span)),
-    }
-}
-
-// widen the byte to integer
-// more types will be implemented later
-// or being strict after adding explicit cast
-fn normalize_numeric(v: Value) -> Value {
-    match v {
-        Value::Byte(b) => Value::Integer(b as i64),
-        other => other,
+        (Value::Integer(a), Value::Float(b)) => vok!(vf!((a as f64).powf(b))),
+        (Value::Float(a), Value::Float(b)) => vok!(vf!(a.powf(b))),
+        (Value::Float(a), Value::Integer(b)) => vok!(vf!(a.powi(b as i32))),
+        _ => verr!(vs!("pow expects numeric arguments".to_string())),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/round.rs
+++ b/crates/rl-interpreter/src/stdlib/math/round.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vi, vok, vs},
+    values::Value,
+};
 
-pub fn std_round(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_round(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Integer(i)),
-        Value::Float(f) => Ok(Value::Float(f.round())),
-        other => Err(eval.err(
-            format!("round() expects a number, got {}", other.type_name(),),
-            span,
-        )),
+        Value::Integer(i) => vok!(vi!(i)),
+        Value::Float(f) => vok!(vf!(f.round())),
+        other => verr!(vs!(format!(
+            "round expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/math/sqrt.rs
+++ b/crates/rl-interpreter/src/stdlib/math/sqrt.rs
@@ -1,13 +1,16 @@
-use crate::{evaluator::Evaluator, values::Value};
-use rl_utils::{errors::Error, span::Span};
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vf, vok, vs},
+    values::Value,
+};
 
-pub fn std_sqrt(eval: &mut Evaluator, a: Value, span: Span) -> Result<Value, Error> {
+pub fn std_sqrt(_: &mut Evaluator, a: Value) -> Value {
     match a {
-        Value::Integer(i) => Ok(Value::Float((i as f64).sqrt())),
-        Value::Float(f) => Ok(Value::Float(f.sqrt())),
-        other => Err(eval.err(
-            format!("round() expects a number, got {}", other.type_name(),),
-            span,
-        )),
+        Value::Integer(i) => vok!(vf!((i as f64).sqrt())),
+        Value::Float(f) => vok!(vf!(f.sqrt())),
+        other => verr!(vs!(format!(
+            "sqrt expects a number, got {}",
+            other.type_name()
+        ))),
     }
 }

--- a/crates/rl-tests/tests/interpreter/stdlib/math.rs
+++ b/crates/rl-tests/tests/interpreter/stdlib/math.rs
@@ -7,7 +7,7 @@ fn abs_positive() {
     let ev = eval_program(
         r#"
 get abs from std::math
-dec int x = abs(5)
+dec int x = abs(5)?
 "#,
     )
     .unwrap();
@@ -19,7 +19,7 @@ fn abs_negative() {
     let ev = eval_program(
         r#"
 get abs from std::math
-dec int x = abs(-7)
+dec int x = abs(-7)?
 "#,
     )
     .unwrap();
@@ -31,7 +31,7 @@ fn max_returns_larger() {
     let ev = eval_program(
         r#"
 get max from std::math
-dec int x = max(3, 9)
+dec int x = max(3, 9)?
 "#,
     )
     .unwrap();
@@ -43,7 +43,7 @@ fn min_returns_smaller() {
     let ev = eval_program(
         r#"
 get min from std::math
-dec int x = min(3, 9)
+dec int x = min(3, 9)?
 "#,
     )
     .unwrap();
@@ -55,7 +55,7 @@ fn pow_integer() {
     let ev = eval_program(
         r#"
 get pow from std::math
-dec int x = pow(2, 10)
+dec int x = pow(2, 10)?
 "#,
     )
     .unwrap();
@@ -67,7 +67,7 @@ fn sqrt_float() {
     let ev = eval_program(
         r#"
 get sqrt from std::math
-dec float x = sqrt(9.0)
+dec float x = sqrt(9.0)?
 "#,
     )
     .unwrap();
@@ -79,7 +79,7 @@ fn floor_float() {
     let ev = eval_program(
         r#"
 get floor from std::math
-dec float x = floor(3.9)
+dec float x = floor(3.9)?
 "#,
     )
     .unwrap();
@@ -91,7 +91,7 @@ fn ceil_float() {
     let ev = eval_program(
         r#"
 get ceil from std::math
-dec float x = ceil(3.1)
+dec float x = ceil(3.1)?
 "#,
     )
     .unwrap();
@@ -103,7 +103,7 @@ fn round_float_up() {
     let ev = eval_program(
         r#"
 get round from std::math
-dec float x = round(2.6)
+dec float x = round(2.6)?
 "#,
     )
     .unwrap();
@@ -115,7 +115,7 @@ fn round_float_down() {
     let ev = eval_program(
         r#"
 get round from std::math
-dec float x = round(2.4)
+dec float x = round(2.4)?
 "#,
     )
     .unwrap();
@@ -127,7 +127,7 @@ fn clamp_within_range() {
     let ev = eval_program(
         r#"
 get clamp from std::math
-dec int x = clamp(5, 0, 10)
+dec int x = clamp(5, 0, 10)?
 "#,
     )
     .unwrap();
@@ -139,7 +139,7 @@ fn clamp_below_min() {
     let ev = eval_program(
         r#"
 get clamp from std::math
-dec int x = clamp(-5, 0, 10)
+dec int x = clamp(-5, 0, 10)?
 "#,
     )
     .unwrap();
@@ -151,7 +151,7 @@ fn clamp_above_max() {
     let ev = eval_program(
         r#"
 get clamp from std::math
-dec int x = clamp(99, 0, 10)
+dec int x = clamp(99, 0, 10)?
 "#,
     )
     .unwrap();
@@ -163,7 +163,7 @@ fn mod_operation() {
     let ev = eval_program(
         r#"
 get mod from std::math
-dec int x = mod(10, 3)
+dec int x = mod(10, 3)?
 "#,
     )
     .unwrap();
@@ -175,7 +175,7 @@ fn log2_eight() {
     let ev = eval_program(
         r#"
 get log2 from std::math
-dec float x = log2(8.0)
+dec float x = log2(8.0)?
 "#,
     )
     .unwrap();
@@ -187,7 +187,7 @@ fn log10_thousand() {
     let ev = eval_program(
         r#"
 get log10 from std::math
-dec float x = log10(1000.0)
+dec float x = log10(1000.0)?
 "#,
     )
     .unwrap();


### PR DESCRIPTION
## What does this PR do?
Update `math` std module to return `result`
and removed implicit conversion between `int` and `byte`

## Related issue
Closes #140

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
