### PR TITLE
Feat(vm)/native

### DIFF
--- a/crates/rl-cli/src/logic_loops.rs
+++ b/crates/rl-cli/src/logic_loops.rs
@@ -112,8 +112,6 @@ pub fn vm_loop(source: SourceFile, ast: Ast, statements: Vec<Statement>) {
         }
     };
 
-    println!("{:?}", chunk);
-
     let mut vm = Vm::new();
     match vm.run(&chunk) {
         Ok(Some(val)) => println!("{:?}", val),

--- a/crates/rl-cli/src/logic_loops.rs
+++ b/crates/rl-cli/src/logic_loops.rs
@@ -114,8 +114,7 @@ pub fn vm_loop(source: SourceFile, ast: Ast, statements: Vec<Statement>) {
 
     let mut vm = Vm::new();
     match vm.run(&chunk) {
-        Ok(Some(val)) => println!("{:?}", val),
-        Ok(None) => {}
+        Ok(_) => {}
         Err(e) => {
             eprintln!("vm runtime error: {}", e.0);
             std::process::exit(1);

--- a/crates/rl-interpreter/src/native.rs
+++ b/crates/rl-interpreter/src/native.rs
@@ -149,7 +149,6 @@ impl FromValue for i64 {
     fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Integer(i) => Ok(i),
-            Value::Byte(b) => Ok(b as i64),
             other => Err(Error::at(
                 Reason::Runtime,
                 format!("expected integer, got {}", other.type_name()),

--- a/crates/rl-interpreter/src/native.rs
+++ b/crates/rl-interpreter/src/native.rs
@@ -149,6 +149,7 @@ impl FromValue for i64 {
     fn from_value(v: Value, span: Span) -> Result<Self, Error> {
         match v {
             Value::Integer(i) => Ok(i),
+            Value::Byte(b) => Ok(b as i64),
             other => Err(Error::at(
                 Reason::Runtime,
                 format!("expected integer, got {}", other.type_name()),

--- a/crates/rl-vm/src/chunk.rs
+++ b/crates/rl-vm/src/chunk.rs
@@ -1,31 +1,4 @@
-use std::rc::Rc;
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum VmValue {
-    Null,
-    Int(i64),
-    Float(f64),
-    Bool(bool),
-    Byte(u8),
-    Char(char),
-    Str(Rc<str>),
-    Function(Rc<VmFunction>),
-}
-
-#[derive(Debug)]
-pub struct VmFunction {
-    pub name: String,
-    pub arity: usize,
-    pub chunk: Chunk,
-}
-
-// VmValue derives PartialEq, so VmFunction needs it too - compare by
-// identity (name+arity) rather than deep-comparing bytecode
-impl PartialEq for VmFunction {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.arity == other.arity
-    }
-}
+use crate::VmValue;
 
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -1,6 +1,8 @@
 use std::rc::Rc;
 
 use crate::chunk::{Chunk, OpCode};
+use crate::native::Module;
+use crate::stdlib;
 use crate::values::{VmFunction, VmValue};
 use rl_ast::{
     Ast, ExprId, nodes::ExpressionKind, statements::Statement, statements::StatementKind,
@@ -15,6 +17,7 @@ pub struct Compiler<'a> {
     chunk: Chunk,
     next_slot: u16,
     scope_bases: Vec<u16>,
+    stdlib: Module,
 }
 
 impl<'a> Compiler<'a> {
@@ -24,6 +27,7 @@ impl<'a> Compiler<'a> {
             chunk: Chunk::new(),
             next_slot: 0,
             scope_bases: Vec::new(),
+            stdlib: stdlib::root(),
         }
     }
 
@@ -309,6 +313,18 @@ impl<'a> Compiler<'a> {
                         self.chunk.write_u16(*slot as u16, line);
                     }
                 }
+            }
+
+            ExpressionKind::Call { path, args } => {
+                let native = self.stdlib.resolve(path).ok_or_else(|| {
+                    CompileError(format!("undefined function {}", path.join("::")))
+                })?;
+                self.emit_const(VmValue::Native(native), line);
+                for arg in args {
+                    self.compile_expr(*arg)?;
+                }
+                self.chunk.write_op(OpCode::Call, line);
+                self.chunk.write_u16(args.len() as u16, line);
             }
 
             ExpressionKind::CallExpr { callee, args } => {

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
-use crate::chunk::{Chunk, OpCode, VmFunction, VmValue};
+use crate::chunk::{Chunk, OpCode};
+use crate::values::{VmFunction, VmValue};
 use rl_ast::{
     Ast, ExprId, nodes::ExpressionKind, statements::Statement, statements::StatementKind,
 };

--- a/crates/rl-vm/src/lib.rs
+++ b/crates/rl-vm/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod chunk;
 pub mod compiler;
+pub mod values;
 pub mod vm_logic;
 
-pub use chunk::{Chunk, OpCode, VmValue};
+pub use chunk::{Chunk, OpCode};
 pub use compiler::{CompileError, Compiler};
+pub use values::{VmNativeFn, VmValue};
 pub use vm_logic::{Vm, VmError};

--- a/crates/rl-vm/src/lib.rs
+++ b/crates/rl-vm/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod chunk;
 pub mod compiler;
 pub mod native;
+pub mod stdlib;
 pub mod values;
 pub mod vm_logic;
 

--- a/crates/rl-vm/src/lib.rs
+++ b/crates/rl-vm/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod chunk;
 pub mod compiler;
+pub mod native;
 pub mod values;
 pub mod vm_logic;
 
 pub use chunk::{Chunk, OpCode};
 pub use compiler::{CompileError, Compiler};
+pub use native::{Module, NativeFn};
 pub use values::{VmNativeFn, VmValue};
 pub use vm_logic::{Vm, VmError};

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -1,5 +1,18 @@
 use crate::values::{VmNativeFn, VmValue};
 use crate::vm_logic::{Vm, VmError};
+use std::collections::HashMap;
+use std::rc::Rc;
 
 /// A heap-allocated native function callable from rl bytecode.
 pub type NativeFn = Rc<dyn Fn(&mut Vm, Vec<VmValue>) -> Result<VmValue, VmError>>;
+
+/// A named collection of [`VmNativeFn`]s, optionally containing sub-[`Module`]s.
+pub struct Module {
+    /// The module name as used in import paths (e.g. `"io"`, `"math"`).
+    pub name: String,
+    /// Named functions registered in this module.
+    pub functions: HashMap<String, Rc<VmNativeFn>>,
+    /// Named submodules (e.g. `math::consts`).
+    pub submodules: HashMap<String, Module>,
+}
+

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -1,3 +1,11 @@
+//! The VM's native function binding system - [`Module`], [`NativeFn`], and the
+//! [`IntoNativeFn`] / [`FromValue`] / [`IntoValue`] trait machinery.
+//!
+//! This mirrors `rl-interpreter`'s `native.rs`, scoped down to what `VmValue`
+//! currently supports: no array/tuple/map/error/ok variants yet (so no
+//! `Vec<T>` impls), and `VmError` carries no `Span` (the VM doesn't track
+//! spans at runtime), unlike the interpreter's `Error`.
+
 use crate::values::{VmNativeFn, VmValue};
 use crate::vm_logic::{Vm, VmError};
 use std::collections::HashMap;
@@ -183,3 +191,139 @@ impl IntoValue for char {
     }
 }
 
+/// Wraps a typed Rust function into a [`NativeFn`] with automatic arity checking
+/// and argument extraction. Implemented by macro for 0-10 arguments.
+pub trait IntoNativeFn<Args> {
+    fn into_native(self) -> NativeFn;
+}
+
+impl<F, R> IntoNativeFn<()> for F
+where
+    F: Fn(&mut Vm) -> R + 'static,
+    R: IntoValue,
+{
+    fn into_native(self) -> NativeFn {
+        Rc::new(
+            move |vm: &mut Vm, args: Vec<VmValue>| -> Result<VmValue, VmError> {
+                if !args.is_empty() {
+                    return Err(VmError(format!(
+                        "expected 0 argument(s), got {}",
+                        args.len()
+                    )));
+                }
+                Ok(self(vm).into_value())
+            },
+        )
+    }
+}
+
+/// Marker type for fallible native functions (returning `Result<R, VmError>`).
+pub struct Fallible<T>(std::marker::PhantomData<T>);
+
+macro_rules! impl_into_native_fn {
+    ($count:literal, $(($ty:ident, $var:ident)),+) => {
+        impl<F, R, $($ty),+> IntoNativeFn<($($ty,)+)> for F
+        where
+            F: Fn(&mut Vm, $($ty),+) -> R + 'static,
+            R: IntoValue,
+            $($ty: FromValue),+
+        {
+            fn into_native(self) -> NativeFn {
+                Rc::new(move |vm: &mut Vm, args: Vec<VmValue>| -> Result<VmValue, VmError> {
+                    if args.len() != $count {
+                        return Err(VmError(format!(
+                            "expected {} argument(s), got {}",
+                            $count,
+                            args.len()
+                        )));
+                    }
+                    let mut iter = args.into_iter();
+                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    Ok(self(vm, $($var),+).into_value())
+                })
+            }
+        }
+
+        impl<F, R, $($ty),+> IntoNativeFn<(Fallible<($($ty,)+)>,)> for F
+        where
+            F: Fn(&mut Vm, $($ty),+) -> Result<R, VmError> + 'static,
+            R: IntoValue,
+            $($ty: FromValue),+
+        {
+            fn into_native(self) -> NativeFn {
+                Rc::new(move |vm: &mut Vm, args: Vec<VmValue>| -> Result<VmValue, VmError> {
+                    if args.len() != $count {
+                        return Err(VmError(format!(
+                            "expected {} argument(s), got {}",
+                            $count,
+                            args.len()
+                        )));
+                    }
+                    let mut iter = args.into_iter();
+                    $(let $var = <$ty>::from_value(iter.next().unwrap())?;)+
+                    Ok(self(vm, $($var),+)?.into_value())
+                })
+            }
+        }
+    };
+}
+impl_into_native_fn!(1, (A1, a1));
+impl_into_native_fn!(2, (A1, a1), (A2, a2));
+impl_into_native_fn!(3, (A1, a1), (A2, a2), (A3, a3));
+impl_into_native_fn!(4, (A1, a1), (A2, a2), (A3, a3), (A4, a4));
+impl_into_native_fn!(5, (A1, a1), (A2, a2), (A3, a3), (A4, a4), (A5, a5));
+impl_into_native_fn!(
+    6,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6)
+);
+impl_into_native_fn!(
+    7,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7)
+);
+impl_into_native_fn!(
+    8,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8)
+);
+impl_into_native_fn!(
+    9,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9)
+);
+impl_into_native_fn!(
+    10,
+    (A1, a1),
+    (A2, a2),
+    (A3, a3),
+    (A4, a4),
+    (A5, a5),
+    (A6, a6),
+    (A7, a7),
+    (A8, a8),
+    (A9, a9),
+    (A10, a10)
+);

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -16,3 +16,65 @@ pub struct Module {
     pub submodules: HashMap<String, Module>,
 }
 
+impl Module {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            functions: HashMap::new(),
+            submodules: HashMap::new(),
+        }
+    }
+
+    /// Registers a typed Rust function using the [`IntoNativeFn`] trait.
+    pub fn with_function<F, A>(mut self, name: impl Into<String>, f: F) -> Self
+    where
+        F: IntoNativeFn<A>,
+    {
+        let name = name.into();
+        self.functions.insert(
+            name.clone(),
+            Rc::new(VmNativeFn {
+                name,
+                func: f.into_native(),
+            }),
+        );
+        self
+    }
+
+    /// Registers a raw `fn(&mut Vm, Vec<VmValue>) -> Result<VmValue, VmError>` directly,
+    /// bypassing the [`IntoNativeFn`] machinery (used for variadic functions like `print`).
+    pub fn with_raw_function<F>(mut self, name: impl Into<String>, f: F) -> Self
+    where
+        F: Fn(&mut Vm, Vec<VmValue>) -> Result<VmValue, VmError> + 'static,
+    {
+        let name = name.into();
+        self.functions.insert(
+            name.clone(),
+            Rc::new(VmNativeFn {
+                name,
+                func: Rc::new(f),
+            }),
+        );
+        self
+    }
+
+    /// Registers a submodule.
+    pub fn with_module(mut self, m: Module) -> Self {
+        self.submodules.insert(m.name.clone(), m);
+        self
+    }
+
+    /// Walks the module tree along `path`, returning the [`VmNativeFn`] at the leaf,
+    /// or `None` if any segment is missing.
+    pub fn resolve(&self, path: &[String]) -> Option<Rc<VmNativeFn>> {
+        if path.is_empty() {
+            return None;
+        }
+        let mut module = self;
+        for seg in &path[..path.len() - 1] {
+            module = module.submodules.get(seg)?;
+        }
+        module.functions.get(&path[path.len() - 1]).cloned()
+    }
+}
+

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -78,3 +78,61 @@ impl Module {
     }
 }
 
+/// Converts a [`VmValue`] into a typed Rust value, or returns a `VmError`.
+/// Implemented for `i64`, `f64`, `String`, `bool`, `char`, and `VmValue` itself.
+pub trait FromValue: Sized {
+    fn from_value(v: VmValue) -> Result<Self, VmError>;
+}
+
+impl FromValue for VmValue {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        Ok(v)
+    }
+}
+
+impl FromValue for i64 {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        match v {
+            VmValue::Int(i) => Ok(i),
+            VmValue::Byte(b) => Ok(b as i64),
+            other => Err(VmError(format!("expected int, got {other:?}"))),
+        }
+    }
+}
+
+impl FromValue for f64 {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        match v {
+            VmValue::Float(f) => Ok(f),
+            other => Err(VmError(format!("expected float, got {other:?}"))),
+        }
+    }
+}
+
+impl FromValue for String {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        match v {
+            VmValue::Str(s) => Ok(s.to_string()),
+            other => Err(VmError(format!("expected string, got {other:?}"))),
+        }
+    }
+}
+
+impl FromValue for bool {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        match v {
+            VmValue::Bool(b) => Ok(b),
+            other => Err(VmError(format!("expected bool, got {other:?}"))),
+        }
+    }
+}
+
+impl FromValue for char {
+    fn from_value(v: VmValue) -> Result<Self, VmError> {
+        match v {
+            VmValue::Char(c) => Ok(c),
+            other => Err(VmError(format!("expected char, got {other:?}"))),
+        }
+    }
+}
+

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -136,3 +136,50 @@ impl FromValue for char {
     }
 }
 
