### PR TITLE
Feat/add mode for generating docs website

### DIFF
--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -450,7 +450,8 @@ fn main() {
                         }
                     }
 
-                    // generate website (placeholder)
+                    // generate website from /// doc comments
+                    use rl_tooling::generate_docs::{extract_doc_items, write_doc_site};
                     let entries = match std::fs::read_dir(parent) {
                         Ok(p) => p,
                         Err(e) => {
@@ -458,6 +459,7 @@ fn main() {
                             std::process::exit(1);
                         }
                     };
+                    let mut all_items = Vec::new();
                     for entry in entries {
                         let entry = match entry {
                             Ok(e) => e,
@@ -470,8 +472,31 @@ fn main() {
                         if file_path.extension().and_then(|e| e.to_str()) != Some("rl") {
                             continue;
                         }
-                        todo!("parse '{}' and generate website page", file_path.display());
+                        let source_text =
+                            std::fs::read_to_string(&file_path).unwrap_or_else(|_| {
+                                eprintln!("error: could not read file '{}'", file_path.display());
+                                std::process::exit(1);
+                            });
+                        let source = SourceFile::new(&*file_path.to_string_lossy(), source_text);
+                        let tokens = lexing_loop(source);
+                        let file_name = file_path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("unknown.rl")
+                            .to_string();
+                        all_items.extend(extract_doc_items(&tokens, &file_name));
                     }
+
+                    let doc_out_dir = parent.join("docs_site");
+                    if let Err(e) = write_doc_site(&all_items, &doc_out_dir, &config.project.name) {
+                        eprintln!("error: failed to write doc site: {}", e);
+                        std::process::exit(1);
+                    }
+                    println!(
+                        "doc site written to '{}' ({} items)",
+                        doc_out_dir.display(),
+                        all_items.len()
+                    );
                 }
                 return;
             }

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -487,7 +487,11 @@ fn main() {
                         all_items.extend(extract_doc_items(&tokens, &file_name));
                     }
 
-                    let doc_out_dir = parent.join("docs_site");
+                    let p = match parent.parent() {
+                        Some(p) => p,
+                        None => parent,
+                    };
+                    let doc_out_dir = p.join("docs_site");
                     if let Err(e) = write_doc_site(&all_items, &doc_out_dir, &config.project.name) {
                         eprintln!("error: failed to write doc site: {}", e);
                         std::process::exit(1);

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -164,6 +164,10 @@ enum Commands {
         /// Custom path for --output (implies --output)
         #[arg(long, value_name = "PATH")]
         out_file: Option<PathBuf>,
+
+        /// Generate docs for current project
+        #[arg(long)]
+        generate: bool,
     },
 
     /// Start the LSP server over stdio
@@ -367,7 +371,111 @@ fn main() {
             stdlib,
             output,
             out_file,
+            generate,
         } => {
+            if generate {
+                #[cfg(feature = "eval")]
+                {
+                    let config = read_rl_toml();
+                    let path = std::path::PathBuf::from(&config.project.entry);
+                    let source_text = std::fs::read_to_string(&path).unwrap_or_else(|_| {
+                        eprintln!(
+                            "error: could not read entry file '{}'",
+                            config.project.entry
+                        );
+                        std::process::exit(1);
+                    });
+                    println!("[{}] v{}", config.project.name, config.project.version);
+                    let source = SourceFile::new(&*config.project.entry, source_text);
+                    let tokens = lexing_loop(source.clone());
+                    let (ast, statements) = parsing_loop(source.clone(), tokens);
+
+                    use rl_checker::TypeChecker;
+                    let mut checker = TypeChecker::new()
+                        .with_source_file(source)
+                        .with_ast_arena(ast)
+                        .with_base_dir(
+                            path.parent()
+                                .unwrap_or_else(|| std::path::Path::new("."))
+                                .to_path_buf(),
+                        );
+                    let errors = checker.check(&statements);
+                    if errors.is_empty() {
+                        println!("check complete");
+                    } else {
+                        for e in errors {
+                            e.report_to_stderr();
+                        }
+                        std::process::exit(1);
+                    }
+
+                    let parent = match path.parent() {
+                        Some(p) => p,
+                        None => {
+                            eprintln!("error when formatting");
+                            std::process::exit(1);
+                        }
+                    };
+
+                    // format every .rl file in the project
+                    let entries = match std::fs::read_dir(parent) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!("error when formatting: {}", e);
+                            std::process::exit(1);
+                        }
+                    };
+                    for entry in entries {
+                        let entry = match entry {
+                            Ok(e) => e,
+                            Err(e) => {
+                                eprintln!("error: {}", e);
+                                continue;
+                            }
+                        };
+                        let file_path = entry.path();
+                        if file_path.extension().and_then(|e| e.to_str()) != Some("rl") {
+                            continue;
+                        }
+                        let source_text =
+                            std::fs::read_to_string(&file_path).unwrap_or_else(|_| {
+                                eprintln!("error: could not read file '{}'", file_path.display());
+                                std::process::exit(1);
+                            });
+                        let source = SourceFile::new(&*file_path.to_string_lossy(), source_text);
+                        let tokens = lexing_loop(source);
+                        let formatted = format_tokens(&tokens);
+                        if let Err(e) = std::fs::write(&file_path, formatted) {
+                            eprintln!("error: {}", e);
+                        }
+                    }
+
+                    // generate website (placeholder)
+                    let entries = match std::fs::read_dir(parent) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            eprintln!("error when generating website: {}", e);
+                            std::process::exit(1);
+                        }
+                    };
+                    for entry in entries {
+                        let entry = match entry {
+                            Ok(e) => e,
+                            Err(e) => {
+                                eprintln!("error: {}", e);
+                                continue;
+                            }
+                        };
+                        let file_path = entry.path();
+                        if file_path.extension().and_then(|e| e.to_str()) != Some("rl") {
+                            continue;
+                        }
+                        todo!("parse '{}' and generate website page", file_path.display());
+                    }
+                }
+                return;
+            }
+
             let std_entries = stdlib_entries();
             let concept_entries = concept_entries();
             let tutorial_entries = tutorial_entries();

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -168,6 +168,20 @@ enum Commands {
         /// Generate docs for current project
         #[arg(long)]
         generate: bool,
+
+        /// Also emit an HTML version of the generated site (used with --generate)
+        #[arg(long)]
+        html: bool,
+
+        /// Path to a client-side syntax-highlighter script for `.rl` code
+        /// blocks, inlined into the generated site in place of the
+        /// built-in highlighter (used with --generate --html)
+        #[arg(long, value_name = "PATH")]
+        highlight_js: Option<PathBuf>,
+
+        /// Skip inlining any syntax-highlighter script (used with --generate --html)
+        #[arg(long)]
+        no_highlight: bool,
     },
 
     /// Start the LSP server over stdio
