### PR TITLE
Refactor(docs)/std result

### DIFF
--- a/crates/rl-docs/src/entries/stdlib/result/is_err.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/is_err.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static IS_ERR: FnEntry = FnEntry {
+    signature: "is_err(r)",
+    description: "true if r is an err value",
+    example: "get std::res::is_err\n\ndec result[int] r = err(\"not found\")\nis_err(r)",
+    expected_output: Some("true"),
+    returns: "bool",
+    errors: None,
+    see_also: &["is_ok"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/is_ok.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/is_ok.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static IS_OK: FnEntry = FnEntry {
+    signature: "is_ok(r)",
+    description: "true if r is an ok value",
+    example: "get std::res::is_ok\n\ndec result[int] r = ok(42)\nis_ok(r)",
+    expected_output: Some("true"),
+    returns: "bool",
+    errors: None,
+    see_also: &["is_err"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/mod.rs
@@ -1,5 +1,13 @@
 use crate::entry::{FnEntry, StdEntry};
 
+mod is_err;
+mod is_ok;
+mod result_map;
+mod result_map_err;
+mod result_unwrap;
+mod result_unwrap_err;
+mod result_unwrap_or;
+
 pub static RES: StdEntry = StdEntry {
     name: "res",
     description: "functions for working with result[T] values (ok / err)",
@@ -9,98 +17,11 @@ pub static RES: StdEntry = StdEntry {
 };
 
 static FUNCTIONS: &[&FnEntry] = &[
-    &IS_OK,
-    &IS_ERR,
-    &RESULT_UNWRAP,
-    &RESULT_UNWRAP_ERR,
-    &RESULT_UNWRAP_OR,
-    &RESULT_MAP,
-    &RESULT_MAP_ERR,
+    &is_ok::IS_OK,
+    &is_err::IS_ERR,
+    &result_unwrap::RESULT_UNWRAP,
+    &result_unwrap_err::RESULT_UNWRAP_ERR,
+    &result_unwrap_or::RESULT_UNWRAP_OR,
+    &result_map::RESULT_MAP,
+    &result_map_err::RESULT_MAP_ERR,
 ];
-
-static IS_OK: FnEntry = FnEntry {
-    signature: "is_ok(r)",
-    description: "true if r is an ok value",
-    example: "get std::res::is_ok\n\ndec result[int] r = ok(42)\nis_ok(r)",
-    expected_output: Some("true"),
-    returns: "bool",
-    errors: None,
-    see_also: &["is_err"],
-    since: Some("v0.1.5"),
-};
-
-static IS_ERR: FnEntry = FnEntry {
-    signature: "is_err(r)",
-    description: "true if r is an err value",
-    example: "get std::res::is_err\n\ndec result[int] r = err(\"not found\")\nis_err(r)",
-    expected_output: Some("true"),
-    returns: "bool",
-    errors: None,
-    see_also: &["is_ok"],
-    since: Some("v0.1.5"),
-};
-
-static RESULT_UNWRAP: FnEntry = FnEntry {
-    signature: "result_unwrap(r)",
-    description: "returns the inner value of an ok result; panics at runtime if r is err",
-    example: "get std::res::result_unwrap\n\ndec result[int] r = ok(10)\nresult_unwrap(r)",
-    expected_output: Some("10"),
-    returns: "T",
-    errors: Some(
-        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `err(..)`\n- `r` is not a result at all",
-    ),
-    see_also: &["result_unwrap_err", "result_unwrap_or", "is_ok"],
-    since: Some("v0.1.5"),
-};
-
-static RESULT_UNWRAP_ERR: FnEntry = FnEntry {
-    signature: "result_unwrap_err(r)",
-    description: "returns the inner value of an err result; panics at runtime if r is ok",
-    example: "get std::res::result_unwrap_err\n\ndec result[int] r = err(\"oops\")\nresult_unwrap_err(r)",
-    expected_output: Some("\"oops\""),
-    returns: "T",
-    errors: Some(
-        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `ok(..)`\n- `r` is not a result at all",
-    ),
-    see_also: &["result_unwrap", "is_err"],
-    since: Some("v0.1.5"),
-};
-
-static RESULT_UNWRAP_OR: FnEntry = FnEntry {
-    signature: "result_unwrap_or(r, default)",
-    description: "returns the inner ok value, or default if r is err",
-    example: "get std::res::result_unwrap_or\n\ndec result[int] r = err(\"fail\")\nresult_unwrap_or(r, 0)",
-    expected_output: Some("0"),
-    returns: "T",
-    errors: Some(
-        "Will panic at runtime (not a catchable `result[..]` err) if `r` is not a\nresult at all. Unlike `result_unwrap`, an `err(..)` value does not panic -\nit returns `default` instead, since that's the documented purpose of\nthis function.",
-    ),
-    see_also: &["result_unwrap"],
-    since: Some("v0.1.5"),
-};
-
-static RESULT_MAP: FnEntry = FnEntry {
-    signature: "result_map(r, fn)",
-    description: "applies a function to the ok value and returns a new ok; passes err through unchanged",
-    example: "get std::res::result_map\n\ndec result[int] r = ok(5)\ndec result[int] doubled = result_map(r, fn(int x) -> int { return x * 2 })\nresult_unwrap(doubled)",
-    expected_output: Some("10"),
-    returns: "result[T]",
-    errors: Some(
-        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
-    ),
-    see_also: &["result_map_err", "result_unwrap"],
-    since: Some("v0.1.5"),
-};
-
-static RESULT_MAP_ERR: FnEntry = FnEntry {
-    signature: "result_map_err(r, fn)",
-    description: "applies a function to the err value and returns a new err; passes ok through unchanged",
-    example: "get std::res::result_map_err\n\ndec result[int] r = err(\"oops\")\ndec result[int] r2 = result_map_err(r, fn(string s) -> string { return concat(\"ERR: \", s) })\nresult_unwrap_err(r2)",
-    expected_output: Some("\"ERR: oops\""),
-    returns: "result[T]",
-    errors: Some(
-        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
-    ),
-    see_also: &["result_map", "result_unwrap_err"],
-    since: Some("v0.1.5"),
-};

--- a/crates/rl-docs/src/entries/stdlib/result/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/mod.rs
@@ -4,7 +4,7 @@ pub static RES: StdEntry = StdEntry {
     name: "res",
     description: "functions for working with result[T] values (ok / err)",
     functions: FUNCTIONS,
-    since: None,
+    since: Some("v0.1.5"),
     unstable: false,
 };
 
@@ -21,76 +21,86 @@ static FUNCTIONS: &[&FnEntry] = &[
 static IS_OK: FnEntry = FnEntry {
     signature: "is_ok(r)",
     description: "true if r is an ok value",
-    example: "get std::res::is_ok\n\ndec result[int] r = ok(42)\nprintln(is_ok(r))  // true",
-    expected_output: None,
-    returns: "",
+    example: "get std::res::is_ok\n\ndec result[int] r = ok(42)\nis_ok(r)",
+    expected_output: Some("true"),
+    returns: "bool",
     errors: None,
-    see_also: &[],
-    since: None,
+    see_also: &["is_err"],
+    since: Some("v0.1.5"),
 };
 
 static IS_ERR: FnEntry = FnEntry {
     signature: "is_err(r)",
     description: "true if r is an err value",
-    example: "get std::res::is_err\n\ndec result[int] r = err(\"not found\")\nprintln(is_err(r))  // true",
-    expected_output: None,
-    returns: "",
+    example: "get std::res::is_err\n\ndec result[int] r = err(\"not found\")\nis_err(r)",
+    expected_output: Some("true"),
+    returns: "bool",
     errors: None,
-    see_also: &[],
-    since: None,
+    see_also: &["is_ok"],
+    since: Some("v0.1.5"),
 };
 
 static RESULT_UNWRAP: FnEntry = FnEntry {
     signature: "result_unwrap(r)",
     description: "returns the inner value of an ok result; panics at runtime if r is err",
-    example: "get std::res::result_unwrap\n\ndec result[int] r = ok(10)\nprintln(result_unwrap(r))  // 10",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
+    example: "get std::res::result_unwrap\n\ndec result[int] r = ok(10)\nresult_unwrap(r)",
+    expected_output: Some("10"),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `err(..)`\n- `r` is not a result at all",
+    ),
+    see_also: &["result_unwrap_err", "result_unwrap_or", "is_ok"],
+    since: Some("v0.1.5"),
 };
 
 static RESULT_UNWRAP_ERR: FnEntry = FnEntry {
     signature: "result_unwrap_err(r)",
     description: "returns the inner value of an err result; panics at runtime if r is ok",
-    example: "get std::res::result_unwrap_err\n\ndec result[int] r = err(\"oops\")\nprintln(result_unwrap_err(r))  // oops",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
+    example: "get std::res::result_unwrap_err\n\ndec result[int] r = err(\"oops\")\nresult_unwrap_err(r)",
+    expected_output: Some("\"oops\""),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `ok(..)`\n- `r` is not a result at all",
+    ),
+    see_also: &["result_unwrap", "is_err"],
+    since: Some("v0.1.5"),
 };
 
 static RESULT_UNWRAP_OR: FnEntry = FnEntry {
     signature: "result_unwrap_or(r, default)",
     description: "returns the inner ok value, or default if r is err",
-    example: "get std::res::result_unwrap_or\n\ndec result[int] r = err(\"fail\")\nprintln(result_unwrap_or(r, 0))  // 0",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
+    example: "get std::res::result_unwrap_or\n\ndec result[int] r = err(\"fail\")\nresult_unwrap_or(r, 0)",
+    expected_output: Some("0"),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) if `r` is not a\nresult at all. Unlike `result_unwrap`, an `err(..)` value does not panic -\nit returns `default` instead, since that's the documented purpose of\nthis function.",
+    ),
+    see_also: &["result_unwrap"],
+    since: Some("v0.1.5"),
 };
 
 static RESULT_MAP: FnEntry = FnEntry {
     signature: "result_map(r, fn)",
     description: "applies a function to the ok value and returns a new ok; passes err through unchanged",
-    example: "get std::res::result_map\n\ndec result[int] r = ok(5)\ndec result[int] doubled = result_map(r, fn(int x) -> int { return x * 2 })\nprintln(result_unwrap(doubled))  // 10",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
+    example: "get std::res::result_map\n\ndec result[int] r = ok(5)\ndec result[int] doubled = result_map(r, fn(int x) -> int { return x * 2 })\nresult_unwrap(doubled)",
+    expected_output: Some("10"),
+    returns: "result[T]",
+    errors: Some(
+        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
+    ),
+    see_also: &["result_map_err", "result_unwrap"],
+    since: Some("v0.1.5"),
 };
 
 static RESULT_MAP_ERR: FnEntry = FnEntry {
     signature: "result_map_err(r, fn)",
     description: "applies a function to the err value and returns a new err; passes ok through unchanged",
-    example: "get std::res::result_map_err\n\ndec result[int] r = err(\"oops\")\ndec result[int] r2 = result_map_err(r, fn(string s) -> string { return concat(s, \"!\") })\nprintln(result_unwrap_err(r2))  // oops!",
-    expected_output: None,
-    returns: "",
-    errors: None,
-    see_also: &[],
-    since: None,
+    example: "get std::res::result_map_err\n\ndec result[int] r = err(\"oops\")\ndec result[int] r2 = result_map_err(r, fn(string s) -> string { return concat(\"ERR: \", s) })\nresult_unwrap_err(r2)",
+    expected_output: Some("\"ERR: oops\""),
+    returns: "result[T]",
+    errors: Some(
+        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
+    ),
+    see_also: &["result_map", "result_unwrap_err"],
+    since: Some("v0.1.5"),
 };

--- a/crates/rl-docs/src/entries/stdlib/result/result_map.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/result_map.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static RESULT_MAP: FnEntry = FnEntry {
+    signature: "result_map(r, fn)",
+    description: "applies a function to the ok value and returns a new ok; passes err through unchanged",
+    example: "get std::res::result_map\n\ndec result[int] r = ok(5)\ndec result[int] doubled = result_map(r, fn(int x) -> int { return x * 2 })\nresult_unwrap(doubled)",
+    expected_output: Some("10"),
+    returns: "result[T]",
+    errors: Some(
+        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
+    ),
+    see_also: &["result_map_err", "result_unwrap"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/result_map_err.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/result_map_err.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static RESULT_MAP_ERR: FnEntry = FnEntry {
+    signature: "result_map_err(r, fn)",
+    description: "applies a function to the err value and returns a new err; passes ok through unchanged",
+    example: "get std::res::result_map_err\n\ndec result[int] r = err(\"oops\")\ndec result[int] r2 = result_map_err(r, fn(string s) -> string { return concat(\"ERR: \", s) })\nresult_unwrap_err(r2)",
+    expected_output: Some("\"ERR: oops\""),
+    returns: "result[T]",
+    errors: Some(
+        "Will return error on the following:\n\n- `r` is not a result\n- calling `fn` fails (the failure message is wrapped as the err value,\n  rather than propagating as an interpreter error)",
+    ),
+    see_also: &["result_map", "result_unwrap_err"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/result_unwrap.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/result_unwrap.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static RESULT_UNWRAP: FnEntry = FnEntry {
+    signature: "result_unwrap(r)",
+    description: "returns the inner value of an ok result; panics at runtime if r is err",
+    example: "get std::res::result_unwrap\n\ndec result[int] r = ok(10)\nresult_unwrap(r)",
+    expected_output: Some("10"),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `err(..)`\n- `r` is not a result at all",
+    ),
+    see_also: &["result_unwrap_err", "result_unwrap_or", "is_ok"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/result_unwrap_err.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/result_unwrap_err.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static RESULT_UNWRAP_ERR: FnEntry = FnEntry {
+    signature: "result_unwrap_err(r)",
+    description: "returns the inner value of an err result; panics at runtime if r is ok",
+    example: "get std::res::result_unwrap_err\n\ndec result[int] r = err(\"oops\")\nresult_unwrap_err(r)",
+    expected_output: Some("\"oops\""),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) on the following:\n\n- `r` is `ok(..)`\n- `r` is not a result at all",
+    ),
+    see_also: &["result_unwrap", "is_err"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-docs/src/entries/stdlib/result/result_unwrap_or.rs
+++ b/crates/rl-docs/src/entries/stdlib/result/result_unwrap_or.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static RESULT_UNWRAP_OR: FnEntry = FnEntry {
+    signature: "result_unwrap_or(r, default)",
+    description: "returns the inner ok value, or default if r is err",
+    example: "get std::res::result_unwrap_or\n\ndec result[int] r = err(\"fail\")\nresult_unwrap_or(r, 0)",
+    expected_output: Some("0"),
+    returns: "T",
+    errors: Some(
+        "Will panic at runtime (not a catchable `result[..]` err) if `r` is not a\nresult at all. Unlike `result_unwrap`, an `err(..)` value does not panic -\nit returns `default` instead, since that's the documented purpose of\nthis function.",
+    ),
+    see_also: &["result_unwrap"],
+    since: Some("v0.1.5"),
+};

--- a/crates/rl-interpreter/src/stdlib/result/result_unwrap.rs
+++ b/crates/rl-interpreter/src/stdlib/result/result_unwrap.rs
@@ -1,38 +1,42 @@
-use crate::{
-    evaluator::Evaluator,
-    stdlib::common::{verr, vs},
-    values::Value,
-};
+use rl_utils::{errors::Error, span::Span};
 
-pub fn std_unwrap(_: &mut Evaluator, v: Value) -> Value {
+use crate::{evaluator::Evaluator, values::Value};
+
+pub fn std_unwrap(eval: &mut Evaluator, v: Value, span: Span) -> Result<Value, Error> {
     match v {
-        Value::Ok(inner) => *inner,
-        Value::Err(v) => verr!(vs!(format!("result_unwrap: called on Err({})", v))),
-        other => verr!(vs!(format!(
-            "result_unwrap: expected result, got {}",
-            other.type_name()
-        ))),
+        Value::Ok(inner) => Ok(*inner),
+        Value::Err(v) => Err(eval.err(format!("result_unwrap: called on Err({})", v), span)),
+        other => Err(eval.err(
+            format!("result_unwrap: expected result, got {}", other.type_name()),
+            span,
+        )),
     }
 }
 
-pub fn std_unwrap_err(_: &mut Evaluator, v: Value) -> Value {
+pub fn std_unwrap_err(eval: &mut Evaluator, v: Value, span: Span) -> Result<Value, Error> {
     match v {
-        Value::Err(inner) => *inner,
-        Value::Ok(v) => verr!(vs!(format!("result_unwrap_err: called on ok({})", v))),
-        other => verr!(vs!(format!(
-            "result_unwrap_err: expected result, got {}",
-            other.type_name()
-        ))),
+        Value::Err(inner) => Ok(*inner),
+        Value::Ok(v) => Err(eval.err(format!("result_unwrap_err: called on ok({})", v), span)),
+        other => Err(eval.err(
+            format!(
+                "result_unwrap_err: expected result, got {}",
+                other.type_name()
+            ),
+            span,
+        )),
     }
 }
 
-pub fn std_unwrap_or(_: &mut Evaluator, v: Value, b: Value) -> Value {
+pub fn std_unwrap_or(eval: &mut Evaluator, v: Value, b: Value, span: Span) -> Result<Value, Error> {
     match v {
-        Value::Ok(inner) => *inner,
-        Value::Err(_) => b,
-        other => verr!(vs!(format!(
-            "result_unwrap_or: expected result, got {}",
-            other.type_name()
-        ))),
+        Value::Ok(inner) => Ok(*inner),
+        Value::Err(_) => Ok(b),
+        other => Err(eval.err(
+            format!(
+                "result_unwrap_or: expected result, got {}",
+                other.type_name()
+            ),
+            span,
+        )),
     }
 }


### PR DESCRIPTION
## What does this PR do?
Change the following functions to panic instead of returning `result`:
- `result_unwrap`
- `result_unwrap_err`
- `result_unwrap_or`

Update `std::res` docs

## Related issue
Closes #199