+/// Converts a typed Rust value into a [`VmValue`].
+pub trait IntoValue {
+    fn into_value(self) -> VmValue;
+}
+
+impl IntoValue for VmValue {
+    fn into_value(self) -> VmValue {
+        self
+    }
+}
+
+impl IntoValue for () {
+    fn into_value(self) -> VmValue {
+        VmValue::Null
+    }
+}
+
+impl IntoValue for i64 {
+    fn into_value(self) -> VmValue {
+        VmValue::Int(self)
+    }
+}
+
+impl IntoValue for f64 {
+    fn into_value(self) -> VmValue {
+        VmValue::Float(self)
+    }
+}
+
+impl IntoValue for String {
+    fn into_value(self) -> VmValue {
+        VmValue::Str(Rc::from(self.as_str()))
+    }
+}
+
+impl IntoValue for bool {
+    fn into_value(self) -> VmValue {
+        VmValue::Bool(self)
+    }
+}
+
+impl IntoValue for char {
+    fn into_value(self) -> VmValue {
+        VmValue::Char(self)
+    }
+}
+

--- a/crates/rl-vm/src/native.rs
+++ b/crates/rl-vm/src/native.rs
@@ -1,0 +1,5 @@
+use crate::values::{VmNativeFn, VmValue};
+use crate::vm_logic::{Vm, VmError};
+
+/// A heap-allocated native function callable from rl bytecode.
+pub type NativeFn = Rc<dyn Fn(&mut Vm, Vec<VmValue>) -> Result<VmValue, VmError>>;