@@ -372,6 +386,9 @@ fn main() {
             output,
             out_file,
             generate,
+            html,
+            highlight_js,
+            no_highlight,
         } => {
             if generate {
                 #[cfg(feature = "eval")]

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -182,6 +182,10 @@ enum Commands {
         /// Skip inlining any syntax-highlighter script (used with --generate --html)
         #[arg(long)]
         no_highlight: bool,
+
+        /// Custom path for --generate
+        #[arg(long, value_name = "PATH")]
+        out_dir: Option<PathBuf>,
     },
 
     /// Start the LSP server over stdio
@@ -389,6 +393,7 @@ fn main() {
             html,
             highlight_js,
             no_highlight,
+            out_dir,
         } => {
             if generate {
                 #[cfg(feature = "eval")]
@@ -468,7 +473,9 @@ fn main() {
                     }
 
                     // generate website from /// doc comments
-                    use rl_tooling::generate_docs::{extract_doc_items, write_doc_site};
+                    use rl_tooling::generate_docs::{
+                        extract_doc_items, write_doc_site, write_doc_site_html,
+                    };
                     let entries = match std::fs::read_dir(parent) {
                         Ok(p) => p,
                         Err(e) => {
@@ -504,9 +511,12 @@ fn main() {
                         all_items.extend(extract_doc_items(&tokens, &file_name));
                     }
 
-                    let p = match parent.parent() {
+                    let p = match out_dir {
                         Some(p) => p,
-                        None => parent,
+                        None => match parent.parent() {
+                            Some(p) => p.to_path_buf(),
+                            None => parent.to_path_buf(),
+                        },
                     };
                     let doc_out_dir = p.join("docs_site");
                     if let Err(e) = write_doc_site(&all_items, &doc_out_dir, &config.project.name) {
@@ -518,6 +528,23 @@ fn main() {
                         doc_out_dir.display(),
                         all_items.len()
                     );
+
+                    if html {
+                        if let Err(e) = write_doc_site_html(
+                            &all_items,
+                            &doc_out_dir,
+                            &config.project.name,
+                            highlight_js.as_deref(),
+                            no_highlight,
+                        ) {
+                            eprintln!("error: failed to write html doc site: {}", e);
+                            std::process::exit(1);
+                        }
+                        println!(
+                            "html doc site written to '{}/index.html'",
+                            doc_out_dir.display()
+                        );
+                    }
                 }
                 return;
             }

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -511,23 +511,14 @@ fn main() {
                         all_items.extend(extract_doc_items(&tokens, &file_name));
                     }
 
-                    let p = match out_dir {
+                    let p = match parent.parent() {
                         Some(p) => p,
-                        None => match parent.parent() {
-                            Some(p) => p.to_path_buf(),
-                            None => parent.to_path_buf(),
-                        },
+                        None => parent,
                     };
-                    let doc_out_dir = p.join("docs_site");
-                    if let Err(e) = write_doc_site(&all_items, &doc_out_dir, &config.project.name) {
-                        eprintln!("error: failed to write doc site: {}", e);
-                        std::process::exit(1);
-                    }
-                    println!(
-                        "doc site written to '{}' ({} items)",
-                        doc_out_dir.display(),
-                        all_items.len()
-                    );
+                    let doc_out_dir = match out_dir {
+                        Some(p) => p,
+                        None => p.join("docs_site"),
+                    };
 
                     if html {
                         if let Err(e) = write_doc_site_html(
@@ -543,6 +534,18 @@ fn main() {
                         println!(
                             "html doc site written to '{}/index.html'",
                             doc_out_dir.display()
+                        );
+                    } else {
+                        if let Err(e) =
+                            write_doc_site(&all_items, &doc_out_dir, &config.project.name)
+                        {
+                            eprintln!("error: failed to write doc site: {}", e);
+                            std::process::exit(1);
+                        }
+                        println!(
+                            "doc site written to '{}' ({} items)",
+                            doc_out_dir.display(),
+                            all_items.len()
                         );
                     }
                 }

--- a/crates/rl-lexer/src/scanner.rs
+++ b/crates/rl-lexer/src/scanner.rs
@@ -101,6 +101,7 @@ impl Tokenizer {
                             return Ok(());
                         }
                         self.pending_trivia.push(trivia);
+                        self.newlines_since_trivia = 0;
                     }
                 } else if self.peek() == '=' {
                     self.advance();

--- a/crates/rl-tooling/assets/rl-highlight.js
+++ b/crates/rl-tooling/assets/rl-highlight.js
@@ -1,0 +1,130 @@
+(function () {
+  "use strict";
+
+  var KEYWORDS = [
+    "fn",
+    "for",
+    "while",
+    "return",
+    "continue",
+    "break",
+    "get",
+    "from",
+    "in",
+    "or",
+    "and",
+    "null",
+    "dec",
+    "if",
+    "else",
+    "as",
+    "match",
+    "CONST",
+  ];
+
+  var TYPES = [
+    "int",
+    "float",
+    "bool",
+    "string",
+    "byte",
+    "char",
+    "arr",
+    "error",
+    "result",
+  ];
+
+  var LITERALS = ["true", "false", "ok", "err"];
+
+  var KEYWORD_SET = new Set(KEYWORDS);
+  var TYPE_SET = new Set(TYPES);
+  var LITERAL_SET = new Set(LITERALS);
+
+  var TOKEN_PATTERNS = [
+    { name: "comment", regex: /^\/\/[^\n]*/ },
+    { name: "string", regex: /^"(?:[^"\\]|\\.)*"/ },
+    { name: "char", regex: /^'(?:[^'\\]|\\.)*'/ },
+    { name: "number", regex: /^\d+\.\d+|^\d+/ },
+    { name: "word", regex: /^[A-Za-z_][A-Za-z0-9_]*/ },
+    {
+      name: "op",
+      regex:
+        /^(==|!=|<=|>=|->|=>|\+=|-=|\*=|\/=|::|\.\.|[+\-*/=<>!?&|.,:;(){}\[\]])/,
+    },
+    { name: "whitespace", regex: /^\s+/ },
+  ];
+
+  function classify(word) {
+    if (KEYWORD_SET.has(word)) return "rl-kw";
+    if (TYPE_SET.has(word)) return "rl-type";
+    if (LITERAL_SET.has(word)) return "rl-lit";
+    return "rl-ident";
+  }
+
+  function escapeHtml(s) {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function highlight(source) {
+    var out = [];
+    var pos = 0;
+    var len = source.length;
+
+    while (pos < len) {
+      var rest = source.slice(pos);
+      var matched = false;
+
+      for (var i = 0; i < TOKEN_PATTERNS.length; i++) {
+        var pat = TOKEN_PATTERNS[i];
+        var m = pat.regex.exec(rest);
+        if (m && m[0].length > 0) {
+          var text = m[0];
+          var cls;
+          if (pat.name === "word") {
+            cls = classify(text);
+          } else if (pat.name === "whitespace") {
+            out.push(escapeHtml(text));
+            pos += text.length;
+            matched = true;
+            break;
+          } else {
+            cls = "rl-" + pat.name;
+          }
+          out.push('<span class="' + cls + '">' + escapeHtml(text) + "</span>");
+          pos += text.length;
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        out.push(escapeHtml(source[pos]));
+        pos += 1;
+      }
+    }
+
+    return out.join("");
+  }
+
+  function rlHighlightAll() {
+    var blocks = document.querySelectorAll("pre.rl-code");
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i];
+      var source = block.textContent;
+      block.innerHTML = highlight(source);
+    }
+  }
+
+  window.rlHighlightAll = rlHighlightAll;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", rlHighlightAll);
+  } else {
+    rlHighlightAll();
+  }
+})();

--- a/crates/rl-tooling/assets/style.css
+++ b/crates/rl-tooling/assets/style.css
@@ -1,0 +1,91 @@
+body {
+    font-family: system-ui, sans-serif;
+    max-width: 46rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    color: #1a1a1a;
+    line-height: 1.5;
+}
+h1 {
+    border-bottom: 2px solid #eee;
+    padding-bottom: 0.5rem;
+}
+.item {
+    margin: 2rem 0;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
+}
+.kind {
+    background: #eef;
+    color: #335;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+}
+.line {
+    color: #888;
+    font-weight: normal;
+    font-size: 0.8em;
+}
+.sig {
+    background: #f6f6f6;
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+.doc {
+    color: #333;
+}
+.file-list {
+    list-style: none;
+    padding: 0;
+}
+.file-list li {
+    padding: 0.25rem 0;
+}
+.count {
+    color: #888;
+    font-size: 0.85em;
+}
+a {
+    color: #2554c7;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+
+/* rl-highlight.js token colors - tweak these to taste */
+.rl-code {
+    color: #24292e;
+}
+.rl-kw {
+    color: #cf222e;
+    font-weight: 600;
+}
+.rl-type {
+    color: #953800;
+}
+.rl-lit {
+    color: #0550ae;
+    font-weight: 600;
+}
+.rl-string {
+    color: #0a3069;
+}
+.rl-char {
+    color: #0a3069;
+}
+.rl-number {
+    color: #0550ae;
+}
+.rl-comment {
+    color: #6e7781;
+    font-style: italic;
+}
+.rl-op {
+    color: #24292e;
+}
+.rl-ident {
+    color: #24292e;
+}

--- a/crates/rl-tooling/src/format.rs
+++ b/crates/rl-tooling/src/format.rs
@@ -86,7 +86,7 @@ pub fn format_tokens(tokens: &[Token]) -> String {
 }
 
 /// Decides whether a space belongs between two adjacent real tokens.
-fn needs_space(prev: &TokenType, curr: &TokenType) -> bool {
+pub fn needs_space(prev: &TokenType, curr: &TokenType) -> bool {
     use TokenType::*;
 
     // never a space right after these "opening"/tight tokens

--- a/crates/rl-tooling/src/format.rs
+++ b/crates/rl-tooling/src/format.rs
@@ -5,6 +5,7 @@ pub fn format_tokens(tokens: &[Token]) -> String {
     let mut indent: usize = 0;
     let mut at_line_start = true;
     let mut prev: Option<&TokenType> = None;
+    let mut prev_minus_is_unary = false;
 
     for tok in tokens {
         for t in &tok.leading_trivia {
@@ -64,25 +65,67 @@ pub fn format_tokens(tokens: &[Token]) -> String {
             _ => {
                 if at_line_start {
                     out.push_str(&"    ".repeat(indent));
-                } else if let Some(p) = prev
-                    && needs_space(p, &tok.token)
-                {
-                    out.push(' ');
+                } else if let Some(p) = prev {
+                    let space = if matches!(p, TokenType::Minus) && prev_minus_is_unary {
+                        false
+                    } else {
+                        needs_space(p, &tok.token)
+                    };
+                    if space {
+                        out.push(' ');
+                    }
                 }
                 out.push_str(&tok.lexeme);
                 at_line_start = false;
+                if matches!(tok.token, TokenType::Minus) {
+                    prev_minus_is_unary = !is_value_token(prev);
+                }
                 prev = Some(&tok.token);
             }
         }
 
         for t in &tok.trailing_trivia {
-            if let Trivia::LineComment(c) = t {
-                out.push_str(" // ");
-                out.push_str(c);
+            match t {
+                Trivia::LineComment(c) => {
+                    out.push_str("// ");
+                    out.push_str(c);
+                }
+                Trivia::DocComment(c) => {
+                    out.push_str("/// ");
+                    out.push_str(c);
+                }
+                Trivia::BlockComment(c) => {
+                    out.push_str("/*");
+                    out.push_str(c);
+                    out.push_str("*/");
+                }
+                Trivia::BlankLine => {}
             }
         }
     }
     out
+}
+
+/// Whether a token can end an expression / stand in as a value, meaning a
+/// `-` immediately following it is a binary (subtraction) operator rather
+/// than a unary negation.
+fn is_value_token(prev: Option<&TokenType>) -> bool {
+    use TokenType::*;
+    matches!(
+        prev,
+        Some(
+            Identifier(_)
+                | NumberLiteral(_)
+                | ByteLiteral(_)
+                | StringLiteral(_)
+                | CharacterLiteral(_)
+                | FloatLiteral(_)
+                | BoolLiteral(_)
+                | RightParen
+                | RightBracket
+                | Null
+        )
+    )
 }
 
 /// Decides whether a space belongs between two adjacent real tokens.
@@ -112,9 +155,19 @@ pub fn needs_space(prev: &TokenType, curr: &TokenType) -> bool {
         return false;
     }
 
-    // function/index calls: identifier immediately followed by ( or [
-    if matches!(curr, LeftParen | LeftBracket)
-        && matches!(prev, Identifier(_) | RightParen | RightBracket)
+    // function calls: identifier (or a value-producing expression)
+    // immediately followed by (
+    if matches!(curr, LeftParen) && matches!(prev, Identifier(_) | RightParen | RightBracket) {
+        return false;
+    }
+
+    // index expressions and generic type brackets: `arr[i]`, `arr[string]`,
+    // `map[string, int]`, `result[int]`, `set[int]`, etc.
+    if matches!(curr, LeftBracket)
+        && matches!(
+            prev,
+            Identifier(_) | RightParen | RightBracket | Array | Map | Set | Result
+        )
     {
         return false;
     }

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -144,6 +144,84 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
     Ok(())
 }
 
+/// Writes an `index.html` plus one HTML page per source file into
+/// `out_dir`, creating it if needed. Shares a single `style.css` across
+/// all pages. Mirrors [`write_doc_site`]'s layout so the two output
+/// formats stay in sync.
+///
+/// `highlight_js`, if given, overrides the built-in `.rl` syntax
+/// highlighter with a different script.
+/// Pass `no_highlight: true` to omit highlighting entirely - otherwise
+/// the built-in [`DEFAULT_HIGHLIGHT_JS`] is inlined automatically.
+pub fn write_doc_site_html(
+    items: &[DocItem],
+    out_dir: &Path,
+    project_name: &str,
+    highlight_js: Option<&Path>,
+    no_highlight: bool,
+) -> io::Result<()> {
+    fs::create_dir_all(out_dir)?;
+    fs::write(out_dir.join("style.css"), STYLE_CSS)?;
+
+    let script_content: Option<String> = if no_highlight {
+        None
+    } else if let Some(src_path) = highlight_js {
+        Some(fs::read_to_string(src_path)?)
+    } else {
+        Some(DEFAULT_HIGHLIGHT_JS.to_string())
+    };
+    let script_content = script_content.as_deref();
+
+    let by_file = group_by_file(items);
+
+    let mut index_links = String::new();
+    for (file, file_items) in &by_file {
+        let page = page_name(file, "html");
+        index_links.push_str(&format!(
+            "<li><a href=\"{page}\">{file}</a> <span class=\"count\">({count} item{s})</span></li>\n",
+            page = page,
+            file = html_escape(file),
+            count = file_items.len(),
+            s = if file_items.len() == 1 { "" } else { "s" }
+        ));
+
+        let mut sections = String::new();
+        for item in file_items {
+            sections.push_str(&format!(
+                "<section class=\"item\">\n\
+                 <h2><code class=\"kind\">{kind}</code> {name} <span class=\"line\">line {line}</span></h2>\n\
+                 <pre class=\"sig rl-code\">{sig}</pre>\n\
+                 <p class=\"doc\">{doc}</p>\n\
+                 </section>\n",
+                kind = html_escape(item.kind),
+                name = html_escape(&item.name),
+                line = item.line,
+                sig = html_escape(&item.signature),
+                doc = html_escape(&item.doc).replace('\n', "<br>\n"),
+            ));
+        }
+
+        let page_html = html_page(
+            &format!("{} - {}", file, project_name),
+            &format!("<h1>{}</h1>\n{}", html_escape(file), sections),
+            script_content,
+        );
+        fs::write(out_dir.join(page_name(file, "html")), page_html)?;
+    }
+
+    let index_html = html_page(
+        &format!("{} docs", project_name),
+        &format!(
+            "<h1>{} docs</h1>\n<ul class=\"file-list\">\n{}</ul>\n",
+            html_escape(project_name),
+            index_links
+        ),
+        script_content,
+    );
+    fs::write(out_dir.join("index.html"), index_html)?;
+    Ok(())
+}
+
 /// Wraps a `<body>` fragment in a minimal HTML5 document that links the
 /// shared `style.css` and, if given, inlines a syntax-highlighter script.
 fn html_page(title: &str, body: &str, script_content: Option<&str>) -> String {

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -145,6 +145,22 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
 }
 
 fn page_name(file: &str) -> String {
+/// Escapes the five characters that are meaningful in HTML text content.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 fn page_name(file: &str, ext: &str) -> String {
     let stem = Path::new(file)
         .file_stem()

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -103,11 +103,9 @@ fn render_signature(tokens: &[Token], start: usize) -> String {
     out
 }
 
-/// Writes an `index.md` plus one markdown page per source file into
-/// `out_dir`, creating it if needed.
-pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> io::Result<()> {
-    fs::create_dir_all(out_dir)?;
-
+/// Groups items by their source file, sorted by file name, ready to be
+/// rendered into per-file pages by any output-format writer.
+fn group_by_file(items: &[DocItem]) -> Vec<(&str, Vec<&DocItem>)> {
     let mut by_file: Vec<(&str, Vec<&DocItem>)> = Vec::new();
     for item in items {
         match by_file.iter_mut().find(|(f, _)| *f == item.file) {
@@ -116,6 +114,15 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
         }
     }
     by_file.sort_by(|a, b| a.0.cmp(b.0));
+    by_file
+}
+
+/// Writes an `index.md` plus one markdown page per source file into
+/// `out_dir`, creating it if needed.
+pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> io::Result<()> {
+    fs::create_dir_all(out_dir)?;
+
+    let by_file = group_by_file(items);
 
     let mut index = format!("# {} docs\n\n", project_name);
     for (file, file_items) in &by_file {

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -17,6 +17,7 @@ use crate::format::needs_space;
 /// inlined into generated pages unless `--no-highlight` is passed or a
 /// different script is supplied via `--highlight-js`.
 const DEFAULT_HIGHLIGHT_JS: &str = include_str!("../assets/rl-highlight.js");
+const STYLE_CSS: &str = include_str!("../assets/style.css");
 
 /// One documented item extracted from a source file.
 pub struct DocItem {

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -144,6 +144,26 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
     Ok(())
 }
 
+/// Wraps a `<body>` fragment in a minimal HTML5 document that links the
+/// shared `style.css` and, if given, inlines a syntax-highlighter script.
+fn html_page(title: &str, body: &str, script_content: Option<&str>) -> String {
+    let script_tag = match script_content {
+        Some(js) => format!("<script>\n{}\n</script>\n", js),
+        None => String::new(),
+    };
+    format!(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n\
+         <meta charset=\"utf-8\">\n\
+         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+         <title>{title}</title>\n\
+         <link rel=\"stylesheet\" href=\"style.css\">\n\
+         </head>\n<body>\n{body}{script_tag}</body>\n</html>\n",
+        title = html_escape(title),
+        body = body,
+        script_tag = script_tag,
+    )
+}
+
 /// Escapes the five characters that are meaningful in HTML text content.
 fn html_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -171,10 +171,7 @@ pub fn write_doc_site_html(
         Some(DEFAULT_HIGHLIGHT_JS.to_string())
     };
     let script_content = script_content.as_deref();
-    match script_content {
-        Some(js) => fs::write(out_dir.join("rl-highlight.js"), js)?,
-        None => {}
-    }
+    if let Some(js) = script_content { fs::write(out_dir.join("rl-highlight.js"), js)? }
 
     let by_file = group_by_file(items);
 

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -1,0 +1,140 @@
+//! Generates a project documentation site from `///` doc comments in `.rl`
+//! source, similar in spirit to rustdoc.
+//!
+//! A `///` block directly above a `fn`, `record`, `tag`, `const`, or `dec`
+//! declaration is picked up as that item's documentation. Plain `//`
+//! comments are ignored.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use rl_lexer::tokentypes::{Token, TokenType, Trivia};
+
+use crate::format::needs_space;
+
+/// One documented item extracted from a source file.
+pub struct DocItem {
+    pub kind: &'static str,
+    pub name: String,
+    pub signature: String,
+    pub doc: String,
+    pub file: String,
+    pub line: usize,
+}
+
+/// Scans `tokens` (from one source file) for declarations immediately
+/// preceded by `///` doc comments and returns the extracted items.
+pub fn extract_doc_items(tokens: &[Token], file_name: &str) -> Vec<DocItem> {
+    let mut items = Vec::new();
+
+    for (i, tok) in tokens.iter().enumerate() {
+        let kind = match &tok.token {
+            TokenType::Fn => "fn",
+            TokenType::Record => "record",
+            TokenType::Tag => "tag",
+            TokenType::Const => "const",
+            TokenType::Dec => "dec",
+            _ => continue,
+        };
+
+        let doc_lines: Vec<&str> = tok
+            .leading_trivia
+            .iter()
+            .filter_map(|t| match t {
+                Trivia::DocComment(c) => Some(c.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        if doc_lines.is_empty() {
+            continue;
+        }
+
+        let name = match tokens.get(i + 1).map(|t| &t.token) {
+            Some(TokenType::Identifier(n)) => n.clone(),
+            _ => continue,
+        };
+
+        let signature = render_signature(tokens, i);
+
+        items.push(DocItem {
+            kind,
+            name,
+            signature,
+            doc: doc_lines.join("\n"),
+            file: file_name.to_string(),
+            line: tok.line,
+        });
+    }
+
+    items
+}
+
+/// Reconstructs a readable one-line-ish signature starting at the
+/// declaration keyword, stopping at the opening `{` (fn/record/tag body) or
+/// at `;`/newline (const/dec), whichever comes first.
+fn render_signature(tokens: &[Token], start: usize) -> String {
+    let mut out = String::new();
+    let mut prev: Option<&TokenType> = None;
+
+    for tok in &tokens[start..] {
+        match &tok.token {
+            TokenType::LeftBrace | TokenType::Semicolon | TokenType::Newline | TokenType::Eof => {
+                break;
+            }
+            other => {
+                if let Some(p) = prev
+                    && needs_space(p, other)
+                {
+                    out.push(' ');
+                }
+                out.push_str(&tok.lexeme);
+                prev = Some(other);
+            }
+        }
+    }
+
+    out
+}
+
+/// Writes an `index.md` plus one markdown page per source file into
+/// `out_dir`, creating it if needed.
+pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> io::Result<()> {
+    fs::create_dir_all(out_dir)?;
+
+    let mut by_file: Vec<(&str, Vec<&DocItem>)> = Vec::new();
+    for item in items {
+        match by_file.iter_mut().find(|(f, _)| *f == item.file) {
+            Some((_, v)) => v.push(item),
+            None => by_file.push((&item.file, vec![item])),
+        }
+    }
+    by_file.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut index = format!("# {} docs\n\n", project_name);
+    for (file, file_items) in &by_file {
+        let page = page_name(file);
+        index.push_str(&format!("- [{}]({})\n", file, page));
+
+        let mut page_out = format!("# {}\n\n", file);
+        for item in file_items {
+            page_out.push_str(&format!(
+                "## `{}` {} (line {})\n\n```rl\n{}\n```\n\n{}\n\n",
+                item.kind, item.name, item.line, item.signature, item.doc
+            ));
+        }
+        fs::write(out_dir.join(&page), page_out)?;
+    }
+
+    fs::write(out_dir.join("index.md"), index)?;
+    Ok(())
+}
+
+fn page_name(file: &str) -> String {
+    let stem = Path::new(file)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("page");
+    format!("{}.md", stem)
+}

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -13,6 +13,11 @@ use rl_lexer::tokentypes::{Token, TokenType, Trivia};
 
 use crate::format::needs_space;
 
+/// The default `.rl` syntax highlighter, compiled into the binary and
+/// inlined into generated pages unless `--no-highlight` is passed or a
+/// different script is supplied via `--highlight-js`.
+const DEFAULT_HIGHLIGHT_JS: &str = include_str!("../assets/rl-highlight.js");
+
 /// One documented item extracted from a source file.
 pub struct DocItem {
     pub kind: &'static str,

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -119,7 +119,7 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
 
     let mut index = format!("# {} docs\n\n", project_name);
     for (file, file_items) in &by_file {
-        let page = page_name(file);
+        let page = page_name(file, "md");
         index.push_str(&format!("- [{}]({})\n", file, page));
 
         let mut page_out = format!("# {}\n\n", file);
@@ -137,9 +137,10 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
 }
 
 fn page_name(file: &str) -> String {
+fn page_name(file: &str, ext: &str) -> String {
     let stem = Path::new(file)
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("page");
-    format!("{}.md", stem)
+    format!("{}.{}", stem, ext)
 }

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -144,7 +144,6 @@ pub fn write_doc_site(items: &[DocItem], out_dir: &Path, project_name: &str) -> 
     Ok(())
 }
 
-fn page_name(file: &str) -> String {
 /// Escapes the five characters that are meaningful in HTML text content.
 fn html_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());

--- a/crates/rl-tooling/src/generate_docs.rs
+++ b/crates/rl-tooling/src/generate_docs.rs
@@ -171,6 +171,10 @@ pub fn write_doc_site_html(
         Some(DEFAULT_HIGHLIGHT_JS.to_string())
     };
     let script_content = script_content.as_deref();
+    match script_content {
+        Some(js) => fs::write(out_dir.join("rl-highlight.js"), js)?,
+        None => {}
+    }
 
     let by_file = group_by_file(items);
 
@@ -226,7 +230,7 @@ pub fn write_doc_site_html(
 /// shared `style.css` and, if given, inlines a syntax-highlighter script.
 fn html_page(title: &str, body: &str, script_content: Option<&str>) -> String {
     let script_tag = match script_content {
-        Some(js) => format!("<script>\n{}\n</script>\n", js),
+        Some(_) => "<script src=\"rl-highlight.js\"></script>\n".to_string(),
         None => String::new(),
     };
     format!(

--- a/crates/rl-tooling/src/lib.rs
+++ b/crates/rl-tooling/src/lib.rs
@@ -4,6 +4,7 @@
 //! - [`dev`] - project manifest parsing (`rl.toml`)
 pub mod dev;
 pub mod format;
+pub mod generate_docs;
 pub mod new;
 pub mod package;
 pub mod workflows;

--- a/examples/http_server/docs_site/index.md
+++ b/examples/http_server/docs_site/index.md
@@ -1,0 +1,3 @@
+# http_server docs
+
+- [main.rl](main.md)

--- a/examples/http_server/docs_site/main.md
+++ b/examples/http_server/docs_site/main.md
@@ -1,0 +1,30 @@
+# main.rl
+
+## `fn` path_only (line 10)
+
+```rl
+fn path_only(string url) -> string
+```
+
+Strips the query string from a URL, returning just the path portion.
+Return the URL unchanged if it has no `?`.
+
+## `fn` query_param (line 20)
+
+```rl
+fn query_param(string url, string key) -> string
+```
+
+Looks up a single query parameter's value for URL by key.
+Return `""` if the URL has no query string or the key isn't present.
+
+## `fn` main (line 45)
+
+```rl
+fn main()
+```
+
+Starts the HTTp server on 127.0.0.1:8000 and serves requests forver,
+routing on the request path: `/`, `/time`, `/hits`, `/echo`, and a
+catch-all 404 for everything else.
+

--- a/examples/http_server/html-site/index.html
+++ b/examples/http_server/html-site/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>http_server docs</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>http_server docs</h1>
+<ul class="file-list">
+<li><a href="main.html">main.rl</a> <span class="count">(3 items)</span></li>
+</ul>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/http_server/html-site/main.html
+++ b/examples/http_server/html-site/main.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>main.rl - http_server</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>main.rl</h1>
+<section class="item">
+<h2><code class="kind">fn</code> path_only <span class="line">line 10</span></h2>
+<pre class="sig rl-code">fn path_only(string url) -&gt; string</pre>
+<p class="doc">Strips the query string from a URL, returning just the path portion.<br>
+Return the URL unchanged if it has no `?`.</p>
+</section>
+<section class="item">
+<h2><code class="kind">fn</code> query_param <span class="line">line 20</span></h2>
+<pre class="sig rl-code">fn query_param(string url, string key) -&gt; string</pre>
+<p class="doc">Looks up a single query parameter&#39;s value for URL by key.<br>
+Return `&quot;&quot;` if the URL has no query string or the key isn&#39;t present.</p>
+</section>
+<section class="item">
+<h2><code class="kind">fn</code> main <span class="line">line 45</span></h2>
+<pre class="sig rl-code">fn main()</pre>
+<p class="doc">Starts the HTTp server on 127.0.0.1:8000 and serves requests forver,<br>
+routing on the request path: `/`, `/time`, `/hits`, `/echo`, and a<br>
+catch-all 404 for everything else.</p>
+</section>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/http_server/html-site/rl-highlight.js
+++ b/examples/http_server/html-site/rl-highlight.js
@@ -1,0 +1,130 @@
+(function () {
+  "use strict";
+
+  var KEYWORDS = [
+    "fn",
+    "for",
+    "while",
+    "return",
+    "continue",
+    "break",
+    "get",
+    "from",
+    "in",
+    "or",
+    "and",
+    "null",
+    "dec",
+    "if",
+    "else",
+    "as",
+    "match",
+    "CONST",
+  ];
+
+  var TYPES = [
+    "int",
+    "float",
+    "bool",
+    "string",
+    "byte",
+    "char",
+    "arr",
+    "error",
+    "result",
+  ];
+
+  var LITERALS = ["true", "false", "ok", "err"];
+
+  var KEYWORD_SET = new Set(KEYWORDS);
+  var TYPE_SET = new Set(TYPES);
+  var LITERAL_SET = new Set(LITERALS);
+
+  var TOKEN_PATTERNS = [
+    { name: "comment", regex: /^\/\/[^\n]*/ },
+    { name: "string", regex: /^"(?:[^"\\]|\\.)*"/ },
+    { name: "char", regex: /^'(?:[^'\\]|\\.)*'/ },
+    { name: "number", regex: /^\d+\.\d+|^\d+/ },
+    { name: "word", regex: /^[A-Za-z_][A-Za-z0-9_]*/ },
+    {
+      name: "op",
+      regex:
+        /^(==|!=|<=|>=|->|=>|\+=|-=|\*=|\/=|::|\.\.|[+\-*/=<>!?&|.,:;(){}\[\]])/,
+    },
+    { name: "whitespace", regex: /^\s+/ },
+  ];
+
+  function classify(word) {
+    if (KEYWORD_SET.has(word)) return "rl-kw";
+    if (TYPE_SET.has(word)) return "rl-type";
+    if (LITERAL_SET.has(word)) return "rl-lit";
+    return "rl-ident";
+  }
+
+  function escapeHtml(s) {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function highlight(source) {
+    var out = [];
+    var pos = 0;
+    var len = source.length;
+
+    while (pos < len) {
+      var rest = source.slice(pos);
+      var matched = false;
+
+      for (var i = 0; i < TOKEN_PATTERNS.length; i++) {
+        var pat = TOKEN_PATTERNS[i];
+        var m = pat.regex.exec(rest);
+        if (m && m[0].length > 0) {
+          var text = m[0];
+          var cls;
+          if (pat.name === "word") {
+            cls = classify(text);
+          } else if (pat.name === "whitespace") {
+            out.push(escapeHtml(text));
+            pos += text.length;
+            matched = true;
+            break;
+          } else {
+            cls = "rl-" + pat.name;
+          }
+          out.push('<span class="' + cls + '">' + escapeHtml(text) + "</span>");
+          pos += text.length;
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        out.push(escapeHtml(source[pos]));
+        pos += 1;
+      }
+    }
+
+    return out.join("");
+  }
+
+  function rlHighlightAll() {
+    var blocks = document.querySelectorAll("pre.rl-code");
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i];
+      var source = block.textContent;
+      block.innerHTML = highlight(source);
+    }
+  }
+
+  window.rlHighlightAll = rlHighlightAll;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", rlHighlightAll);
+  } else {
+    rlHighlightAll();
+  }
+})();

--- a/examples/http_server/html-site/style.css
+++ b/examples/http_server/html-site/style.css
@@ -1,0 +1,91 @@
+body {
+    font-family: system-ui, sans-serif;
+    max-width: 46rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    color: #1a1a1a;
+    line-height: 1.5;
+}
+h1 {
+    border-bottom: 2px solid #eee;
+    padding-bottom: 0.5rem;
+}
+.item {
+    margin: 2rem 0;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
+}
+.kind {
+    background: #eef;
+    color: #335;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+}
+.line {
+    color: #888;
+    font-weight: normal;
+    font-size: 0.8em;
+}
+.sig {
+    background: #f6f6f6;
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+.doc {
+    color: #333;
+}
+.file-list {
+    list-style: none;
+    padding: 0;
+}
+.file-list li {
+    padding: 0.25rem 0;
+}
+.count {
+    color: #888;
+    font-size: 0.85em;
+}
+a {
+    color: #2554c7;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+
+/* rl-highlight.js token colors - tweak these to taste */
+.rl-code {
+    color: #24292e;
+}
+.rl-kw {
+    color: #cf222e;
+    font-weight: 600;
+}
+.rl-type {
+    color: #953800;
+}
+.rl-lit {
+    color: #0550ae;
+    font-weight: 600;
+}
+.rl-string {
+    color: #0a3069;
+}
+.rl-char {
+    color: #0a3069;
+}
+.rl-number {
+    color: #0550ae;
+}
+.rl-comment {
+    color: #6e7781;
+    font-style: italic;
+}
+.rl-op {
+    color: #24292e;
+}
+.rl-ident {
+    color: #24292e;
+}

--- a/examples/http_server/src/main.rl
+++ b/examples/http_server/src/main.rl
@@ -5,6 +5,8 @@ get time_now, format_time_str, format_date_str from std::time
 get split, index_of, slice, format from std::str
 get len, arr_range from std::array
 
+/// Strips the query string from a URL, returning just the path portion.
+/// Return the URL unchanged if it has no `?`.
 fn path_only(string url) -> string {
     dec int q = index_of(url, "?")
     if (q == -1) {
@@ -13,6 +15,8 @@ fn path_only(string url) -> string {
     return slice(url, 0, q)
 }
 
+/// Looks up a single query parameter's value for URL by key.
+/// Return `""` if the URL has no query string or the key isn't present.
 fn query_param(string url, string key) -> string {
     dec int q = index_of(url, "?")
     if (q == -1) {
@@ -35,6 +39,9 @@ fn query_param(string url, string key) -> string {
     return ""
 }
 
+/// Starts the HTTp server on 127.0.0.1:8000 and serves requests forver,
+/// routing on the request path: `/`, `/time`, `/hits`, `/echo`, and a
+/// catch-all 404 for everything else.
 fn main() {
     dec result[int] start_result = http_server_start("127.0.0.1:8080")
     if (is_err(start_result)) {
@@ -58,10 +65,10 @@ fn main() {
 
         if (path == "/") {
             dec string body = format(
-                "welcome to my rl-lang server\ndate: {}\ntime: {}\nhits so far: {}\n",
-                result_unwrap(format_date_str(time_now())),
-                result_unwrap(format_time_str(time_now())),
-                hits
+            "welcome to my rl-lang server\ndate: {}\ntime: {}\nhits so far: {}\n",
+            result_unwrap(format_date_str(time_now())),
+            result_unwrap(format_time_str(time_now())),
+            hits
             )
             result_unwrap(http_respond(req, 200, body, "text/plain"))
         } else if (path == "/time") {

--- a/examples/net_server/docs_site/client.md
+++ b/examples/net_server/docs_site/client.md
@@ -1,0 +1,11 @@
+# client.rl
+
+## `fn` connect (line 7)
+
+```rl
+fn connect()
+```
+
+Connects to a server on 127.0.0.1:7878, sends a greeting, prints the
+server's reply, then closes the connection.
+

--- a/examples/net_server/docs_site/index.md
+++ b/examples/net_server/docs_site/index.md
@@ -1,0 +1,5 @@
+# net_server docs
+
+- [client.rl](client.md)
+- [main.rl](main.md)
+- [server.rl](server.md)

--- a/examples/net_server/docs_site/main.md
+++ b/examples/net_server/docs_site/main.md
@@ -1,0 +1,11 @@
+# main.rl
+
+## `fn` main (line 7)
+
+```rl
+fn main()
+```
+
+Entry point for the demo: asks the user to pick a mode and dispatches
+to `server()` (mode 1) or `connect()` (mode 2)
+

--- a/examples/net_server/docs_site/server.md
+++ b/examples/net_server/docs_site/server.md
@@ -1,0 +1,11 @@
+# server.rl
+
+## `fn` serve (line 7)
+
+```rl
+fn serve()
+```
+
+Listens on 127.0.0.1:7878, accepts a single client connection, reads
+one message, sends a canned reply, then closes the connection.
+

--- a/examples/net_server/html-site/client.html
+++ b/examples/net_server/html-site/client.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>client.rl - net_server</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>client.rl</h1>
+<section class="item">
+<h2><code class="kind">fn</code> connect <span class="line">line 7</span></h2>
+<pre class="sig rl-code">fn connect()</pre>
+<p class="doc">Connects to a server on 127.0.0.1:7878, sends a greeting, prints the<br>
+server&#39;s reply, then closes the connection.</p>
+</section>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/net_server/html-site/index.html
+++ b/examples/net_server/html-site/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>net_server docs</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>net_server docs</h1>
+<ul class="file-list">
+<li><a href="client.html">client.rl</a> <span class="count">(1 item)</span></li>
+<li><a href="main.html">main.rl</a> <span class="count">(1 item)</span></li>
+<li><a href="server.html">server.rl</a> <span class="count">(1 item)</span></li>
+</ul>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/net_server/html-site/main.html
+++ b/examples/net_server/html-site/main.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>main.rl - net_server</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>main.rl</h1>
+<section class="item">
+<h2><code class="kind">fn</code> main <span class="line">line 7</span></h2>
+<pre class="sig rl-code">fn main()</pre>
+<p class="doc">Entry point for the demo: asks the user to pick a mode and dispatches<br>
+to `server()` (mode 1) or `connect()` (mode 2)</p>
+</section>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/net_server/html-site/rl-highlight.js
+++ b/examples/net_server/html-site/rl-highlight.js
@@ -1,0 +1,130 @@
+(function () {
+  "use strict";
+
+  var KEYWORDS = [
+    "fn",
+    "for",
+    "while",
+    "return",
+    "continue",
+    "break",
+    "get",
+    "from",
+    "in",
+    "or",
+    "and",
+    "null",
+    "dec",
+    "if",
+    "else",
+    "as",
+    "match",
+    "CONST",
+  ];
+
+  var TYPES = [
+    "int",
+    "float",
+    "bool",
+    "string",
+    "byte",
+    "char",
+    "arr",
+    "error",
+    "result",
+  ];
+
+  var LITERALS = ["true", "false", "ok", "err"];
+
+  var KEYWORD_SET = new Set(KEYWORDS);
+  var TYPE_SET = new Set(TYPES);
+  var LITERAL_SET = new Set(LITERALS);
+
+  var TOKEN_PATTERNS = [
+    { name: "comment", regex: /^\/\/[^\n]*/ },
+    { name: "string", regex: /^"(?:[^"\\]|\\.)*"/ },
+    { name: "char", regex: /^'(?:[^'\\]|\\.)*'/ },
+    { name: "number", regex: /^\d+\.\d+|^\d+/ },
+    { name: "word", regex: /^[A-Za-z_][A-Za-z0-9_]*/ },
+    {
+      name: "op",
+      regex:
+        /^(==|!=|<=|>=|->|=>|\+=|-=|\*=|\/=|::|\.\.|[+\-*/=<>!?&|.,:;(){}\[\]])/,
+    },
+    { name: "whitespace", regex: /^\s+/ },
+  ];
+
+  function classify(word) {
+    if (KEYWORD_SET.has(word)) return "rl-kw";
+    if (TYPE_SET.has(word)) return "rl-type";
+    if (LITERAL_SET.has(word)) return "rl-lit";
+    return "rl-ident";
+  }
+
+  function escapeHtml(s) {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function highlight(source) {
+    var out = [];
+    var pos = 0;
+    var len = source.length;
+
+    while (pos < len) {
+      var rest = source.slice(pos);
+      var matched = false;
+
+      for (var i = 0; i < TOKEN_PATTERNS.length; i++) {
+        var pat = TOKEN_PATTERNS[i];
+        var m = pat.regex.exec(rest);
+        if (m && m[0].length > 0) {
+          var text = m[0];
+          var cls;
+          if (pat.name === "word") {
+            cls = classify(text);
+          } else if (pat.name === "whitespace") {
+            out.push(escapeHtml(text));
+            pos += text.length;
+            matched = true;
+            break;
+          } else {
+            cls = "rl-" + pat.name;
+          }
+          out.push('<span class="' + cls + '">' + escapeHtml(text) + "</span>");
+          pos += text.length;
+          matched = true;
+          break;
+        }
+      }
+
+      if (!matched) {
+        out.push(escapeHtml(source[pos]));
+        pos += 1;
+      }
+    }
+
+    return out.join("");
+  }
+
+  function rlHighlightAll() {
+    var blocks = document.querySelectorAll("pre.rl-code");
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i];
+      var source = block.textContent;
+      block.innerHTML = highlight(source);
+    }
+  }
+
+  window.rlHighlightAll = rlHighlightAll;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", rlHighlightAll);
+  } else {
+    rlHighlightAll();
+  }
+})();

--- a/examples/net_server/html-site/server.html
+++ b/examples/net_server/html-site/server.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>server.rl - net_server</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>server.rl</h1>
+<section class="item">
+<h2><code class="kind">fn</code> serve <span class="line">line 7</span></h2>
+<pre class="sig rl-code">fn serve()</pre>
+<p class="doc">Listens on 127.0.0.1:7878, accepts a single client connection, reads<br>
+one message, sends a canned reply, then closes the connection.</p>
+</section>
+<script src="rl-highlight.js"></script>
+</body>
+</html>

--- a/examples/net_server/html-site/style.css
+++ b/examples/net_server/html-site/style.css
@@ -1,0 +1,91 @@
+body {
+    font-family: system-ui, sans-serif;
+    max-width: 46rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    color: #1a1a1a;
+    line-height: 1.5;
+}
+h1 {
+    border-bottom: 2px solid #eee;
+    padding-bottom: 0.5rem;
+}
+.item {
+    margin: 2rem 0;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
+}
+.kind {
+    background: #eef;
+    color: #335;
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-size: 0.85em;
+}
+.line {
+    color: #888;
+    font-weight: normal;
+    font-size: 0.8em;
+}
+.sig {
+    background: #f6f6f6;
+    padding: 0.75rem;
+    border-radius: 6px;
+    overflow-x: auto;
+}
+.doc {
+    color: #333;
+}
+.file-list {
+    list-style: none;
+    padding: 0;
+}
+.file-list li {
+    padding: 0.25rem 0;
+}
+.count {
+    color: #888;
+    font-size: 0.85em;
+}
+a {
+    color: #2554c7;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+
+/* rl-highlight.js token colors - tweak these to taste */
+.rl-code {
+    color: #24292e;
+}
+.rl-kw {
+    color: #cf222e;
+    font-weight: 600;
+}
+.rl-type {
+    color: #953800;
+}
+.rl-lit {
+    color: #0550ae;
+    font-weight: 600;
+}
+.rl-string {
+    color: #0a3069;
+}
+.rl-char {
+    color: #0a3069;
+}
+.rl-number {
+    color: #0550ae;
+}
+.rl-comment {
+    color: #6e7781;
+    font-style: italic;
+}
+.rl-op {
+    color: #24292e;
+}
+.rl-ident {
+    color: #24292e;
+}

--- a/examples/net_server/src/client.rl
+++ b/examples/net_server/src/client.rl
@@ -2,6 +2,8 @@ get println from std::io
 get tcp_connect, tcp_write, tcp_read, tcp_close from std::net
 get result_unwrap from std::res
 
+/// Connects to a server on 127.0.0.1:7878, sends a greeting, prints the
+/// server's reply, then closes the connection.
 fn connect() {
     println("connecting to 127.0.0.1:7878...")
 

--- a/examples/net_server/src/main.rl
+++ b/examples/net_server/src/main.rl
@@ -9,8 +9,14 @@ fn main() {
     println("\t1| server")
     println("\t2| client")
     match read_int("your choice: ") {
-        1 => { serve() }
-        2 => { connect() }
-        _ => { println("invalid choice") }
+        1 => {
+            serve()
+        }
+        2 => {
+            connect()
+        }
+        _ => {
+            println("invalid choice")
+        }
     }
 }

--- a/examples/net_server/src/main.rl
+++ b/examples/net_server/src/main.rl
@@ -2,6 +2,8 @@ get client
 get server
 get println, read_int from std::io
 
+/// Entry point for the demo: asks the user to pick a mode and dispatches
+/// to `server()` (mode 1) or `connect()` (mode 2)
 fn main() {
     println("choose mode:")
     println("\t1| server")

--- a/examples/net_server/src/server.rl
+++ b/examples/net_server/src/server.rl
@@ -2,6 +2,8 @@ get println from std::io
 get tcp_listen, tcp_accept, tcp_read, tcp_write, tcp_close from std::net
 get is_err, result_unwrap, result_unwrap_err from std::res
 
+/// Listens on 127.0.0.1:7878, accepts a single client connection, reads
+/// one message, sends a canned reply, then closes the connection.
 fn serve() {
     println("starting server on 127.0.0.1:7878...")
 


### PR DESCRIPTION
## What does this PR do?
Add new mode for `docs` for generating websites of codebase
this works for projects generated by `rl new` or manually created ones with correct `rl.toml` file

## Whats new (should run in root of project)
- `rl docs --generate`  generates `md` website to default `doc_site/` path 
- `rl docs --generate --html` generates `html` website instead with highlighting
- `rl docs --generate --html --no-highlight` same but no highlighting
- `rl docs --generate --html --highlight-js my-highlighter.js` highlighter in custom path
- `rl docs --generate --out-dir my_website` custom directory for the output 

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
