### PR TITLE
Refactor(type)/set

### DIFF
--- a/crates/rl-interpreter/src/evaluator.rs
+++ b/crates/rl-interpreter/src/evaluator.rs
@@ -248,8 +248,10 @@ impl Evaluator {
             }
             Value::Set { items, .. } => {
                 let inner = items
-                    .first()
-                    .map(|v| Self::infer_type(v, false))
+                    .borrow()
+                    .iter()
+                    .next()
+                    .map(|k| Self::infer_type(&k.clone().into_value(), false))
                     .unwrap_or(TypeAnnotation::Null);
                 if is_const {
                     TypeAnnotation::CSet(Box::new(inner))
@@ -498,8 +500,9 @@ impl Evaluator {
                     .map(|v| Self::infer_type(v, false))
                     .unwrap_or(TypeAnnotation::Null);
 
-                if items_type != TypeAnnotation::Null {
-                    for (i, v) in values.iter().enumerate() {
+                let mut set = std::collections::HashSet::with_capacity(len);
+                for (i, v) in values.iter().enumerate() {
+                    if items_type != TypeAnnotation::Null {
                         let actual = Self::infer_type(v, false);
                         if !Self::types_compatible(&actual, &items_type) {
                             return Err(self.err(
@@ -511,13 +514,19 @@ impl Evaluator {
                             ));
                         }
                     }
+                    let key = MapKey::from_value(v).ok_or_else(|| {
+                        self.err(
+                            format!("type {} cannot be a set element", v.type_name()),
+                            span,
+                        )
+                    })?;
+                    set.insert(key);
                 }
                 Ok(Value::Set {
                     items_type,
-                    items: values,
+                    items: Rc::new(RefCell::new(set)),
                 })
             }
-
             ExpressionKind::MapLiteral(entries) => {
                 let len = entries.len();
                 let mut map = HashMap::with_capacity(len);

--- a/crates/rl-interpreter/src/evaluator_types/addressing.rs
+++ b/crates/rl-interpreter/src/evaluator_types/addressing.rs
@@ -166,30 +166,6 @@ impl Evaluator {
                     .cloned()
                     .ok_or_else(|| self.err(format!("key {} not found in map", key), index_span))
             }
-            (Value::Set { items, .. }, Value::Integer(i)) => {
-                let i_usize = *i as usize;
-                if i_usize >= items.len() {
-                    return Err(self
-                        .err(
-                            format!("index {} out of bounds (len {})", i, items.len()),
-                            span,
-                        )
-                        .with_label(target_span, format!("this set has length {}", items.len())));
-                }
-                Ok(items[i_usize].clone())
-            }
-            (Value::Set { items, .. }, Value::Byte(b)) => {
-                let b_usize = *b as usize;
-                if b_usize >= items.len() {
-                    return Err(self
-                        .err(
-                            format!("index {} out of bounds (len {})", b, items.len()),
-                            span,
-                        )
-                        .with_label(target_span, format!("this set has length {}", items.len())));
-                }
-                Ok(items[b_usize].clone())
-            }
             _ => Err(self
                 .err("invalid index operation", span)
                 .with_label(target_span, format!("this is {}", arr.type_name()))
@@ -217,7 +193,6 @@ impl Evaluator {
             current = match current {
                 Value::Values { items, .. } => items.get(i),
                 Value::Tuple(items) => items.get(i),
-                Value::Set { items, .. } => items.get(i),
                 _ => None,
             }
             .ok_or_else(|| self.err(format!("index {} out of bounds", i), span))?;

--- a/crates/rl-interpreter/src/utils/statements.rs
+++ b/crates/rl-interpreter/src/utils/statements.rs
@@ -158,8 +158,8 @@ impl Evaluator {
                 let val = self.evaluate(*value)?;
                 let val = match val {
                     Value::Set { items, .. } => {
-                        for item in &items {
-                            let actual = Self::infer_type(item, false);
+                        for key in items.borrow().iter() {
+                            let actual = Self::infer_type(&key.clone().into_value(), false);
                             if !Self::types_compatible(&actual, type_annotation) {
                                 return Err(self.err(
                                     format!(
@@ -195,8 +195,8 @@ impl Evaluator {
                 let val = self.evaluate(*value)?;
                 let val = match val {
                     Value::Set { items, .. } => {
-                        for item in &items {
-                            let actual = Self::infer_type(item, false);
+                        for key in items.borrow().iter() {
+                            let actual = Self::infer_type(&key.clone().into_value(), false);
                             if !Self::types_compatible(&actual, type_annotation) {
                                 return Err(self.err(
                                     format!(

--- a/crates/rl-interpreter/src/values.rs
+++ b/crates/rl-interpreter/src/values.rs
@@ -2,7 +2,12 @@
 
 use crate::evaluator::EnvironmentItem;
 use rl_ast::statements::{Param, Statement, TypeAnnotation};
-use std::{cell::RefCell, collections::HashMap, fmt, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    fmt,
+    rc::Rc,
+};
 
 /// A runtime value produced by evaluating an rl expression.
 #[derive(Debug, Clone, PartialEq)]
@@ -55,7 +60,7 @@ pub enum Value {
     Set {
         /// The declared element type of this set.
         items_type: TypeAnnotation,
-        items: Vec<Value>,
+        items: Rc<RefCell<HashSet<MapKey>>>,
     },
 }
 
@@ -180,8 +185,14 @@ impl fmt::Display for Value {
                 write!(f, "{{{}}}", formatted.join(", "))
             }
             Value::Set { items, .. } => {
-                let formatted: Vec<String> = items.iter().map(|v| v.to_string()).collect();
-                write!(f, "{{{}}}", formatted.join(", "))
+                write!(f, "{{")?;
+                for (i, item) in items.borrow().iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item.clone().into_value())?;
+                }
+                write!(f, "}}")
             }
         }
     }

--- a/crates/rl-vm/src/bytecode.rs
+++ b/crates/rl-vm/src/bytecode.rs
@@ -61,7 +61,7 @@
 //! compress/decompress time for smaller files on disk.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
 
@@ -242,8 +242,8 @@ fn collect_strings_value(value: &VmValue, pool: &mut StringPoolBuilder) {
         }
 
         VmValue::Set(items) => {
-            for item in items.iter() {
-                collect_strings_value(item, pool);
+            for item in items.borrow().iter() {
+                collect_strings_value(&item.clone().into_value(), pool);
             }
         }
         VmValue::Map(entries) => {
@@ -399,9 +399,10 @@ fn write_value(value: &VmValue, pool: &StringPoolBuilder, out: &mut Vec<u8>) {
         }
         VmValue::Set(items) => {
             out.push(14);
+            let items = items.borrow();
             write_uvarint(items.len() as u64, out);
             for item in items.iter() {
-                write_value(item, pool, out);
+                write_value(&item.clone().into_value(), pool, out);
             }
         }
         VmValue::Map(entries) => {
@@ -608,11 +609,14 @@ fn read_value(
         }
         14 => {
             let len = cursor.uvarint()? as usize;
-            let mut items = Vec::with_capacity(len);
+            let mut set = HashSet::with_capacity(len);
             for _ in 0..len {
-                items.push(read_value(cursor, stdlib, pool)?);
+                let v = read_value(cursor, stdlib, pool)?;
+                let key = VmMapKey::from_value(&v)
+                    .ok_or_else(|| BytecodeError("corrupt .rlc: invalid set element".into()))?;
+                set.insert(key);
             }
-            VmValue::Set(Rc::new(items))
+            VmValue::Set(Rc::new(RefCell::new(set)))
         }
         15 => {
             let len = cursor.uvarint()? as usize;

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::rc::Rc;
 
@@ -24,7 +24,7 @@ pub enum VmValue {
     Error(Box<VmValue>),
     Arr(Rc<Vec<VmValue>>),
     Tuple(Rc<Vec<VmValue>>),
-    Set(Rc<Vec<VmValue>>),
+    Set(Rc<RefCell<HashSet<VmMapKey>>>),
     Map(Rc<RefCell<HashMap<VmMapKey, VmValue>>>),
     Record {
         name: Rc<str>,
@@ -155,11 +155,11 @@ impl fmt::Display for VmValue {
             }
             VmValue::Set(items) => {
                 write!(f, "{{")?;
-                for (i, item) in items.iter().enumerate() {
+                for (i, item) in items.borrow().iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
-                    write!(f, "{}", item)?;
+                    write!(f, "{}", item.clone().into_value())?;
                 }
                 write!(f, "}}")
             }

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -573,7 +573,7 @@ impl Vm {
 
     fn index_get(arr: &VmValue, index: &VmValue) -> Result<VmValue, VmError> {
         match arr {
-            VmValue::Arr(items) | VmValue::Tuple(items) | VmValue::Set(items) => {
+            VmValue::Arr(items) | VmValue::Tuple(items) => {
                 let i = Self::index_as_usize(index, items.len())?;
                 Ok(items[i].clone())
             }

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::chunk::{Chunk, OpCode};
@@ -398,7 +398,14 @@ impl Vm {
                         return Err(VmError("stack underflow building set".into()));
                     }
                     let items = self.stack.split_off(self.stack.len() - count);
-                    self.stack.push(VmValue::Set(Rc::new(items)));
+                    let mut set = HashSet::with_capacity(count);
+                    for v in items {
+                        let key = VmMapKey::from_value(&v).ok_or_else(|| {
+                            VmError(format!("type {} cannot be a set element", v.type_name()))
+                        })?;
+                        set.insert(key);
+                    }
+                    self.stack.push(VmValue::Set(Rc::new(RefCell::new(set))));
                 }
 
                 OpCode::BuildMap => {


### PR DESCRIPTION
## What does this PR do?
update `set`s to actually be unique
and now they cannot be indexed since they are unordered

## Related issue
Closes #262

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