--- a/crates/rl-vm/src/stdlib/io/mod.rs
+++ b/crates/rl-vm/src/stdlib/io/mod.rs
@@ -1,0 +1,27 @@
+//! `std::io` - VM stdlib. Only `print`/`println` for now, since they're
+//! variadic and every `VmValue` variant already has a `Display` impl.
+//!
+//! Unlike the interpreter's version, there's no `output_buffer` so
+//! it will write to stdout directly
+
+use crate::native::Module;
+use crate::values::VmValue;
+use crate::vm_logic::{Vm, VmError};
+
+pub fn module() -> Module {
+    Module::new("io")
+        .with_raw_function("print", std_print)
+        .with_raw_function("println", std_println)
+}
+
+fn std_print(_: &mut Vm, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let text = args.iter().map(|v| v.to_string()).collect::<String>();
+    print!("{}", text);
+    Ok(VmValue::Null)
+}
+
+fn std_println(_: &mut Vm, args: Vec<VmValue>) -> Result<VmValue, VmError> {
+    let text = args.iter().map(|v| v.to_string()).collect::<String>();
+    println!("{}", text);
+    Ok(VmValue::Null)
+}

--- a/crates/rl-vm/src/stdlib/mod.rs
+++ b/crates/rl-vm/src/stdlib/mod.rs
@@ -1,8 +1,17 @@
+//! The VM's standard library - built-in modules registered under `std::*`.
+//!
+//! Only `io` exists so far (`print`/`println`). Everything else in
+//! `rl-interpreter`'s stdlib (math, string, array, fs, ...) hasn't been
+//! ported yet - most of it needs `VmValue` to grow array/tuple/error
+//! variants first.
+
+pub mod io;
+
 use crate::native::Module;
 
 /// Builds the compiler-facing native module tree: an unnamed root holding
 /// a `std` submodule, mirroring `rl-interpreter`'s `root_module` shape so
 /// `std::io::println` resolves the same way in both.
 pub fn root() -> Module {
-    Module::new("root")
+    Module::new("root").with_module(Module::new("std").with_module(io::module()))
 }

