### PR TITLE
Feat(vm)/types/maps and sets

### DIFF
--- a/crates/rl-vm/src/bytecode.rs
+++ b/crates/rl-vm/src/bytecode.rs
@@ -60,13 +60,14 @@
 //! effect on bytecode execution speed. It trades a small amount of
 //! compress/decompress time for smaller files on disk.
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
 use crate::chunk::Chunk;
 use crate::native::Module;
-use crate::values::{VmFunction, VmValue};
+use crate::values::{VmFunction, VmMapKey, VmValue};
 
 const MAGIC: &[u8; 4] = b"RLZ2";
 
@@ -239,6 +240,18 @@ fn collect_strings_value(value: &VmValue, pool: &mut StringPoolBuilder) {
                 collect_strings_value(item, pool);
             }
         }
+
+        VmValue::Set(items) => {
+            for item in items.iter() {
+                collect_strings_value(item, pool);
+            }
+        }
+        VmValue::Map(entries) => {
+            for (k, v) in entries.borrow().iter() {
+                collect_strings_value(&k.clone().into_value(), pool);
+                collect_strings_value(v, pool);
+            }
+        }
     }
 }
 
@@ -365,6 +378,22 @@ fn write_value(value: &VmValue, pool: &StringPoolBuilder, out: &mut Vec<u8>) {
             write_uvarint(items.len() as u64, out);
             for item in items.iter() {
                 write_value(item, pool, out);
+            }
+        }
+        VmValue::Set(items) => {
+            out.push(14);
+            write_uvarint(items.len() as u64, out);
+            for item in items.iter() {
+                write_value(item, pool, out);
+            }
+        }
+        VmValue::Map(entries) => {
+            out.push(15);
+            let entries = entries.borrow();
+            write_uvarint(entries.len() as u64, out);
+            for (k, v) in entries.iter() {
+                write_value(&k.clone().into_value(), pool, out);
+                write_value(v, pool, out);
             }
         }
     }
@@ -532,6 +561,26 @@ fn read_value(
                 items.push(read_value(cursor, stdlib, pool)?);
             }
             VmValue::Tuple(Rc::new(items))
