### PR TITLE
Feat(docs)/tui view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,8 @@ version = "0.1.5"
 dependencies = [
  "crossterm",
  "ratatui",
+ "rl-lexer",
+ "rl-utils",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,8 @@ dependencies = [
 name = "rl-docs"
 version = "0.1.5"
 dependencies = [
+ "crossterm",
+ "ratatui",
  "serde",
  "serde_json",
 ]

--- a/crates/rl-cli/Cargo.toml
+++ b/crates/rl-cli/Cargo.toml
@@ -32,7 +32,7 @@ log = { workspace = true, optional = true }
 env_logger = { workspace = true, optional = true }
 
 [features]
-default = ["repl", "run", "eval", "vm"]
+default = ["repl", "run", "eval", "vm", "docs-tui"]
 run = []
 repl = ["dep:rl-repl"]
 debug = ["dep:env_logger", "dep:log"]
@@ -40,3 +40,4 @@ eval = []
 vm = []
 cranelift = ["rl-cranelift"]
 lsp = ["dep:rl-lsp", "dep:tokio"]
+docs-tui = ["rl-docs/tui"]

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -141,6 +141,10 @@ enum Commands {
         #[arg(value_name = "TOPIC")]
         topic: Option<String>,
 
+        /// Browse docs in an interactive terminal UI instead of printing them
+        #[arg(long)]
+        tui: bool,
+
         /// Print output as JSON instead of Markdown
         #[arg(long)]
         json: bool,
@@ -457,6 +461,7 @@ fn main() {
             highlight_js,
             no_highlight,
             out_dir,
+            tui,
         } => {
             if generate {
                 #[cfg(feature = "eval")]

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -694,6 +694,29 @@ fn main() {
                 }
             };
 
+            if tui {
+                #[cfg(feature = "docs-tui")]
+                {
+                    if let Err(e) = rl_docs::tui::run_docs_tui(
+                        &matched_std,
+                        &matched_concepts,
+                        &matched_tutorial,
+                        topic.as_deref(),
+                    ) {
+                        eprintln!("error: docs tui failed: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+                #[cfg(not(feature = "docs-tui"))]
+                {
+                    eprintln!(
+                        "error: this build of rl was compiled without --tui support (missing 'docs-tui' feature)"
+                    );
+                    std::process::exit(1);
+                }
+                return;
+            }
+
             let rendered = if json {
                 match docs_to_json(&matched_std, &matched_concepts, &matched_tutorial) {
                     Ok(s) => s,

--- a/crates/rl-docs/Cargo.toml
+++ b/crates/rl-docs/Cargo.toml
@@ -11,6 +11,8 @@ serde.workspace = true
 serde_json.workspace = true
 ratatui = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
+rl-lexer = { workspace = true, optional = true }
+rl-utils = { workspace = true, optional = true }
 
 [features]
-tui = ["dep:ratatui", "dep:crossterm"]
+tui = ["dep:ratatui", "dep:crossterm", "dep:rl-lexer", "dep:rl-utils"]

--- a/crates/rl-docs/Cargo.toml
+++ b/crates/rl-docs/Cargo.toml
@@ -9,3 +9,8 @@ repository.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+ratatui = { workspace = true, optional = true }
+crossterm = { workspace = true, optional = true }
+
+[features]
+tui = ["dep:ratatui", "dep:crossterm"]

--- a/crates/rl-docs/src/lib.rs
+++ b/crates/rl-docs/src/lib.rs
@@ -12,6 +12,8 @@
 
 pub mod entries;
 pub mod entry;
+#[cfg(feature = "tui")]
+pub mod tui;
 use serde::Serialize;
 use serde_json::to_string_pretty;
 

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -25,3 +25,85 @@ pub fn parse_inline(text: &str, base: Color) -> Vec<Span<'static>> {
     spans
 }
 
+pub fn markdown_to_lines(content: &str) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut in_code = false;
+
+    for raw in content.lines() {
+        // code blocks
+        if raw.starts_with("```") {
+            in_code = !in_code;
+            lines.push(Line::from(Span::styled(
+                "─".repeat(40),
+                Style::default().fg(Color::DarkGray),
+            )));
+            continue;
+        }
+        // code in code blocks
+        if in_code {
+            lines.push(Line::from(Span::styled(
+                format!("   {raw}"),
+                Style::default().fg(Color::Green),
+            )));
+            continue;
+        }
+        // ---headings---
+        // heading 4
+        if let Some(rest) = raw.strip_prefix("#### ") {
+            lines.push(Line::from(Span::styled(
+                format!(" {rest}"),
+                Style::default()
+                    .fg(Color::LightBlue)
+                    .add_modifier(Modifier::BOLD | Modifier::ITALIC),
+            )));
+        }
+        // heading 3
+        else if let Some(rest) = raw.strip_prefix("### ") {
+            lines.push(Line::from(Span::styled(
+                format!(" {rest}"),
+                Style::default()
+                    .fg(Color::LightBlue)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        }
+        // heading 2
+        else if let Some(rest) = raw.strip_prefix("## ") {
+            lines.push(Line::from(Span::styled(
+                format!("- {rest}"),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        }
+        // heading 1
+        else if let Some(rest) = raw.strip_prefix("# ") {
+            lines.push(Line::from(Span::styled(
+                rest.to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+            )));
+        } else if let Some(rest) = raw.trim_start().strip_prefix("- ") {
+            let indent = " ".repeat(raw.len() - raw.trim_start().len());
+            let mut spans = vec![
+                Span::raw(indent),
+                Span::styled("  • ", Style::default().fg(Color::DarkGray)),
+            ];
+            spans.extend(parse_inline(rest, Color::White));
+            lines.push(Line::from(spans));
+        } else if raw.starts_with("output:") {
+            lines.push(Line::from(Span::styled(
+                raw.to_string(),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            )));
+        } else if raw.trim().is_empty() {
+            lines.push(Line::from(""));
+        } else {
+            lines.push(Line::from(parse_inline(&format!(" {raw}"), Color::White)));
+        }
+    }
+
+    lines
+}

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -3,6 +3,8 @@ use ratatui::{
     text::{Line, Span},
 };
 
+/// Splits `text` on `**bold**` delimiters into styled spans, alternating
+/// `base` and bold-cyan on every `**` boundary.
 pub fn parse_inline(text: &str, base: Color) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
     let mut bold = false;
@@ -25,6 +27,10 @@ pub fn parse_inline(text: &str, base: Color) -> Vec<Span<'static>> {
     spans
 }
 
+/// Converts a single entry's rendered Markdown into styled ratatui lines:
+/// headers get bold/cyan treatment, fenced code blocks are colored green
+/// with the fence itself replaced by a divider, bullets get a dim marker,
+/// and everything else runs through [`parse_inline`] for `**bold**` spans.
 pub fn markdown_to_lines(content: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let mut in_code = false;

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -2,6 +2,8 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use rl_lexer::{tokenizer::Tokenizer, tokentypes::TokenType};
+use rl_utils::source::SourceFile;
 
 /// Splits `text` on `**bold**` delimiters into styled spans, alternating
 /// `base` and bold-cyan on every `**` boundary.
@@ -25,6 +27,28 @@ pub fn parse_inline(text: &str, base: Color) -> Vec<Span<'static>> {
         spans.push(Span::raw(String::new()));
     }
     spans
+}
+
+/// Maps a lexer [`TokenType`] to the color it should render as in the TUI.
+fn token_color(token: &TokenType) -> Color {
+    use TokenType::*;
+    match token {
+        // keywords
+        Null | Fn | In | For | While | Return | Break | Continue | Get | From | If | Else
+        | Const | Dec | As | Ok | Err | Match | Record | Tag | Loop => Color::Magenta,
+        // type keywords
+        Int | Float | Bool | String | Byte | Char | Array | Error | Result | Map | Set => {
+            Color::LightBlue
+        }
+        // literals
+        StringLiteral(_) | CharacterLiteral(_) => Color::Green,
+        NumberLiteral(_) | FloatLiteral(_) | ByteLiteral(_) => Color::Yellow,
+        BoolLiteral(_) => Color::Magenta,
+        // identifiers
+        Identifier(_) => Color::White,
+        // everything else: delimiters, punctuation, operators, newline/eof
+        _ => Color::DarkGray,
+    }
 }
 
 /// Converts a single entry's rendered Markdown into styled ratatui lines:

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -1,0 +1,27 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+pub fn parse_inline(text: &str, base: Color) -> Vec<Span<'static>> {
+    let mut spans = Vec::new();
+    let mut bold = false;
+    for part in text.split("**") {
+        if !part.is_empty() {
+            let style = if bold {
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(base)
+            };
+            spans.push(Span::styled(part.to_string(), style));
+        }
+        bold = !bold;
+    }
+    if spans.is_empty() {
+        spans.push(Span::raw(String::new()));
+    }
+    spans
+}
+

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -51,6 +51,76 @@ fn token_color(token: &TokenType) -> Color {
     }
 }
 
+/// Tokenizes `code` with `rl-lexer` and renders it as syntax-highlighted
+/// ratatui [`Line`]s.
+fn highlight_rl_code(code: &str) -> Vec<Line<'static>> {
+    let source_file = SourceFile::new("<docs>", code.to_string());
+    let tokens = match Tokenizer::lex(source_file) {
+        Ok(tokens) => tokens,
+        Err(_) => {
+            return code
+                .lines()
+                .map(|raw| {
+                    Line::from(Span::styled(
+                        format!("   {raw}"),
+                        Style::default().fg(Color::Green),
+                    ))
+                })
+                .collect();
+        }
+    };
+
+    // Walk the token spans, filling any gaps (whitespace, comments - trivia
+    // carries no span of its own) with the original source text in a dim
+    // comment-ish color, so nothing from the snippet is silently dropped.
+    let mut pieces: Vec<(String, Color)> = Vec::new();
+    let mut cursor = 0usize;
+    let bytes_len = code.len();
+
+    for tok in &tokens {
+        if matches!(tok.token, TokenType::Eof) {
+            break;
+        }
+        let start = tok.span.start.min(bytes_len);
+        let end = tok.span.end.min(bytes_len);
+        if start > cursor {
+            pieces.push((code[cursor..start].to_string(), Color::DarkGray));
+        }
+        if end > start {
+            pieces.push((code[start..end].to_string(), token_color(&tok.token)));
+        }
+        cursor = end.max(cursor);
+    }
+    if cursor < bytes_len {
+        pieces.push((code[cursor..].to_string(), Color::DarkGray));
+    }
+
+    // Split the colored pieces into lines at '\n', starting each rendered
+    // line with the same 3-space indent as the old plain rendering.
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut current: Vec<Span<'static>> = vec![Span::raw("   ")];
+    let mut current_has_content = false;
+
+    for (text, color) in pieces {
+        for (i, part) in text.split('\n').enumerate() {
+            if i > 0 {
+                lines.push(Line::from(std::mem::take(&mut current)));
+                current.push(Span::raw("   "));
+                current_has_content = false;
+            }
+            if !part.is_empty() {
+                current.push(Span::styled(part.to_string(), Style::default().fg(color)));
+                current_has_content = true;
+            }
+        }
+    }
+    if current_has_content || lines.is_empty() {
+        lines.push(Line::from(current));
+    }
+
+    lines
+}
+
 /// Converts a single entry's rendered Markdown into styled ratatui lines:
 /// headers get bold/cyan treatment, fenced code blocks are colored green
 /// with the fence itself replaced by a divider, bullets get a dim marker,

--- a/crates/rl-docs/src/tui/formatting.rs
+++ b/crates/rl-docs/src/tui/formatting.rs
@@ -122,16 +122,23 @@ fn highlight_rl_code(code: &str) -> Vec<Line<'static>> {
 }
 
 /// Converts a single entry's rendered Markdown into styled ratatui lines:
-/// headers get bold/cyan treatment, fenced code blocks are colored green
-/// with the fence itself replaced by a divider, bullets get a dim marker,
-/// and everything else runs through [`parse_inline`] for `**bold**` spans.
+/// headers get bold/cyan treatment, fenced code blocks are syntax
+/// highlighted via `rl-lexer` with the fence itself replaced by a divider,
+/// bullets get a dim marker, and everything else runs through
+/// [`parse_inline`] for `**bold**` spans.
 pub fn markdown_to_lines(content: &str) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let mut in_code = false;
+    let mut code_buf: Vec<&str> = Vec::new();
 
     for raw in content.lines() {
         // code blocks
         if raw.starts_with("```") {
+            if in_code {
+                // closing fence: flush buffered code through the highlighter
+                lines.extend(highlight_rl_code(&code_buf.join("\n")));
+                code_buf.clear();
+            }
             in_code = !in_code;
             lines.push(Line::from(Span::styled(
                 "─".repeat(40),
@@ -139,12 +146,10 @@ pub fn markdown_to_lines(content: &str) -> Vec<Line<'static>> {
             )));
             continue;
         }
-        // code in code blocks
+        // code in code blocks: buffer until the closing fence so the whole
+        // block can be lexed together (tokens can span line boundaries).
         if in_code {
-            lines.push(Line::from(Span::styled(
-                format!("   {raw}"),
-                Style::default().fg(Color::Green),
-            )));
+            code_buf.push(raw);
             continue;
         }
         // ---headings---
@@ -203,6 +208,12 @@ pub fn markdown_to_lines(content: &str) -> Vec<Line<'static>> {
         } else {
             lines.push(Line::from(parse_inline(&format!(" {raw}"), Color::White)));
         }
+    }
+
+    // Unterminated code block (shouldn't normally happen): flush whatever
+    // was buffered rather than silently dropping it.
+    if in_code && !code_buf.is_empty() {
+        lines.extend(highlight_rl_code(&code_buf.join("\n")));
     }
 
     lines

--- a/crates/rl-docs/src/tui/main_loop.rs
+++ b/crates/rl-docs/src/tui/main_loop.rs
@@ -1,0 +1,245 @@
+use crate::{
+    entry::{ConceptEntry, StdEntry},
+    tui::{
+        formatting::markdown_to_lines,
+        types::Focus,
+        utils::{build_items, filter_items},
+    },
+};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use ratatui::{
+    DefaultTerminal,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+pub fn run(
+    terminal: &mut DefaultTerminal,
+    std_entries: &[&StdEntry],
+    concept_entries: &[&ConceptEntry],
+    tutorial_entries: &[&ConceptEntry],
+    initial_query: Option<&str>,
+) -> std::io::Result<()> {
+    let items = build_items(std_entries, concept_entries, tutorial_entries);
+    let mut query = initial_query.unwrap_or("").to_string();
+    let mut focus = Focus::List;
+    let mut selected: usize = 0;
+    let mut content_scroll: u16 = 0;
+    let mut list_state = ListState::default();
+
+    loop {
+        let filtered = filter_items(&items, &query);
+        if filtered.is_empty() {
+            selected = 0;
+        } else if selected >= filtered.len() {
+            selected = filtered.len() - 1;
+        }
+        list_state.select(if filtered.is_empty() {
+            None
+        } else {
+            Some(selected)
+        });
+
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let outer = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(3), Constraint::Length(1)])
+                .split(area);
+
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(32), Constraint::Percentage(68)])
+                .split(outer[0]);
+
+            let left = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Min(3)])
+                .split(cols[0]);
+
+            // search box
+            let search_border = match focus {
+                Focus::Search => Style::default().fg(Color::Cyan),
+                Focus::List => Style::default().fg(Color::DarkGray),
+            };
+            let search_line = if query.is_empty() && matches!(focus, Focus::List) {
+                Line::from(Span::styled(
+                    "/ to search...",
+                    Style::default().fg(Color::DarkGray),
+                ))
+            } else {
+                let mut spans = vec![Span::styled(
+                    query.clone(),
+                    Style::default().fg(Color::White),
+                )];
+                if matches!(focus, Focus::Search) {
+                    spans.push(Span::styled("│", Style::default().fg(Color::Cyan)));
+                }
+                Line::from(spans)
+            };
+            let search_widget = Paragraph::new(search_line).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(search_border)
+                    .title(Span::styled(
+                        " search ",
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )),
+            );
+            frame.render_widget(search_widget, left[0]);
+
+            // sidebar list
+            let list_items: Vec<ListItem> = filtered
+                .iter()
+                .map(|&idx| {
+                    let item = &items[idx];
+                    ListItem::new(Line::from(vec![
+                        Span::styled(
+                            format!("{:>8} ", item.tag),
+                            Style::default().fg(item.tag_color),
+                        ),
+                        Span::styled(item.label.clone(), Style::default().fg(Color::White)),
+                    ]))
+                })
+                .collect();
+
+            let list_widget = List::new(list_items)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::DarkGray))
+                        .title(Span::styled(
+                            format!(" entries ({}) ", filtered.len()),
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD),
+                        )),
+                )
+                .highlight_style(
+                    Style::default()
+                        .bg(Color::Cyan)
+                        .fg(Color::Black)
+                        .add_modifier(Modifier::BOLD),
+                );
+            frame.render_stateful_widget(list_widget, left[1], &mut list_state);
+
+            // content pane
+            let selected_item = filtered.get(selected).map(|&idx| &items[idx]);
+            let content_lines = match selected_item {
+                Some(item) => markdown_to_lines(&item.content),
+                None => vec![Line::from(Span::styled(
+                    "no matches",
+                    Style::default().fg(Color::DarkGray),
+                ))],
+            };
+            let total = content_lines.len() as u16;
+            let visible = cols[1].height.saturating_sub(2);
+            let max_scroll = total.saturating_sub(visible);
+            if content_scroll > max_scroll {
+                content_scroll = max_scroll;
+            }
+            let content_title = selected_item
+                .map(|item| format!(" {} ", item.label))
+                .unwrap_or_else(|| " docs ".to_string());
+            let content_widget = Paragraph::new(content_lines)
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::DarkGray))
+                        .title(Span::styled(
+                            content_title,
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::BOLD),
+                        )),
+                )
+                .wrap(Wrap { trim: false })
+                .scroll((content_scroll, 0));
+            frame.render_widget(content_widget, cols[1]);
+
+            // footer
+            let footer_text = match focus {
+                Focus::Search => "type to filter  •  Enter/Esc back to list  •  Ctrl+C quit",
+                Focus::List => {
+                    "/ search  •  ↑↓/jk select  •  PgUp/PgDn scroll  •  g/G first/last  •  q quit"
+                }
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    footer_text,
+                    Style::default().fg(Color::DarkGray),
+                ))),
+                outer[1],
+            );
+        })?;
+
+        if let Event::Key(key) = event::read()? {
+            match focus {
+                Focus::Search => match (key.modifiers, key.code) {
+                    (KeyModifiers::CONTROL, KeyCode::Char('c')) => break,
+                    (_, KeyCode::Enter) => {
+                        focus = Focus::List;
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Esc) => {
+                        query.clear();
+                        focus = Focus::List;
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Backspace) => {
+                        query.pop();
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Char(c)) => {
+                        query.push(c);
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    _ => {}
+                },
+                Focus::List => match (key.modifiers, key.code) {
+                    (KeyModifiers::CONTROL, KeyCode::Char('c')) => break,
+                    (_, KeyCode::Char('q')) => break,
+                    (_, KeyCode::Char('/')) => focus = Focus::Search,
+                    (_, KeyCode::Esc) if !query.is_empty() => {
+                        query.clear();
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Up) | (_, KeyCode::Char('k')) => {
+                        selected = selected.saturating_sub(1);
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Down) | (_, KeyCode::Char('j')) => {
+                        selected = selected.saturating_add(1);
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Char('g')) => {
+                        selected = 0;
+                        content_scroll = 0;
+                    }
+                    (_, KeyCode::Char('G')) => {
+                        selected = usize::MAX;
+                        content_scroll = 0;
+                    }
+                    (KeyModifiers::CONTROL, KeyCode::Char('d')) | (_, KeyCode::PageDown) => {
+                        content_scroll = content_scroll.saturating_add(10);
+                    }
+                    (KeyModifiers::CONTROL, KeyCode::Char('u')) | (_, KeyCode::PageUp) => {
+                        content_scroll = content_scroll.saturating_sub(10);
+                    }
+                    _ => {}
+                },
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -1,0 +1,2 @@
+mod types;
+

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -38,6 +38,12 @@ mod utils;
 
 use crate::entry::{ConceptEntry, StdEntry};
 
+/// Initializes the ratatui terminal, runs the docs viewer loop, and restores
+/// the terminal on exit (mirrors [`rl_repl::start_repl`]'s init/restore pattern).
+///
+/// `initial_query` seeds the filter box - typically the `TOPIC` the user
+/// already passed to `rl docs`, so `--tui` behaves as a drop-in, browsable
+/// upgrade over the flat Markdown output.
 pub fn run_docs_tui(
     std_entries: &[&StdEntry],
     concept_entries: &[&ConceptEntry],

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -3,3 +3,22 @@ mod main_loop;
 mod types;
 mod utils;
 
+use crate::entry::{ConceptEntry, StdEntry};
+
+pub fn run_docs_tui(
+    std_entries: &[&StdEntry],
+    concept_entries: &[&ConceptEntry],
+    tutorial_entries: &[&ConceptEntry],
+    initial_query: Option<&str>,
+) -> std::io::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = main_loop::run(
+        &mut terminal,
+        std_entries,
+        concept_entries,
+        tutorial_entries,
+        initial_query,
+    );
+    ratatui::restore();
+    result
+}

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -1,3 +1,4 @@
 mod formatting;
 mod types;
+mod utils;
 

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -1,4 +1,5 @@
 mod formatting;
+mod main_loop;
 mod types;
 mod utils;
 

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -1,3 +1,36 @@
+//! Interactive TUI docs viewer for `rl docs --tui`.
+//!
+//! Renders the same stdlib / concept / tutorial entries used by
+//! [`crate::std_to_markdown`] and friends, but as a browsable, filterable
+//! two-pane app instead of a flat Markdown dump.
+//!
+//! # Layout
+//!
+//! ```text
+//! |----------------------|--------------------------------------|
+//! |  search               |                                      |
+//! |----------------------|   content (scrollable, styled from    |
+//! |  [std] io             |   the selected entry's Markdown)      |
+//! |  [std] math            |                                      |
+//! |  [concept] arrays      |                                      |
+//! |  [tutorial] step 1     |                                      |
+//! |----------------------|--------------------------------------|
+//! |  footer / key hints                                          |
+//! |----------------------------------------------------------------|
+//! ```
+//!
+//! # Key bindings
+//!
+//! | Key                                    | Action                       |
+//! |-----------------------------------------|------------------------------|
+//! | `/`                                     | focus the search box         |
+//! | `Enter` / `Esc` (while searching)       | back to the list             |
+//! | `↑`/`↓`, `k`/`j`                        | move selection               |
+//! | `g` / `G`                               | jump to first / last entry   |
+//! | `PageUp`/`PageDown`, `Ctrl+u`/`Ctrl+d`   | scroll the content pane      |
+//! | `Esc` (list focused, search non-empty)  | clear the filter             |
+//! | `q`, `Ctrl+C`                            | quit                          |
+
 mod formatting;
 mod main_loop;
 mod types;

--- a/crates/rl-docs/src/tui/mod.rs
+++ b/crates/rl-docs/src/tui/mod.rs
@@ -1,2 +1,3 @@
+mod formatting;
 mod types;
 

--- a/crates/rl-docs/src/tui/types.rs
+++ b/crates/rl-docs/src/tui/types.rs
@@ -1,0 +1,13 @@
+use ratatui::style::Color;
+
+pub struct DocItem {
+    pub label: String,
+    pub tag: &'static str,
+    pub tag_color: Color,
+    pub content: String,
+}
+
+pub enum Focus {
+    List,
+    Search,
+}

--- a/crates/rl-docs/src/tui/types.rs
+++ b/crates/rl-docs/src/tui/types.rs
@@ -1,12 +1,16 @@
 use ratatui::style::Color;
 
+/// One flattened, browsable row in the sidebar list.
 pub struct DocItem {
     pub label: String,
     pub tag: &'static str,
     pub tag_color: Color,
+    /// Pre-rendered Markdown for this single entry, reusing the same
+    /// renderers as the non-interactive `rl docs` output.
     pub content: String,
 }
 
+/// Which widget currently receives key input.
 pub enum Focus {
     List,
     Search,

--- a/crates/rl-docs/src/tui/utils.rs
+++ b/crates/rl-docs/src/tui/utils.rs
@@ -38,3 +38,17 @@ pub fn build_items(
     items
 }
 
+pub fn filter_items(items: &[DocItem], query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return (0..items.len()).collect();
+    }
+    let needle = query.to_lowercase();
+    items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| {
+            item.label.to_lowercase().contains(&needle) || item.tag.contains(&needle)
+        })
+        .map(|(i, _)| i)
+        .collect()
+}

--- a/crates/rl-docs/src/tui/utils.rs
+++ b/crates/rl-docs/src/tui/utils.rs
@@ -1,0 +1,40 @@
+use crate::entry::{ConceptEntry, StdEntry};
+use crate::tui::types::DocItem;
+use crate::{concept_to_markdown, std_to_markdown, tutorial_to_markdown};
+use ratatui::style::Color;
+
+pub fn build_items(
+    std_entries: &[&StdEntry],
+    concept_entries: &[&ConceptEntry],
+    tutorial_entries: &[&ConceptEntry],
+) -> Vec<DocItem> {
+    let mut items = Vec::new();
+
+    for entry in std_entries.iter().copied() {
+        items.push(DocItem {
+            label: format!("std::{}", entry.name),
+            tag: "std",
+            tag_color: Color::Cyan,
+            content: std_to_markdown(std::slice::from_ref(&entry)),
+        });
+    }
+    for entry in concept_entries.iter().copied() {
+        items.push(DocItem {
+            label: entry.name.to_string(),
+            tag: "concept",
+            tag_color: Color::LightBlue,
+            content: concept_to_markdown(std::slice::from_ref(&entry)),
+        });
+    }
+    for entry in tutorial_entries.iter().copied() {
+        items.push(DocItem {
+            label: entry.name.to_string(),
+            tag: "tutorial",
+            tag_color: Color::Yellow,
+            content: tutorial_to_markdown(std::slice::from_ref(&entry)),
+        });
+    }
+
+    items
+}
+

--- a/crates/rl-docs/src/tui/utils.rs
+++ b/crates/rl-docs/src/tui/utils.rs
@@ -3,6 +3,8 @@ use crate::tui::types::DocItem;
 use crate::{concept_to_markdown, std_to_markdown, tutorial_to_markdown};
 use ratatui::style::Color;
 
+/// Flattens stdlib/concept/tutorial entries into a single browsable list,
+/// pre-rendering each entry's Markdown once up front.
 pub fn build_items(
     std_entries: &[&StdEntry],
     concept_entries: &[&ConceptEntry],
@@ -38,6 +40,8 @@ pub fn build_items(
     items
 }
 
+/// Returns the indices of `items` whose label or tag contains `query`
+/// (case-insensitive). Empty query matches everything.
 pub fn filter_items(items: &[DocItem], query: &str) -> Vec<usize> {
     if query.is_empty() {
         return (0..items.len()).collect();


### PR DESCRIPTION
## What does this PR do?
Add new `tui` view mode for `docs` command
supports `std` entries and language `concepts` as well as `tutorial`
comes with syntax highlighting for code blocks
(looks good) 

## Related issue
Closes #236

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