--- a/crates/rl-vm/src/stdlib/mod.rs
+++ b/crates/rl-vm/src/stdlib/mod.rs
@@ -1,0 +1,8 @@
+use crate::native::Module;
+
+/// Builds the compiler-facing native module tree: an unnamed root holding
+/// a `std` submodule, mirroring `rl-interpreter`'s `root_module` shape so
+/// `std::io::println` resolves the same way in both.
+pub fn root() -> Module {
+    Module::new("root")
+}

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -58,3 +58,14 @@ pub struct VmNativeFn {
     pub func: NativeFn,
 }
 
+impl fmt::Debug for VmNativeFn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "VmNativeFn({})", self.name)
+    }
+}
+
+impl PartialEq for VmNativeFn {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -1,0 +1,31 @@
+use std::rc::Rc;
+
+use crate::Chunk;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VmValue {
+    Null,
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Byte(u8),
+    Char(char),
+    Str(Rc<str>),
+    Function(Rc<VmFunction>),
+}
+
+#[derive(Debug)]
+pub struct VmFunction {
+    pub name: String,
+    pub arity: usize,
+    pub chunk: Chunk,
+}
+
+// VmValue derives PartialEq, so VmFunction needs it too - compare by
+// identity (name+arity) rather than deep-comparing bytecode
+impl PartialEq for VmFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.arity == other.arity
+    }
+}
+

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -19,6 +19,22 @@ pub enum VmValue {
     Native(Rc<VmNativeFn>),
 }
 
