### PR TITLE
Feat(std)/collections/add functions to map

### DIFF
--- a/crates/rl-commons/src/keywords.rs
+++ b/crates/rl-commons/src/keywords.rs
@@ -404,13 +404,23 @@ pub mod math {
     }
 }
 
-pub mod set {
+pub mod collections {
     pub const KEYWORDS: &[&str] = &[
         "set_add",
         "set_contains",
         "set_is_empty",
         "set_len",
         "set_remove",
-        "set_to_array"
+        "set_to_array",
+        "map_contains",
+        "map_remove",
+        "map_len",
+        "map_is_empty",
+        "map_to_array",
+        "map_get",
+        "map_keys",
+        "map_values",
+        "map_clear",
+        "map_merge"
     ];
 }

--- a/crates/rl-commons/src/keywords.rs
+++ b/crates/rl-commons/src/keywords.rs
@@ -421,6 +421,6 @@ pub mod collections {
         "map_keys",
         "map_values",
         "map_clear",
-        "map_merge"
+        "map_merge",
     ];
 }

--- a/crates/rl-commons/src/stdlib_signatures/collections.rs
+++ b/crates/rl-commons/src/stdlib_signatures/collections.rs
@@ -115,10 +115,7 @@ fn map_to_array() -> StdFn {
 }
 
 fn map_get() -> StdFn {
-    StdFn::typed(
-        "map_get",
-        vec![(params(vec![map_t(), k()]), result(v()))],
-    )
+    StdFn::typed("map_get", vec![(params(vec![map_t(), k()]), result(v()))])
 }
 
 fn map_keys() -> StdFn {

--- a/crates/rl-commons/src/stdlib_signatures/collections.rs
+++ b/crates/rl-commons/src/stdlib_signatures/collections.rs
@@ -3,6 +3,7 @@
 use super::{params, result, t};
 use crate::{ModuleNames, StdFn};
 use rl_ast::statements::TypeAnnotation as T;
+use std::rc::Rc;
 
 pub fn module() -> ModuleNames {
     ModuleNames::new("collections")
@@ -12,6 +13,16 @@ pub fn module() -> ModuleNames {
         .with_typed_function(set_len())
         .with_typed_function(set_remove())
         .with_typed_function(set_to_array())
+        .with_typed_function(map_contains())
+        .with_typed_function(map_remove())
+        .with_typed_function(map_len())
+        .with_typed_function(map_is_empty())
+        .with_typed_function(map_to_array())
+        .with_typed_function(map_get())
+        .with_typed_function(map_keys())
+        .with_typed_function(map_values())
+        .with_typed_function(map_clear())
+        .with_typed_function(map_merge())
 }
 
 fn set_t() -> T {
@@ -50,5 +61,87 @@ fn set_to_array() -> StdFn {
     StdFn::typed(
         "set_to_array",
         vec![(params(vec![set_t()]), result(T::Array(Box::new(t()))))],
+    )
+}
+
+/// The generic key placeholder `K`, shared by every `map_*` signature.
+fn k() -> T {
+    T::Generic("K".into())
+}
+
+/// The generic value placeholder `V`, shared by every `map_*` signature.
+fn v() -> T {
+    T::Generic("V".into())
+}
+
+/// `map[K, V]` - shorthand for "map of the generic key/value pair".
+fn map_t() -> T {
+    T::Map(Box::new(k()), Box::new(v()))
+}
+
+fn map_contains() -> StdFn {
+    StdFn::typed(
+        "map_contains",
+        vec![(params(vec![map_t(), k()]), result(T::Bool))],
+    )
+}
+
+fn map_remove() -> StdFn {
+    StdFn::typed(
+        "map_remove",
+        vec![(params(vec![map_t(), k()]), result(map_t()))],
+    )
+}
+
+fn map_len() -> StdFn {
+    StdFn::typed("map_len", vec![(params(vec![map_t()]), result(T::Int))])
+}
+
+fn map_is_empty() -> StdFn {
+    StdFn::typed(
+        "map_is_empty",
+        vec![(params(vec![map_t()]), result(T::Bool))],
+    )
+}
+
+fn map_to_array() -> StdFn {
+    StdFn::typed(
+        "map_to_array",
+        vec![(
+            params(vec![map_t()]),
+            result(T::Array(Box::new(T::Tuple(Rc::new(vec![k(), v()]))))),
+        )],
+    )
+}
+
+fn map_get() -> StdFn {
+    StdFn::typed(
+        "map_get",
+        vec![(params(vec![map_t(), k()]), result(v()))],
+    )
+}
+
+fn map_keys() -> StdFn {
+    StdFn::typed(
+        "map_keys",
+        vec![(params(vec![map_t()]), result(T::Array(Box::new(k()))))],
+    )
+}
+
+fn map_values() -> StdFn {
+    StdFn::typed(
+        "map_values",
+        vec![(params(vec![map_t()]), result(T::Array(Box::new(v()))))],
+    )
+}
+
+fn map_clear() -> StdFn {
+    StdFn::typed("map_clear", vec![(params(vec![map_t()]), result(map_t()))])
+}
+
+fn map_merge() -> StdFn {
+    StdFn::typed(
+        "map_merge",
+        vec![(params(vec![map_t(), map_t()]), result(map_t()))],
     )
 }

--- a/crates/rl-docs/src/entries/concepts/maps/mod.rs
+++ b/crates/rl-docs/src/entries/concepts/maps/mod.rs
@@ -65,14 +65,14 @@ pub static MAPS: ConceptEntry = ConceptEntry {
         DescriptionEntry {
             kind: DescriptionKind::Pitfall,
             title: Some("missing keys error, they don't return null"),
-            description: "reading a key that doesn't exist is a runtime error, not `null` - there is no `map_get`-with-default yet, so check with a lookup helper once the map stdlib module exists, or guard with a `match`/`if`",
+            description: "reading a key that doesn't exist with `map[key]` is a runtime error, not `null` - use `map_contains` (from `std::collections`) to check first, or `map_get` to get a `result[V]` back instead of a panic",
             examples: &[],
             expected_output: &[],
         },
         DescriptionEntry {
             kind: DescriptionKind::Note,
-            title: Some("no iteration or stdlib module yet"),
-            description: "there's no iteration syntax for maps yet (no `for key, value in map`), and no stdlib module (`map_get`, `map_keys`, `map_values`, `map_has`, `map_remove`) - only literal construction and single-level `map[key]` read/write are currently supported",
+            title: Some("stdlib module and no iteration yet"),
+            description: "`std::collections` provides `map_contains`, `map_get`, `map_remove`, `map_len`, `map_is_empty`, `map_keys`, `map_values`, `map_to_array`, `map_clear`, and `map_merge` - but there's still no iteration syntax for maps (no `for key, value in map`), so looping over entries means going through `map_to_array` first",
             examples: &[],
             expected_output: &[],
         },
@@ -81,6 +81,6 @@ pub static MAPS: ConceptEntry = ConceptEntry {
         "assigning through more than one level of nesting, e.g. `arr[0][\"key\"] = value` where the outer container is an array of maps, is not yet supported - only a bare `map[key] = value` works",
     ],
     related: &["arrays", "types"],
-    related_stdlib: &[],
+    related_stdlib: &["collections"],
     since: Some("v0.1.5"),
 };

--- a/crates/rl-docs/src/entries/concepts/sets/mod.rs
+++ b/crates/rl-docs/src/entries/concepts/sets/mod.rs
@@ -68,14 +68,14 @@ pub static SETS: ConceptEntry = ConceptEntry {
         DescriptionEntry {
             kind: DescriptionKind::Note,
             title: None,
-            description: "unlike map keys, set items are not restricted to hashable types - any type usable in an array (including nested arrays, records, or other sets) can be used as a set item, since a set is stored the same way as an array under the hood",
+            description: "like map keys, set items are restricted to hashable types",
             examples: &[],
             expected_output: &[],
         },
         DescriptionEntry {
             kind: DescriptionKind::Note,
             title: None,
-            description: "there's no iteration syntax for sets yet (no `for item in set`), and no stdlib module (`set_add`, `set_contains`, `set_remove`, `set_union`, `set_intersect`) - only declaration-site construction and positional `set[index]` reads are currently supported",
+            description: "`std::collections` provides `set_add`, `set_remove`, `set_contains`, `set_len`, `set_is_empty`, and `set_to_array` - but there's still no iteration syntax for sets (no `for item in set`), so looping over items means going through `set_to_array` first",
             examples: &[],
             expected_output: &[],
         },
@@ -85,6 +85,6 @@ pub static SETS: ConceptEntry = ConceptEntry {
         "a set literal only parses correctly as the initializer of a `dec set[T]`/`const set[T]` declaration - it is not yet a general-purpose expression",
     ],
     related: &["arrays", "maps", "types"],
-    related_stdlib: &[],
+    related_stdlib: &["collections"],
     since: Some("v0.1.5"),
 };

--- a/crates/rl-docs/src/entries/stdlib/collections/map_clear.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_clear.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MAP_CLEAR: FnEntry = FnEntry {
+    signature: "map_clear(map)",
+    description: "removes every entry from the map and returns the (now empty) map",
+    example: "get map_clear, map_is_empty from std::collections\n\ndec map[string, int] m = {\"a\": 1, \"b\": 2}\nm = map_clear(m)?\nmap_is_empty(m)?",
+    expected_output: Some("true"),
+    returns: "result[map[K, V]]",
+    errors: Some("Will return error if `map` is not a map"),
+    see_also: &["map_remove", "map_is_empty"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_contains.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_contains.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_CONTAINS: FnEntry = FnEntry {
+    signature: "map_contains(map, key)",
+    description: "true if key is present in the map",
+    example: "get map_contains from std::collections\n\ndec map[string, int] m = {\"a\": 1, \"b\": 2}\nmap_contains(m, \"a\")?",
+    expected_output: Some("true"),
+    returns: "result[bool]",
+    errors: Some(
+        "Will return error if `map` is not a map.\n\nUnlike `map_remove`/`map_get`, passing a `key` whose type can't be used\nas a map key is not an error here - it just returns `false`.",
+    ),
+    see_also: &["map_get", "map_len"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_get.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_get.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_GET: FnEntry = FnEntry {
+    signature: "map_get(map, key)",
+    description: "returns the value stored at key - unlike `map[key]` indexing, a missing key produces an `err` result instead of a runtime panic, so it can be handled with `?` or a `match`",
+    example: "get map_get from std::collections\n\ndec map[string, int] m = {\"a\": 1}\nmap_get(m, \"a\")?",
+    expected_output: Some("1"),
+    returns: "result[V]",
+    errors: Some(
+        "Will return error on the following:\n\n- `map` is not a map\n- `key`'s type can't be used as a map key\n- `key` is not present in the map",
+    ),
+    see_also: &["map_contains", "map_keys", "map_values"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_is_empty.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_is_empty.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MAP_IS_EMPTY: FnEntry = FnEntry {
+    signature: "map_is_empty(map)",
+    description: "true if the map has no key-value pairs",
+    example: "get map_is_empty from std::collections\n\ndec map[string, int] m = {}\nmap_is_empty(m)?",
+    expected_output: Some("true"),
+    returns: "result[bool]",
+    errors: Some("Will return error if `map` is not a map"),
+    see_also: &["map_len"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_keys.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_keys.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_KEYS: FnEntry = FnEntry {
+    signature: "map_keys(map)",
+    description: "returns the map's keys as an array",
+    example: "get map_keys from std::collections\nget arr_sort from std::array\n\ndec map[int, string] m = {2: \"b\", 1: \"a\"}\ndec arr[int] keys = map_keys(m)?\narr_sort(keys)?",
+    expected_output: Some("[1, 2]"),
+    returns: "result[arr[K]]",
+    errors: Some(
+        "Will return error if `map` is not a map.\n\nNote: the returned array's element order is not guaranteed - a map is\nbacked by a hash map internally, so the same map can produce arrays in\ndifferent orders across runs. Sort the result with `arr_sort` (from\n`std::array`, int/float keys only) if a stable order matters.",
+    ),
+    see_also: &["map_values", "map_to_array"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_len.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_len.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static MAP_LEN: FnEntry = FnEntry {
+    signature: "map_len(map)",
+    description: "returns the number of key-value pairs in the map",
+    example: "get map_len from std::collections\n\ndec map[string, int] m = {\"a\": 1, \"b\": 2, \"c\": 3}\nmap_len(m)?",
+    expected_output: Some("3"),
+    returns: "result[int]",
+    errors: Some("Will return error if `map` is not a map"),
+    see_also: &["map_is_empty", "map_to_array"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_merge.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_merge.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_MERGE: FnEntry = FnEntry {
+    signature: "map_merge(map1, map2)",
+    description: "merges map2 into map1 and returns the updated map - keys from map2 overwrite matching keys already in map1, keys only in either map are kept as-is",
+    example: "get map_merge, map_len from std::collections\n\ndec map[string, int] a = {\"x\": 1}\ndec map[string, int] b = {\"x\": 9, \"y\": 2}\na = map_merge(a, b)?\nmap_len(a)?",
+    expected_output: Some("2"),
+    returns: "result[map[K, V]]",
+    errors: Some(
+        "Will return error on the following:\n\n- either `map1` or `map2` is not a map\n- `map1` and `map2` have different key or value types",
+    ),
+    see_also: &["map_to_array", "map_clear"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_remove.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_remove.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_REMOVE: FnEntry = FnEntry {
+    signature: "map_remove(map, key)",
+    description: "removes key (and its value) from the map and returns the updated map; removing a key that isn't present (including from an empty map) is a no-op, not an error",
+    example: "get map_remove, map_len from std::collections\n\ndec map[string, int] m = {\"a\": 1}\nm = map_remove(m, \"a\")?\nmap_len(m)?",
+    expected_output: Some("0"),
+    returns: "result[map[K, V]]",
+    errors: Some(
+        "Will return error on the following:\n\n- `map` is not a map\n- `key`'s type can't be used as a map key (e.g. a function, closure, or native function)",
+    ),
+    see_also: &["map_contains", "map_clear"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_to_array.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_to_array.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_TO_ARRAY: FnEntry = FnEntry {
+    signature: "map_to_array(map)",
+    description: "returns the map's entries as an array of (key, value) tuples",
+    example: "get map_to_array from std::collections\n\ndec map[string, int] m = {\"a\": 1}\nmap_to_array(m)?",
+    expected_output: Some("[(a, 1)]"),
+    returns: "result[arr[(K, V)]]",
+    errors: Some(
+        "Will return error if `map` is not a map.\n\nNote: the returned array's entry order is not guaranteed - a map is\nbacked by a hash map internally, so the same map can produce arrays in\ndifferent orders across runs.",
+    ),
+    see_also: &["map_keys", "map_values"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/map_values.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/map_values.rs
@@ -1,0 +1,14 @@
+use crate::entry::FnEntry;
+
+pub static MAP_VALUES: FnEntry = FnEntry {
+    signature: "map_values(map)",
+    description: "returns the map's values as an array",
+    example: "get map_values from std::collections\nget arr_sort from std::array\n\ndec map[string, int] m = {\"a\": 2, \"b\": 1}\ndec arr[int] values = map_values(m)?\narr_sort(values)?",
+    expected_output: Some("[1, 2]"),
+    returns: "result[arr[V]]",
+    errors: Some(
+        "Will return error if `map` is not a map.\n\nNote: the returned array's element order is not guaranteed - a map is\nbacked by a hash map internally, so the same map can produce arrays in\ndifferent orders across runs. Sort the result with `arr_sort` (from\n`std::array`) if a stable order matters.",
+    ),
+    see_also: &["map_keys", "map_to_array"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/collections/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/collections/mod.rs
@@ -1,5 +1,15 @@
 use crate::entry::{FnEntry, StdEntry};
 
+mod map_clear;
+mod map_contains;
+mod map_get;
+mod map_is_empty;
+mod map_keys;
+mod map_len;
+mod map_merge;
+mod map_remove;
+mod map_to_array;
+mod map_values;
 mod set_add;
 mod set_contains;
 mod set_is_empty;
@@ -7,6 +17,16 @@ mod set_len;
 mod set_remove;
 mod set_to_array;
 
+use map_clear::MAP_CLEAR;
+use map_contains::MAP_CONTAINS;
+use map_get::MAP_GET;
+use map_is_empty::MAP_IS_EMPTY;
+use map_keys::MAP_KEYS;
+use map_len::MAP_LEN;
+use map_merge::MAP_MERGE;
+use map_remove::MAP_REMOVE;
+use map_to_array::MAP_TO_ARRAY;
+use map_values::MAP_VALUES;
 use set_add::SET_ADD;
 use set_contains::SET_CONTAINS;
 use set_is_empty::SET_IS_EMPTY;
@@ -16,7 +36,7 @@ use set_to_array::SET_TO_ARRAY;
 
 pub static COLLECTIONS: StdEntry = StdEntry {
     name: "collections",
-    description: "functions for working with set[T] collections - add, remove, membership, size, and conversion to an array",
+    description: "functions for working with set[T] and map[K, V] collections - add, remove, membership, size, lookup, merging, and conversion to an array",
     functions: FUNCTIONS,
     since: Some("v0.4.0"),
     unstable: false,
@@ -29,4 +49,14 @@ static FUNCTIONS: &[&FnEntry] = &[
     &SET_LEN,
     &SET_IS_EMPTY,
     &SET_TO_ARRAY,
+    &MAP_CONTAINS,
+    &MAP_REMOVE,
+    &MAP_LEN,
+    &MAP_IS_EMPTY,
+    &MAP_TO_ARRAY,
+    &MAP_GET,
+    &MAP_KEYS,
+    &MAP_VALUES,
+    &MAP_CLEAR,
+    &MAP_MERGE,
 ];

--- a/crates/rl-interpreter/src/stdlib/collections/map_clear.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_clear.rs
@@ -1,0 +1,26 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_clear(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map {
+            key_type,
+            value_type,
+            entries,
+        } => {
+            entries.borrow_mut().clear();
+            vok!(Value::Map {
+                key_type,
+                value_type,
+                entries,
+            })
+        }
+        other => verr!(vs!(format!(
+            "map_clear: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_contains.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_contains.rs
@@ -1,0 +1,21 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::{MapKey, Value},
+};
+
+pub fn std_map_contains(_: &mut Evaluator, map: Value, key: Value) -> Value {
+    match map {
+        Value::Map { entries, .. } => {
+            let map_key = match MapKey::from_value(&key) {
+                Some(k) => k,
+                None => return vok!(Value::Bool(false)),
+            };
+            vok!(Value::Bool(entries.borrow().contains_key(&map_key)))
+        }
+        other => verr!(vs!(format!(
+            "map_contains: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_get.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_get.rs
@@ -13,7 +13,7 @@ pub fn std_map_get(_: &mut Evaluator, map: Value, key: Value) -> Value {
                     return verr!(vs!(format!(
                         "map_get: cannot use {} as a map key",
                         key.type_name()
-                    )))
+                    )));
                 }
             };
             match entries.borrow().get(&map_key) {

--- a/crates/rl-interpreter/src/stdlib/collections/map_get.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_get.rs
@@ -1,0 +1,32 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::{MapKey, Value},
+};
+
+pub fn std_map_get(_: &mut Evaluator, map: Value, key: Value) -> Value {
+    match map {
+        Value::Map { entries, .. } => {
+            let map_key = match MapKey::from_value(&key) {
+                Some(k) => k,
+                None => {
+                    return verr!(vs!(format!(
+                        "map_get: cannot use {} as a map key",
+                        key.type_name()
+                    )))
+                }
+            };
+            match entries.borrow().get(&map_key) {
+                Some(value) => vok!(value.clone()),
+                None => verr!(vs!(format!(
+                    "map_get: key {} not found in map",
+                    map_key.into_value()
+                ))),
+            }
+        }
+        other => verr!(vs!(format!(
+            "map_get: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_is_empty.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_is_empty.rs
@@ -1,0 +1,15 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_is_empty(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map { entries, .. } => vok!(Value::Bool(entries.borrow().is_empty())),
+        other => verr!(vs!(format!(
+            "map_is_empty: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_keys.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_keys.rs
@@ -1,0 +1,27 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_keys(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map {
+            key_type, entries, ..
+        } => {
+            let items = entries
+                .borrow()
+                .keys()
+                .map(|k| k.clone().into_value())
+                .collect();
+            vok!(Value::Values {
+                items_type: key_type,
+                items,
+            })
+        }
+        other => verr!(vs!(format!(
+            "map_keys: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_len.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_len.rs
@@ -1,0 +1,15 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_len(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map { entries, .. } => vok!(Value::Integer(entries.borrow().len() as i64)),
+        other => verr!(vs!(format!(
+            "map_len: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_merge.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_merge.rs
@@ -1,0 +1,43 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_merge(_: &mut Evaluator, map1: Value, map2: Value) -> Value {
+    match (map1, map2) {
+        (
+            Value::Map {
+                key_type,
+                value_type,
+                entries,
+            },
+            Value::Map {
+                key_type: key_type2,
+                value_type: value_type2,
+                entries: entries2,
+            },
+        ) => {
+            if !Evaluator::types_compatible(&key_type2, &key_type)
+                || !Evaluator::types_compatible(&value_type2, &value_type)
+            {
+                return verr!(vs!(format!(
+                    "map_merge: type mismatch: expects map[{:?}, {:?}], found map[{:?}, {:?}]",
+                    key_type, value_type, key_type2, value_type2
+                )));
+            }
+            for (k, v) in entries2.borrow().iter() {
+                entries.borrow_mut().insert(k.clone(), v.clone());
+            }
+            vok!(Value::Map {
+                key_type,
+                value_type,
+                entries,
+            })
+        }
+        (other, _) => verr!(vs!(format!(
+            "map_merge: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_remove.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_remove.rs
@@ -1,0 +1,35 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::{MapKey, Value},
+};
+
+pub fn std_map_remove(_: &mut Evaluator, map: Value, key: Value) -> Value {
+    match map {
+        Value::Map {
+            key_type,
+            value_type,
+            entries,
+        } => {
+            let map_key = match MapKey::from_value(&key) {
+                Some(k) => k,
+                None => {
+                    return verr!(vs!(format!(
+                        "map_remove: cannot remove {} from a map",
+                        key.type_name()
+                    )))
+                }
+            };
+            entries.borrow_mut().remove(&map_key);
+            vok!(Value::Map {
+                key_type,
+                value_type,
+                entries,
+            })
+        }
+        other => verr!(vs!(format!(
+            "map_remove: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_remove.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_remove.rs
@@ -17,7 +17,7 @@ pub fn std_map_remove(_: &mut Evaluator, map: Value, key: Value) -> Value {
                     return verr!(vs!(format!(
                         "map_remove: cannot remove {} from a map",
                         key.type_name()
-                    )))
+                    )));
                 }
             };
             entries.borrow_mut().remove(&map_key);

--- a/crates/rl-interpreter/src/stdlib/collections/map_to_array.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_to_array.rs
@@ -1,0 +1,32 @@
+use std::rc::Rc;
+
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+use rl_ast::statements::TypeAnnotation;
+
+pub fn std_map_to_array(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map {
+            key_type,
+            value_type,
+            entries,
+        } => {
+            let items = entries
+                .borrow()
+                .iter()
+                .map(|(k, v)| Value::Tuple(vec![k.clone().into_value(), v.clone()]))
+                .collect();
+            vok!(Value::Values {
+                items_type: TypeAnnotation::Tuple(Rc::new(vec![key_type, value_type])),
+                items,
+            })
+        }
+        other => verr!(vs!(format!(
+            "map_to_array: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/map_values.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/map_values.rs
@@ -1,0 +1,25 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::common::{verr, vok, vs},
+    values::Value,
+};
+
+pub fn std_map_values(_: &mut Evaluator, map: Value) -> Value {
+    match map {
+        Value::Map {
+            value_type,
+            entries,
+            ..
+        } => {
+            let items = entries.borrow().values().cloned().collect();
+            vok!(Value::Values {
+                items_type: value_type,
+                items,
+            })
+        }
+        other => verr!(vs!(format!(
+            "map_values: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/collections/mod.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/mod.rs
@@ -1,7 +1,17 @@
 use crate::native::Module;
 
-pub use rl_commons::keywords::set::KEYWORDS;
+pub use rl_commons::keywords::collections::KEYWORDS;
 
+mod map_clear;
+mod map_contains;
+mod map_get;
+mod map_is_empty;
+mod map_keys;
+mod map_len;
+mod map_merge;
+mod map_remove;
+mod map_to_array;
+mod map_values;
 mod set_add;
 mod set_contains;
 mod set_is_empty;
@@ -17,4 +27,14 @@ pub fn module() -> Module {
         .with_function("set_len", set_len::std_set_len)
         .with_function("set_is_empty", set_is_empty::std_set_is_empty)
         .with_function("set_to_array", set_to_array::std_set_to_array)
+        .with_function("map_contains", map_contains::std_map_contains)
+        .with_function("map_remove", map_remove::std_map_remove)
+        .with_function("map_len", map_len::std_map_len)
+        .with_function("map_is_empty", map_is_empty::std_map_is_empty)
+        .with_function("map_to_array", map_to_array::std_map_to_array)
+        .with_function("map_get", map_get::std_map_get)
+        .with_function("map_keys", map_keys::std_map_keys)
+        .with_function("map_values", map_values::std_map_values)
+        .with_function("map_clear", map_clear::std_map_clear)
+        .with_function("map_merge", map_merge::std_map_merge)
 }

--- a/crates/rl-interpreter/src/stdlib/collections/set_add.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/set_add.rs
@@ -20,7 +20,7 @@ pub fn std_set_add(_: &mut Evaluator, set: Value, value: Value) -> Value {
                     return verr!(vs!(format!(
                         "set_add: cannot add {} to a set",
                         value.type_name()
-                    )))
+                    )));
                 }
             };
             items.borrow_mut().insert(key);

--- a/crates/rl-interpreter/src/stdlib/collections/set_remove.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/set_remove.rs
@@ -13,7 +13,7 @@ pub fn std_set_remove(_: &mut Evaluator, set: Value, value: Value) -> Value {
                     return verr!(vs!(format!(
                         "set_remove: cannot remove {} from a set",
                         value.type_name()
-                    )))
+                    )));
                 }
             };
             items.borrow_mut().remove(&key);

--- a/crates/rl-interpreter/src/stdlib/collections/set_to_array.rs
+++ b/crates/rl-interpreter/src/stdlib/collections/set_to_array.rs
@@ -6,19 +6,13 @@ use crate::{
 
 pub fn std_set_to_array(_: &mut Evaluator, set: Value) -> Value {
     match set {
-        Value::Set {
-            items_type,
-            items,
-        } => {
+        Value::Set { items_type, items } => {
             let items = items
                 .borrow()
                 .iter()
                 .map(|k| k.clone().into_value())
                 .collect();
-            vok!(Value::Values {
-                items_type,
-                items,
-            })
+            vok!(Value::Values { items_type, items })
         }
         other => verr!(vs!(format!(
             "set_to_array: accepts only sets, found {}",

--- a/crates/rl-tests/tests/interpreter/stdlib/collections.rs
+++ b/crates/rl-tests/tests/interpreter/stdlib/collections.rs
@@ -522,7 +522,7 @@ dec arr[string] keys = map_keys(m)?
         Value::Values { items, .. } => items.clone(),
         other => panic!("expected array, got {:?}", other),
     };
-    items.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    items.sort_by_key(|a| a.to_string());
     assert_eq!(
         items,
         vec![
@@ -550,7 +550,7 @@ dec int n = map_len(m)?
         Value::Values { items, .. } => items.clone(),
         other => panic!("expected array, got {:?}", other),
     };
-    items.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    items.sort_by_key(|a| a.to_string());
     assert_eq!(
         items,
         vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)]

--- a/crates/rl-tests/tests/interpreter/stdlib/collections.rs
+++ b/crates/rl-tests/tests/interpreter/stdlib/collections.rs
@@ -332,3 +332,271 @@ dec bool has_3 = set_contains(s, 3)?
     assert_eq!(ev.get_value_raw("has_2"), Some(Value::Bool(false)));
     assert_eq!(ev.get_value_raw("has_3"), Some(Value::Bool(true)));
 }
+
+#[test]
+fn map_contains_found() {
+    let ev = eval_program(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+dec bool x = map_contains(m, "a")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Bool(true)));
+}
+
+#[test]
+fn map_contains_not_found() {
+    let ev = eval_program(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+dec bool x = map_contains(m, "z")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Bool(false)));
+}
+
+#[test]
+fn map_contains_empty_map() {
+    let ev = eval_program(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {}
+dec bool x = map_contains(m, "a")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Bool(false)));
+}
+
+#[test]
+fn map_remove_existing() {
+    let ev = eval_program(
+        r#"
+get map_remove, map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+m = map_remove(m, "a")?
+dec bool has_a = map_contains(m, "a")?
+dec bool has_b = map_contains(m, "b")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("has_a"), Some(Value::Bool(false)));
+    assert_eq!(ev.get_value_raw("has_b"), Some(Value::Bool(true)));
+}
+
+#[test]
+fn map_remove_nonexistent_is_noop() {
+    let ev = eval_program(
+        r#"
+get map_remove, map_len from std::collections
+dec map[string, int] m = {"a": 1}
+m = map_remove(m, "z")?
+dec int n = map_len(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(1)));
+}
+
+#[test]
+fn map_len_empty() {
+    let ev = eval_program(
+        r#"
+get map_len from std::collections
+dec map[string, int] m = {}
+dec int n = map_len(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(0)));
+}
+
+#[test]
+fn map_len_nonempty() {
+    let ev = eval_program(
+        r#"
+get map_len from std::collections
+dec map[string, int] m = {"a": 1, "b": 2, "c": 3}
+dec int n = map_len(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(3)));
+}
+
+#[test]
+fn map_is_empty_true() {
+    let ev = eval_program(
+        r#"
+get map_is_empty from std::collections
+dec map[string, int] m = {}
+dec bool x = map_is_empty(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Bool(true)));
+}
+
+#[test]
+fn map_is_empty_false() {
+    let ev = eval_program(
+        r#"
+get map_is_empty from std::collections
+dec map[string, int] m = {"a": 1}
+dec bool x = map_is_empty(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Bool(false)));
+}
+
+#[test]
+fn map_to_array_single_entry() {
+    let ev = eval_program(
+        r#"
+get map_to_array from std::collections
+dec map[string, int] m = {"a": 1}
+dec arr[(string, int)] a = map_to_array(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        ev.get_value_raw("a"),
+        Some(Value::Values {
+            items_type: rl_ast::statements::TypeAnnotation::Tuple(std::rc::Rc::new(vec![
+                rl_ast::statements::TypeAnnotation::String,
+                rl_ast::statements::TypeAnnotation::Int,
+            ])),
+            items: vec![Value::Tuple(vec![
+                Value::String("a".to_string()),
+                Value::Integer(1),
+            ])],
+        })
+    );
+}
+
+#[test]
+fn map_to_array_empty() {
+    let ev = eval_program(
+        r#"
+get map_to_array from std::collections
+get len from std::array
+dec map[string, int] m = {}
+dec arr[(string, int)] a = map_to_array(m)?
+dec int n = len(a)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(0)));
+}
+
+#[test]
+fn map_get_found() {
+    let ev = eval_program(
+        r#"
+get map_get from std::collections
+dec map[string, int] m = {"a": 1}
+dec int x = map_get(m, "a")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Integer(1)));
+}
+
+#[test]
+fn map_keys_preserves_elements() {
+    let ev = eval_program(
+        r#"
+get map_keys from std::collections
+dec map[string, int] m = {"b": 2, "a": 1, "c": 3}
+dec arr[string] keys = map_keys(m)?
+"#,
+    )
+    .unwrap();
+    let keys = ev.get_value_raw("keys").unwrap();
+    let mut items = match keys {
+        Value::Values { items, .. } => items.clone(),
+        other => panic!("expected array, got {:?}", other),
+    };
+    items.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    assert_eq!(
+        items,
+        vec![
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+            Value::String("c".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn map_values_preserves_elements() {
+    let ev = eval_program(
+        r#"
+get map_values, map_len from std::collections
+dec map[string, int] m = {"a": 1, "b": 2, "c": 3}
+dec arr[int] values = map_values(m)?
+dec int n = map_len(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(3)));
+    let values = ev.get_value_raw("values").unwrap();
+    let mut items = match values {
+        Value::Values { items, .. } => items.clone(),
+        other => panic!("expected array, got {:?}", other),
+    };
+    items.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    assert_eq!(
+        items,
+        vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)]
+    );
+}
+
+#[test]
+fn map_clear_empties_map() {
+    let ev = eval_program(
+        r#"
+get map_clear, map_is_empty from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+m = map_clear(m)?
+dec bool empty = map_is_empty(m)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("empty"), Some(Value::Bool(true)));
+}
+
+#[test]
+fn map_merge_combines_keys() {
+    let ev = eval_program(
+        r#"
+get map_merge, map_len from std::collections
+dec map[string, int] a = {"x": 1}
+dec map[string, int] b = {"y": 2}
+a = map_merge(a, b)?
+dec int n = map_len(a)?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("n"), Some(Value::Integer(2)));
+}
+
+#[test]
+fn map_merge_overwrites_matching_keys() {
+    let ev = eval_program(
+        r#"
+get map_merge, map_get from std::collections
+dec map[string, int] a = {"x": 1}
+dec map[string, int] b = {"x": 9}
+a = map_merge(a, b)?
+dec int x = map_get(a, "x")?
+"#,
+    )
+    .unwrap();
+    assert_eq!(ev.get_value_raw("x"), Some(Value::Integer(9)));
+}

--- a/crates/rl-tests/tests/vm/stdlib/collections/maps.rs
+++ b/crates/rl-tests/tests/vm/stdlib/collections/maps.rs
@@ -1,0 +1,256 @@
+use std::rc::Rc;
+
+use rl_vm::VmValue;
+
+use crate::common::compile_and_run;
+
+#[test]
+fn map_contains_found() {
+    let result = compile_and_run(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+dec bool x = map_contains(m, "a")?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn map_contains_not_found() {
+    let result = compile_and_run(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+dec bool x = map_contains(m, "z")?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(false));
+}
+
+#[test]
+fn map_contains_empty_map() {
+    let result = compile_and_run(
+        r#"
+get map_contains from std::collections
+dec map[string, int] m = {}
+dec bool x = map_contains(m, "a")?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(false));
+}
+
+#[test]
+fn map_remove_existing() {
+    let has_a = compile_and_run(
+        r#"
+get map_remove, map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+m = map_remove(m, "a")?
+dec bool has_a = map_contains(m, "a")?
+has_a
+"#,
+    )
+    .unwrap();
+    let has_b = compile_and_run(
+        r#"
+get map_remove, map_contains from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+m = map_remove(m, "a")?
+dec bool has_b = map_contains(m, "b")?
+has_b
+"#,
+    )
+    .unwrap();
+    assert_eq!(has_a, VmValue::Bool(false));
+    assert_eq!(has_b, VmValue::Bool(true));
+}
+
+#[test]
+fn map_remove_nonexistent_is_noop() {
+    let result = compile_and_run(
+        r#"
+get map_remove, map_len from std::collections
+dec map[string, int] m = {"a": 1}
+m = map_remove(m, "z")?
+dec int n = map_len(m)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(1));
+}
+
+#[test]
+fn map_len_empty() {
+    let result = compile_and_run(
+        r#"
+get map_len from std::collections
+dec map[string, int] m = {}
+dec int n = map_len(m)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(0));
+}
+
+#[test]
+fn map_len_nonempty() {
+    let result = compile_and_run(
+        r#"
+get map_len from std::collections
+dec map[string, int] m = {"a": 1, "b": 2, "c": 3}
+dec int n = map_len(m)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(3));
+}
+
+#[test]
+fn map_is_empty_true() {
+    let result = compile_and_run(
+        r#"
+get map_is_empty from std::collections
+dec map[string, int] m = {}
+dec bool x = map_is_empty(m)?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn map_is_empty_false() {
+    let result = compile_and_run(
+        r#"
+get map_is_empty from std::collections
+dec map[string, int] m = {"a": 1}
+dec bool x = map_is_empty(m)?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(false));
+}
+
+#[test]
+fn map_to_array_single_entry() {
+    let result = compile_and_run(
+        r#"
+get map_to_array from std::collections
+dec map[string, int] m = {"a": 1}
+dec arr[(string, int)] a = map_to_array(m)?
+a
+"#,
+    )
+    .unwrap();
+    assert_eq!(
+        result,
+        VmValue::Arr(Rc::new(vec![VmValue::Tuple(Rc::new(vec![
+            VmValue::Str(Rc::from("a")),
+            VmValue::Int(1),
+        ]))]))
+    );
+}
+
+#[test]
+fn map_to_array_empty() {
+    let result = compile_and_run(
+        r#"
+get map_to_array from std::collections
+get len from std::array
+dec map[string, int] m = {}
+dec arr[(string, int)] a = map_to_array(m)?
+dec int n = len(a)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(0));
+}
+
+#[test]
+fn map_get_found() {
+    let result = compile_and_run(
+        r#"
+get map_get from std::collections
+dec map[string, int] m = {"a": 1}
+dec int x = map_get(m, "a")?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(1));
+}
+
+#[test]
+fn map_values_preserves_elements() {
+    let result = compile_and_run(
+        r#"
+get map_values, map_len from std::collections
+dec map[string, int] m = {"a": 1, "b": 2, "c": 3}
+dec arr[int] values = map_values(m)?
+dec int n = map_len(m)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(3));
+}
+
+#[test]
+fn map_clear_empties_map() {
+    let result = compile_and_run(
+        r#"
+get map_clear, map_is_empty from std::collections
+dec map[string, int] m = {"a": 1, "b": 2}
+m = map_clear(m)?
+dec bool empty = map_is_empty(m)?
+empty
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn map_merge_combines_keys() {
+    let result = compile_and_run(
+        r#"
+get map_merge, map_len from std::collections
+dec map[string, int] a = {"x": 1}
+dec map[string, int] b = {"y": 2}
+a = map_merge(a, b)?
+dec int n = map_len(a)?
+n
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(2));
+}
+
+#[test]
+fn map_merge_overwrites_matching_keys() {
+    let result = compile_and_run(
+        r#"
+get map_merge, map_get from std::collections
+dec map[string, int] a = {"x": 1}
+dec map[string, int] b = {"x": 9}
+a = map_merge(a, b)?
+dec int x = map_get(a, "x")?
+x
+"#,
+    )
+    .unwrap();
+    assert_eq!(result, VmValue::Int(9));
+}

--- a/crates/rl-tests/tests/vm/stdlib/collections/mod.rs
+++ b/crates/rl-tests/tests/vm/stdlib/collections/mod.rs
@@ -1,1 +1,2 @@
+mod maps;
 mod sets;

--- a/crates/rl-vm/src/stdlib/collections/map_clear.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_clear.rs
@@ -1,0 +1,18 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_clear(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => {
+            entries.borrow_mut().clear();
+            vok!(VmValue::Map(entries))
+        }
+        other => verr!(vs!(format!(
+            "map_clear: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_contains.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_contains.rs
@@ -1,0 +1,18 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::{VmMapKey, VmValue},
+};
+
+pub fn std_map_contains(_: &mut Vm, map: VmValue, key: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => match VmMapKey::from_value(&key) {
+            Some(map_key) => vok!(VmValue::Bool(entries.borrow().contains_key(&map_key))),
+            None => vok!(VmValue::Bool(false)),
+        },
+        other => verr!(vs!(format!(
+            "map_contains: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_get.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_get.rs
@@ -1,0 +1,32 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::{VmMapKey, VmValue},
+};
+
+pub fn std_map_get(_: &mut Vm, map: VmValue, key: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => {
+            let map_key = match VmMapKey::from_value(&key) {
+                Some(k) => k,
+                None => {
+                    return verr!(vs!(format!(
+                        "map_get: cannot use {} as a map key",
+                        key.type_name()
+                    )));
+                }
+            };
+            match entries.borrow().get(&map_key) {
+                Some(value) => vok!(value.clone()),
+                None => verr!(vs!(format!(
+                    "map_get: key {} not found in map",
+                    map_key.into_value()
+                ))),
+            }
+        }
+        other => verr!(vs!(format!(
+            "map_get: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_is_empty.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_is_empty.rs
@@ -1,0 +1,15 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_is_empty(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => vok!(VmValue::Bool(entries.borrow().is_empty())),
+        other => verr!(vs!(format!(
+            "map_is_empty: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_keys.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_keys.rs
@@ -1,0 +1,24 @@
+use std::rc::Rc;
+
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_keys(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => {
+            let items: Vec<VmValue> = entries
+                .borrow()
+                .keys()
+                .map(|k| k.clone().into_value())
+                .collect();
+            vok!(VmValue::Arr(Rc::new(items)))
+        }
+        other => verr!(vs!(format!(
+            "map_keys: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_len.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_len.rs
@@ -1,0 +1,15 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_len(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => vok!(VmValue::Int(entries.borrow().len() as i64)),
+        other => verr!(vs!(format!(
+            "map_len: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_merge.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_merge.rs
@@ -1,0 +1,20 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_merge(_: &mut Vm, map1: VmValue, map2: VmValue) -> VmValue {
+    match (map1, map2) {
+        (VmValue::Map(entries), VmValue::Map(entries2)) => {
+            for (k, v) in entries2.borrow().iter() {
+                entries.borrow_mut().insert(k.clone(), v.clone());
+            }
+            vok!(VmValue::Map(entries))
+        }
+        (other, _) => verr!(vs!(format!(
+            "map_merge: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_remove.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_remove.rs
@@ -1,0 +1,24 @@
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::{VmMapKey, VmValue},
+};
+
+pub fn std_map_remove(_: &mut Vm, map: VmValue, key: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => match VmMapKey::from_value(&key) {
+            Some(map_key) => {
+                entries.borrow_mut().remove(&map_key);
+                vok!(VmValue::Map(entries))
+            }
+            None => verr!(vs!(format!(
+                "map_remove: cannot remove {} from a map",
+                key.type_name()
+            ))),
+        },
+        other => verr!(vs!(format!(
+            "map_remove: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_to_array.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_to_array.rs
@@ -1,0 +1,24 @@
+use std::rc::Rc;
+
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_to_array(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => {
+            let items: Vec<VmValue> = entries
+                .borrow()
+                .iter()
+                .map(|(k, v)| VmValue::Tuple(Rc::new(vec![k.clone().into_value(), v.clone()])))
+                .collect();
+            vok!(VmValue::Arr(Rc::new(items)))
+        }
+        other => verr!(vs!(format!(
+            "map_to_array: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/map_values.rs
+++ b/crates/rl-vm/src/stdlib/collections/map_values.rs
@@ -1,0 +1,20 @@
+use std::rc::Rc;
+
+use crate::{
+    Vm,
+    stdlib::macros::{verr, vok, vs},
+    values::VmValue,
+};
+
+pub fn std_map_values(_: &mut Vm, map: VmValue) -> VmValue {
+    match map {
+        VmValue::Map(entries) => {
+            let items: Vec<VmValue> = entries.borrow().values().cloned().collect();
+            vok!(VmValue::Arr(Rc::new(items)))
+        }
+        other => verr!(vs!(format!(
+            "map_values: accepts only maps, found {}",
+            other.type_name()
+        ))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/collections/mod.rs
+++ b/crates/rl-vm/src/stdlib/collections/mod.rs
@@ -1,3 +1,13 @@
+mod map_clear;
+mod map_contains;
+mod map_get;
+mod map_is_empty;
+mod map_keys;
+mod map_len;
+mod map_merge;
+mod map_remove;
+mod map_to_array;
+mod map_values;
 mod set_add;
 mod set_contains;
 mod set_is_empty;
@@ -15,4 +25,14 @@ pub fn module() -> Module {
         .with_function("set_len", set_len::std_set_len)
         .with_function("set_is_empty", set_is_empty::std_set_is_empty)
         .with_function("set_to_array", set_to_array::std_set_to_array)
+        .with_function("map_contains", map_contains::std_map_contains)
+        .with_function("map_remove", map_remove::std_map_remove)
+        .with_function("map_len", map_len::std_map_len)
+        .with_function("map_is_empty", map_is_empty::std_map_is_empty)
+        .with_function("map_to_array", map_to_array::std_map_to_array)
+        .with_function("map_get", map_get::std_map_get)
+        .with_function("map_keys", map_keys::std_map_keys)
+        .with_function("map_values", map_values::std_map_values)
+        .with_function("map_clear", map_clear::std_map_clear)
+        .with_function("map_merge", map_merge::std_map_merge)
 }


### PR DESCRIPTION
## What does this PR do?
Updates `sets` concept in docs:
- fix the types allowed in `set` to be similar to map keys
- mention `std::collections` for functions related to `set`s type

Updates `maps` concept in docs:
- mentions `std::collections` for functions related to `map`s type

Extend `std::collections` to have the following functions:
- `map_clear`
- `map_contains`
- `map_get`
- `map_is_empty`
- `map_len`
- `map_merge`
- `map_remove`
- `map_to_array`
- `map_keys`
- `map_values`

## Related issue
Closes #229 -- the `std::collections`
Closes #222 -- the `sets` concept
Closes #155 -- the tracking issue for `rl-docs`

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