+        }
+        14 => {
+            let len = cursor.uvarint()? as usize;
+            let mut items = Vec::with_capacity(len);
+            for _ in 0..len {
+                items.push(read_value(cursor, stdlib, pool)?);
+            }
+            VmValue::Set(Rc::new(items))
+        }
+        15 => {
+            let len = cursor.uvarint()? as usize;
+            let mut map = HashMap::with_capacity(len);
+            for _ in 0..len {
+                let k = read_value(cursor, stdlib, pool)?;
+                let v = read_value(cursor, stdlib, pool)?;
+                let key = VmMapKey::from_value(&k)
+                    .ok_or_else(|| BytecodeError("corrupt .rlc: invalid map key".into()))?;
+                map.insert(key, v);
+            }
+            VmValue::Map(Rc::new(RefCell::new(map)))
         }
         other => {
             return Err(BytecodeError(format!(

--- a/crates/rl-vm/src/chunk.rs
+++ b/crates/rl-vm/src/chunk.rs
@@ -69,6 +69,10 @@ pub enum OpCode {
     ArrSet = 32,
     /// build a tuple fromthe top N stack values
     BuildTuple = 33,
+    /// builds a set from the top N stack values
+    BuildSet = 34,
+    /// builds a map from the top N*2 stack values
+    BuildMap = 35,
 }
 
 impl OpCode {
@@ -78,7 +82,7 @@ impl OpCode {
     #[inline(always)]
     pub fn from_u8_unchecked(byte: u8) -> Self {
         debug_assert!(
-            byte <= OpCode::BuildTuple as u8,
+            byte <= OpCode::BuildMap as u8,
             "corrupt bytecode: opcode {byte}"
         );
         unsafe { std::mem::transmute::<u8, OpCode>(byte) }
@@ -122,6 +126,8 @@ impl OpCode {
             31 => OpCode::Index,
             32 => OpCode::ArrSet,
             33 => OpCode::BuildTuple,
+            34 => OpCode::BuildSet,
+            35 => OpCode::BuildMap,
             other => panic!("corrupt bytecode: unknown opcode byte {other}"),
         }
     }

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -76,7 +76,11 @@ impl<'a> Compiler<'a> {
             StatementKind::ResolvedVariableDeclaration { value, .. }
             | StatementKind::ResolvedConstantDeclaration { value, .. }
             | StatementKind::ResolvedArray { value, .. }
-            | StatementKind::ResolvedConstantArray { value, .. } => {
+            | StatementKind::ResolvedConstantArray { value, .. }
+            | StatementKind::ResolvedMap { value, .. }
+            | StatementKind::ResolvedConstantMap { value, .. }
+            | StatementKind::ResolvedSet { value, .. }
+            | StatementKind::ResolvedConstantSet { value, .. } => {
                 self.compile_expr(*value)?;
                 let slot = self.next_slot;
                 self.next_slot += 1;
@@ -88,7 +92,11 @@ impl<'a> Compiler<'a> {
             StatementKind::VariableDeclaration { .. }
             | StatementKind::ConstantDeclaration { .. }
             | StatementKind::Array { .. }
-            | StatementKind::ConstantArray { .. } => Err(CompileError(
+            | StatementKind::ConstantArray { .. }
+            | StatementKind::Map { .. }
+            | StatementKind::ConstantMap { .. }
+            | StatementKind::Set { .. }
+            | StatementKind::ConstantSet { .. } => Err(CompileError(
                 "unresolved declaration reached the compiler - run the resolver pass first".into(),
             )),
 
@@ -373,6 +381,23 @@ impl<'a> Compiler<'a> {
                     self.compile_expr(*item)?;
                 }
                 self.chunk.write_op(OpCode::BuildTuple, line);
+                self.chunk.write_u16(items.len() as u16, line);
+            }
+
+            ExpressionKind::SetLiteral(items) => {
+                for item in items {
+                    self.compile_expr(*item)?;
+                }
+                self.chunk.write_op(OpCode::BuildSet, line);
+                self.chunk.write_u16(items.len() as u16, line);
+            }
+
+            ExpressionKind::MapLiteral(items) => {
+                for (key, value) in items {
+                    self.compile_expr(*key)?;
+                    self.compile_expr(*value)?;
+                }
+                self.chunk.write_op(OpCode::BuildMap, line);
                 self.chunk.write_u16(items.len() as u16, line);
             }
 

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt;
 use std::rc::Rc;
 
@@ -22,6 +24,39 @@ pub enum VmValue {
     Error(Box<VmValue>),
     Arr(Rc<Vec<VmValue>>),
     Tuple(Rc<Vec<VmValue>>),
+    Set(Rc<Vec<VmValue>>),
+    Map(Rc<RefCell<HashMap<VmMapKey, VmValue>>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VmMapKey {
+    Int(i64),
+    Str(Rc<str>),
+    Bool(bool),
+    Byte(u8),
+    Char(char),
+}
+
+impl VmMapKey {
+    pub fn from_value(v: &VmValue) -> Option<VmMapKey> {
+        match v {
+            VmValue::Int(i) => Some(VmMapKey::Int(*i)),
+            VmValue::Str(s) => Some(VmMapKey::Str(s.clone())),
+            VmValue::Bool(b) => Some(VmMapKey::Bool(*b)),
+            VmValue::Byte(b) => Some(VmMapKey::Byte(*b)),
+            VmValue::Char(c) => Some(VmMapKey::Char(*c)),
+            _ => None,
+        }
+    }
+    pub fn into_value(self) -> VmValue {
+        match self {
+            VmMapKey::Int(i) => VmValue::Int(i),
+            VmMapKey::Str(s) => VmValue::Str(s),
+            VmMapKey::Bool(b) => VmValue::Bool(b),
+            VmMapKey::Byte(b) => VmValue::Byte(b),
+            VmMapKey::Char(c) => VmValue::Char(c),
+        }
+    }
 }
 
 impl fmt::Display for VmValue {
@@ -59,6 +94,26 @@ impl fmt::Display for VmValue {
                 }
                 write!(f, ")")
             }
+            VmValue::Set(items) => {
+                write!(f, "{{")?;
+                for (i, item) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                write!(f, "}}")
+            }
+            VmValue::Map(entries) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in entries.borrow().iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}: {}", k.clone().into_value(), v)?;
+                }
+                write!(f, "}}")
+            }
         }
     }
 }
@@ -81,6 +136,8 @@ impl VmValue {
             VmValue::Error(_) => "error",
             VmValue::Arr(_) => "arr",
             VmValue::Tuple(_) => "tuple",
+            VmValue::Set(_) => "set",
+            VmValue::Map(_) => "map",
         }
     }
 

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -1,7 +1,9 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::chunk::{Chunk, OpCode};
-use crate::values::{VmFunction, VmValue};
+use crate::values::{VmFunction, VmMapKey, VmValue};
 
 #[derive(Debug)]
 pub struct VmError(pub String);
@@ -352,6 +354,36 @@ impl Vm {
                     let arr = self.pop()?;
                     self.stack.push(Self::index_set(arr, &index, value)?);
                 }
+
+                OpCode::BuildSet => {
+                    let count = chunk!().read_u16(ip) as usize;
+                    ip += 2;
+                    if self.stack.len() < count {
+                        return Err(VmError("stack underflow building set".into()));
+                    }
+                    let items = self.stack.split_off(self.stack.len() - count);
+                    self.stack.push(VmValue::Set(Rc::new(items)));
+                }
+
+                OpCode::BuildMap => {
+                    let count = chunk!().read_u16(ip) as usize; // number of entries
+                    ip += 2;
+                    if self.stack.len() < count * 2 {
+                        return Err(VmError("stack underflow building map".into()));
+                    }
+                    let flat = self.stack.split_off(self.stack.len() - count * 2);
+                    let mut map = HashMap::with_capacity(count);
+                    for pair in flat.chunks_exact(2) {
+                        let key = VmMapKey::from_value(&pair[0]).ok_or_else(|| {
+                            VmError(format!(
+                                "type {} cannot be used as a map key",
+                                pair[0].type_name()
+                            ))
+                        })?;
+                        map.insert(key, pair[1].clone());
+                    }
+                    self.stack.push(VmValue::Map(Rc::new(RefCell::new(map))));
+                }
             }
         }
     }
@@ -386,22 +418,48 @@ impl Vm {
     }
 
     fn index_get(arr: &VmValue, index: &VmValue) -> Result<VmValue, VmError> {
-        let items = match arr {
-            VmValue::Arr(items) | VmValue::Tuple(items) => items,
-            other => return Err(VmError(format!("cannot index into {}", other.type_name()))),
-        };
-        let i = Self::index_as_usize(index, items.len())?;
-        Ok(items[i].clone())
+        match arr {
+            VmValue::Arr(items) | VmValue::Tuple(items) | VmValue::Set(items) => {
+                let i = Self::index_as_usize(index, items.len())?;
+                Ok(items[i].clone())
+            }
+            VmValue::Map(entries) => {
+                let key = VmMapKey::from_value(index).ok_or_else(|| {
+                    VmError(format!(
+                        "type {} cannot be used as a map key",
+                        index.type_name()
+                    ))
+                })?;
+                entries
+                    .borrow()
+                    .get(&key)
+                    .cloned()
+                    .ok_or_else(|| VmError(format!("key {} not found in map", index)))
+            }
+            other => Err(VmError(format!("cannot index into {}", other.type_name()))),
+        }
     }
 
     fn index_set(arr: VmValue, index: &VmValue, value: VmValue) -> Result<VmValue, VmError> {
-        let VmValue::Arr(items) = arr else {
-            return Err(VmError(format!("cannot index into {}", arr.type_name())));
-        };
-        let i = Self::index_as_usize(index, items.len())?;
-        let mut items = Rc::try_unwrap(items).unwrap_or_else(|rc| (*rc).clone());
-        items[i] = value;
-        Ok(VmValue::Arr(Rc::new(items)))
+        match arr {
+            VmValue::Arr(items) => {
+                let i = Self::index_as_usize(index, items.len())?;
+                let mut items = Rc::try_unwrap(items).unwrap_or_else(|rc| (*rc).clone());
+                items[i] = value;
+                Ok(VmValue::Arr(Rc::new(items)))
+            }
+            VmValue::Map(entries) => {
+                let key = VmMapKey::from_value(index).ok_or_else(|| {
+                    VmError(format!(
+                        "type {} cannot be used as a map key",
+                        index.type_name()
+                    ))
+                })?;
+                entries.borrow_mut().insert(key, value);
+                Ok(VmValue::Map(entries))
+            }
+            other => Err(VmError(format!("cannot index into {}", other.type_name()))),
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
## What does this PR do?
add support for `vm` types: `map` and `set`

## Related issue
Closes #253
Closes #254 

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
