### PR TITLE
update `std::c`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libffi"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed185dbb87539a100c1b36c219e16e71572c6d4d4fed3ded898140f755adeaaf"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25831b230b6a90bdea9f28339c1d00d59773a1c492e8ca09b1ad80e56394c261"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1570,7 @@ name = "rl-interpreter"
 version = "0.4.0"
 dependencies = [
  "crossterm",
+ "libffi",
  "libloading",
  "log",
  "rl-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ toml = "0.8"
 tiny_http = "0.12"
 ureq = "2"
 libloading = "0.8"
+libffi = "5"
 clap = { version = "4.6.1", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"

--- a/crates/rl-commons/src/stdlib_signatures/c.rs
+++ b/crates/rl-commons/src/stdlib_signatures/c.rs
@@ -1,6 +1,6 @@
 //! Typed signatures for `std::c`.
 
-use super::{fixed, handle, overloads, params, result};
+use super::{handle, overloads, params, result};
 use crate::{ModuleNames, StdFn};
 use rl_ast::statements::TypeAnnotation as T;
 
@@ -12,24 +12,11 @@ pub fn module() -> ModuleNames {
 }
 
 fn compile() -> StdFn {
-    StdFn::typed(
-        "compile",
-        vec![(params(vec![T::String]), result(T::Int))],
-    )
+    StdFn::typed("compile", vec![(params(vec![T::String]), result(T::Int))])
 }
 
 fn call() -> StdFn {
-    StdFn::typed(
-        "call",
-        overloads(
-            vec![
-                handle(),
-                fixed(T::String),
-                fixed(T::Array(Box::new(T::Int))),
-            ],
-            result(T::Int),
-        ),
-    )
+    StdFn::untyped("call")
 }
 
 fn close() -> StdFn {

--- a/crates/rl-interpreter/Cargo.toml
+++ b/crates/rl-interpreter/Cargo.toml
@@ -19,6 +19,7 @@ crossterm.workspace = true
 tiny_http.workspace = true
 ureq.workspace = true
 libloading.workspace = true
+libffi.workspace = true
 log = { workspace = true, optional = true }
 
 [features]

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -119,76 +119,39 @@ pub fn func(
             CArg::F64(v) => arg(v),
         })
         .collect();
+
+    let cif = Cif::new(arg_ffi_types, ret_ffi_type);
+
+    // SAFETY: `cif`'s arg/return types come directly from `arg_types`/`ret_type`
+    // as declared by the caller. If those don't match the real C function's
+    // signature, this is UB - same contract as any FFI call. Getting the
+    // symbol itself (`lib.get`) is also unsafe per `libloading`'s contract.
     let result = unsafe {
-        match args.len() {
-            0 => {
-                let sym: Symbol<'_, unsafe extern "C" fn() -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym()
+        let sym: Symbol<unsafe extern "C" fn()> = match lib.get(fn_name.as_bytes()) {
+            Ok(s) => s,
+            Err(e) => {
+                return verr!(vs!(format!(
+                    "call: symbol \"{}\" not found: {}",
+                    fn_name, e
+                )));
             }
-            1 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0])
+        };
+        let code_ptr = CodePtr::from_fun(*sym);
+
+        match ret_type.as_str() {
+            "void" => {
+                let _: () = cif.call(code_ptr, &ffi_args);
+                vok!(vnl!())
             }
-            2 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64, i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0], args[1])
-            }
-            3 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64, i64, i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0], args[1], args[2])
-            }
-            4 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64, i64, i64, i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0], args[1], args[2], args[3])
-            }
-            5 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64, i64, i64, i64, i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0], args[1], args[2], args[3], args[4])
-            }
-            6 => {
-                let sym: Symbol<'_, unsafe extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64> =
-                    match lib.get(fn_name.as_bytes()) {
-                        Ok(s) => s,
-                        Err(e) => return sym_err(&fn_name, e),
-                    };
-                sym(args[0], args[1], args[2], args[3], args[4], args[5])
-            }
-            _ => unreachable!("checked above"),
+            "i32" => vok!(vi!(cif.call::<i32>(code_ptr, &ffi_args) as i64)),
+            "i64" => vok!(vi!(cif.call::<i64>(code_ptr, &ffi_args))),
+            "f32" => vok!(vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64)),
+            "f64" => vok!(vf!(cif.call::<f64>(code_ptr, &ffi_args))),
+            _ => unreachable!("ret_type validated by parse_type above"),
         }
     };
 