+impl fmt::Display for VmValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VmValue::Null => write!(f, "null"),
+            VmValue::Int(i) => write!(f, "{}", i),
+            VmValue::Float(fl) => write!(f, "{}", fl),
+            VmValue::Bool(b) => write!(f, "{}", b),
+            VmValue::Byte(b) => write!(f, "{}", b),
+            VmValue::Char(c) => write!(f, "'{}'", c),
+            VmValue::Str(s) => write!(f, "{}", s),
+            VmValue::Function(func) => write!(f, "<fn {}/{}>", func.name, func.arity),
+            VmValue::Native(func) => write!(f, "<native fn {}>", func.name),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct VmFunction {
     pub name: String,

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -1,6 +1,8 @@
+use std::fmt;
 use std::rc::Rc;
 
 use crate::Chunk;
+use crate::native::NativeFn;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum VmValue {
@@ -11,7 +13,10 @@ pub enum VmValue {
     Byte(u8),
     Char(char),
     Str(Rc<str>),
+    /// user defined function call
     Function(Rc<VmFunction>),
+    /// std function call
+    Native(Rc<VmNativeFn>),
 }
 
 #[derive(Debug)]
@@ -27,5 +32,13 @@ impl PartialEq for VmFunction {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.arity == other.arity
     }
+}
+
+/// A native (Rust-implemented) function bound into `VmValue::Native`.
+/// Compiled call paths like `std::io::println` resolve to one of these
+/// at compile time and get embedded as a constant, same as `VmFunction`.
+pub struct VmNativeFn {
+    pub name: String,
+    pub func: NativeFn,
 }
 

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -45,7 +45,7 @@ impl Vm {
     }
 
     /// Vm entry function
-    pub fn run(&mut self, chunk: &Chunk) -> Result<Option<VmValue>, VmError> {
+    pub fn run(&mut self, chunk: &Chunk) -> Result<(), VmError> {
         let mut frames: Vec<CallFrame> = vec![CallFrame {
             source: FrameSource::Top(chunk),
             ip: 0,
@@ -68,7 +68,7 @@ impl Vm {
                 self.stack.push(VmValue::Null);
                 frames.last_mut().unwrap().ip = ip;
                 if !self.finish_call(&mut frames)? {
-                    return Ok(self.stack.pop());
+                    return Ok(());
                 }
                 let top = frames.last().unwrap();
                 cur_chunk = top.source.chunk();
@@ -192,7 +192,7 @@ impl Vm {
                     self.stack.push(ret.unwrap_or(VmValue::Null));
                     frames.last_mut().unwrap().ip = ip;
                     if !self.finish_call(&mut frames)? {
-                        return Ok(self.stack.pop());
+                        return Ok(());
                     }
                     let top = frames.last().unwrap();
                     cur_chunk = top.source.chunk();

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
-use crate::chunk::{Chunk, OpCode, VmFunction, VmValue};
+use crate::chunk::{Chunk, OpCode};
+use crate::values::{VmFunction, VmValue};
 
 #[derive(Debug)]
 pub struct VmError(pub String);

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -238,35 +238,51 @@ impl Vm {
                     let arg_count = chunk!().read_u16(ip) as usize;
                     ip += 2;
 
-                    let base = self.locals.len();
-                    self.locals.resize(base + arg_count, VmValue::Null);
-                    for i in (0..arg_count).rev() {
-                        self.locals[base + i] = self.pop()?;
-                    }
+                    let callee_idx = self.stack.len() - 1 - arg_count;
+                    match self.stack[callee_idx].clone() {
+                        VmValue::Function(func) => {
+                            let base = self.locals.len();
+                            self.locals.resize(base + arg_count, VmValue::Null);
+                            for i in (0..arg_count).rev() {
+                                self.locals[base + i] = self.pop()?;
+                            }
+                            self.pop()?; // discard the callee itself
 
-                    let func = match self.pop()? {
-                        VmValue::Function(f) => f,
+                            if arg_count != func.arity {
+                                return Err(VmError(format!(
+                                    "{} expects {} args, got {}",
+                                    func.name, func.arity, arg_count
+                                )));
+                            }
+
+                            self.scope_starts.push(base);
+                            let new_scope_base = self.scope_starts.len() - 1;
+
+                            frames.last_mut().unwrap().ip = ip;
+                            cur_chunk = &func.chunk as *const Chunk;
+                            frames.push(CallFrame {
+                                source: FrameSource::Func(func),
+                                ip: 0,
+                                scope_base: new_scope_base,
+                            });
+                            ip = 0;
+                            scope_base = new_scope_base;
+                        }
+
+                        VmValue::Native(native) => {
+                            let mut call_args = Vec::with_capacity(arg_count);
+                            for _ in 0..arg_count {
+                                call_args.push(self.pop()?);
+                            }
+                            call_args.reverse();
+                            self.pop()?; // discard the callee itself
+
+                            let result = (native.func)(self, call_args)?;
+                            self.stack.push(result);
+                        }
+
                         other => return Err(VmError(format!("cannot call {other:?}"))),
-                    };
-                    if arg_count != func.arity {
-                        return Err(VmError(format!(
-                            "{} expects {} args, got {}",
-                            func.name, func.arity, arg_count
-                        )));
                     }
-
-                    self.scope_starts.push(base);
-                    let new_scope_base = self.scope_starts.len() - 1;
-
-                    frames.last_mut().unwrap().ip = ip;
-                    cur_chunk = &func.chunk as *const Chunk;
-                    frames.push(CallFrame {
-                        source: FrameSource::Func(func),
-                        ip: 0,
-                        scope_base: new_scope_base,
-                    });
-                    ip = 0;
-                    scope_base = new_scope_base;
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?
- Remove `Chunk` debug print and last `VmValue` from `logic_loops.rs`
- Add `native.rs` mirroring the `interpreter`'s without the `Span` related features
- Implement `Display` for `VmValue`s and extract them from `compiler.rs` to `values.rs`
- Implement `std::io` with two functions `print` and `println` 

## What works now
```rl
std::io::println(1000)
```

## Related issue
Closes #231

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