-    vok!(vi!(result))
-}
-
-fn sym_err(fn_name: &str, e: libloading::Error) -> Value {
-    verr!(vs!(format!(
-        "call: symbol \"{}\" not found: {}",
-        fn_name, e
-    )))
+    result
 }
 
 fn parse_type(name: &str, context: &str) -> Result<Type, Value> {

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -138,3 +138,33 @@ fn sym_err(fn_name: &str, e: libloading::Error) -> Value {
         fn_name, e
     )))
 }
+
+fn parse_type(name: &str, context: &str) -> Result<Type, Value> {
+    match name {
+        "i32" => Ok(Type::i32()),
+        "i64" => Ok(Type::i64()),
+        "f32" => Ok(Type::f32()),
+        "f64" => Ok(Type::f64()),
+        other => Err(verr!(vs!(format!(
+            "call: unsupported {} type \"{}\" (supported: i32, i64, f32, f64)",
+            context, other
+        )))),
+    }
+}
+
+fn value_to_carg(value: Value, type_name: &str, index: usize) -> Result<CArg, Value> {
+    match (type_name, &value) {
+        ("i32", Value::Integer(i)) => Ok(CArg::I32(*i as i32)),
+        ("i32", Value::Byte(b)) => Ok(CArg::I32(*b as i32)),
+        ("i64", Value::Integer(i)) => Ok(CArg::I64(*i)),
+        ("i64", Value::Byte(b)) => Ok(CArg::I64(*b as i64)),
+        ("f32", Value::Float(f)) => Ok(CArg::F32(*f as f32)),
+        ("f64", Value::Float(f)) => Ok(CArg::F64(*f)),
+        (t, other) => Err(verr!(vs!(format!(
+            "call: arg {} declared as \"{}\" but got {}",
+            index,
+            t,
+            other.type_name()
+        )))),
+    }
+}

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -1,10 +1,11 @@
+use libffi::middle::{Arg, Cif, CodePtr, Type, arg};
 use libloading::Symbol;
 
 use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string, verr, vi, vok, vs},
+        common::{extract_number, extract_string, verr, vf, vi, vnl, vok, vs},
     },
     values::Value,
 };

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -130,7 +130,7 @@ pub fn func(
     // as declared by the caller. If those don't match the real C function's
     // signature, this is UB - same contract as any FFI call. Getting the
     // symbol itself (`lib.get`) is also unsafe per `libloading`'s contract.
-    let result = unsafe {
+    unsafe {
         let sym: Symbol<unsafe extern "C" fn()> = match lib.get(fn_name.as_bytes()) {
             Ok(s) => s,
             Err(e) => {
@@ -153,9 +153,7 @@ pub fn func(
             "f64" => vok!(vf!(cif.call::<f64>(code_ptr, &ffi_args))),
             _ => unreachable!("ret_type validated by parse_type above"),
         }
-    };
-
-    result
+    }
 }
 
 fn parse_type(name: &str, context: &str) -> Result<Type, Value> {

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -80,14 +80,45 @@ pub fn func(
         )));
     }
 
+    let mut c_args: Vec<CArg> = Vec::with_capacity(arg_values.len());
+    for (i, (value, type_name)) in arg_values.into_iter().zip(&arg_type_names).enumerate() {
+        match value_to_carg(value, type_name, i) {
+            Ok(c_arg) => c_args.push(c_arg),
+            Err(e) => return e,
+        }
+    }
+
+    let mut arg_ffi_types: Vec<Type> = Vec::with_capacity(arg_type_names.len());
+    for type_name in &arg_type_names {
+        match parse_type(type_name, "arg") {
+            Ok(t) => arg_ffi_types.push(t),
+            Err(e) => return e,
+        }
+    }
+
+    let ret_ffi_type = if ret_type == "void" {
+        Type::void()
+    } else {
+        match parse_type(&ret_type, "return") {
+            Ok(t) => t,
+            Err(e) => return e,
+        }
+    };
+
     let CHandle::Library(lib) = match eval.c_handles.get(&handle_id) {
         Some(h) => h,
         None => return verr!(vs!(format!("call: unknown handle {}", handle_id))),
     };
 
-    // SAFETY: the caller-declared signature (all-i64, fixed arity) must match
-    // the real C function's signature. Getting this wrong is UB - same
-    // contract as any FFI call.
+    let ffi_args: Vec<Arg> = c_args
+        .iter()
+        .map(|c| match c {
+            CArg::I32(v) => arg(v),
+            CArg::I64(v) => arg(v),
+            CArg::F32(v) => arg(v),
+            CArg::F64(v) => arg(v),
+        })
+        .collect();
     let result = unsafe {
         match args.len() {
             0 => {

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -10,6 +10,10 @@ use crate::{
     values::Value,
 };
 
+/// One argument's value, converted from its rl-lang `Value` into the exact
+/// Rust type its declared C type requires. Kept as an owned value (rather
+/// than immediately building an `Arg`) so it has somewhere to live while the
+/// `Arg`s that borrow from it are assembled and passed to `Cif::call`.
 enum CArg {
     I32(i32),
     I64(i64),

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -10,7 +10,6 @@ use crate::{
     values::Value,
 };
 
-const MAX_ARGS: usize = 6;
 enum CArg {
     I32(i32),
     I64(i64),
@@ -18,7 +17,14 @@ enum CArg {
     F64(f64),
 }
 
-pub fn func(eval: &mut Evaluator, handle: Value, fn_name: Value, args: Value) -> Value {
+pub fn func(
+    eval: &mut Evaluator,
+    handle: Value,
+    fn_name: Value,
+    args: Value,
+    arg_types: Value,
+    ret_type: Value,
+) -> Value {
     let handle_id = match extract_number(handle, "call") {
         Ok(n) => n as i64,
         Err(e) => return verr!(vs!(format!("call: {}", e))),
@@ -27,16 +33,20 @@ pub fn func(eval: &mut Evaluator, handle: Value, fn_name: Value, args: Value) ->
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("call: {}", e))),
     };
-    let args: Vec<i64> = match args {
+    let ret_type = match extract_string(ret_type, "call") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("call: {}", e))),
+    };
+
+    let arg_type_names: Vec<String> = match arg_types {
         Value::Values { items, .. } => {
             let mut out = Vec::with_capacity(items.len());
             for item in items {
                 match item {
-                    Value::Integer(i) => out.push(i),
-                    Value::Byte(b) => out.push(b as i64),
+                    Value::String(s) => out.push(s),
                     other => {
                         return verr!(vs!(format!(
-                            "call: all args must be int, found {}",
+                            "call: arg_types must be an array of string, found {}",
                             other.type_name()
                         )));
                     }
@@ -46,16 +56,27 @@ pub fn func(eval: &mut Evaluator, handle: Value, fn_name: Value, args: Value) ->
         }
         other => {
             return verr!(vs!(format!(
-                "call: expected an array of int args, found {}",
+                "call: expected an array of string for arg_types, found {}",
                 other.type_name()
             )));
         }
     };
-    if args.len() > MAX_ARGS {
+
+    let arg_values: Vec<Value> = match args {
+        Value::Values { items, .. } => items,
+        other => {
+            return verr!(vs!(format!(
+                "call: expected an array of args, found {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    if arg_values.len() != arg_type_names.len() {
         return verr!(vs!(format!(
-            "call: at most {} args are supported in this version, got {}",
-            MAX_ARGS,
-            args.len()
+            "call: {} arg(s) but {} arg_type(s) given",
+            arg_values.len(),
+            arg_type_names.len()
         )));
     }
 

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -11,6 +11,12 @@ use crate::{
 };
 
 const MAX_ARGS: usize = 6;
+enum CArg {
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+}
 
 pub fn func(eval: &mut Evaluator, handle: Value, fn_name: Value, args: Value) -> Value {
     let handle_id = match extract_number(handle, "call") {


### PR DESCRIPTION
## What does this PR do?
Add `libffi` crate
Support `float` type arguments
Support for argument types: `f64 (float)` `f32 (float)` `i64 (int|byte)` `i32 (int|byte)`
Support for return types: `f64 (float)` `f32 (float)` `i64 (int)` `i32 (int)` `void (null)`