### PR TITLE
Update `std::c`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,6 +1674,8 @@ dependencies = [
 name = "rl-vm"
 version = "0.3.0"
 dependencies = [
+ "libffi",
+ "libloading",
  "rl-ast",
  "rl-lexer",
  "rl-utils",

--- a/crates/rl-commons/src/keywords.rs
+++ b/crates/rl-commons/src/keywords.rs
@@ -147,7 +147,7 @@ pub mod net {
 }
 
 pub mod c {
-    pub const KEYWORDS: &[&str] = &["compile", "call", "close"];
+    pub const KEYWORDS: &[&str] = &["compile", "load", "call", "close"];
 }
 
 pub mod path {

--- a/crates/rl-commons/src/stdlib_signatures/c.rs
+++ b/crates/rl-commons/src/stdlib_signatures/c.rs
@@ -7,12 +7,17 @@ use rl_ast::statements::TypeAnnotation as T;
 pub fn module() -> ModuleNames {
     ModuleNames::new("c")
         .with_typed_function(compile())
+        .with_typed_function(load())
         .with_typed_function(call())
         .with_typed_function(close())
 }
 
 fn compile() -> StdFn {
     StdFn::typed("compile", vec![(params(vec![T::String]), result(T::Int))])
+}
+
+fn load() -> StdFn {
+    StdFn::typed("load", vec![(params(vec![T::String]), result(T::Int))])
 }
 
 fn call() -> StdFn {

--- a/crates/rl-docs/src/entries/mod.rs
+++ b/crates/rl-docs/src/entries/mod.rs
@@ -28,6 +28,7 @@ pub fn stdlib_entries() -> Vec<&'static StdEntry> {
         &stdlib::net::NET,
         &stdlib::http::HTTP,
         &stdlib::collections::COLLECTIONS,
+        &stdlib::c::C,
     ]
 }
 

--- a/crates/rl-docs/src/entries/stdlib/c/call.rs
+++ b/crates/rl-docs/src/entries/stdlib/c/call.rs
@@ -1,0 +1,21 @@
+use crate::entry::FnEntry;
+
+pub static CALL: FnEntry = FnEntry {
+    signature: "call(handle, fn_name, args, arg_types, ret_type)",
+    description: "calls `fn_name` in the library behind `handle` via libffi. `args` is a *tuple* (`(...)`, not `[...]`) since C argument lists mix types and rl-lang arrays are homogeneous. `arg_types` is an `arr[string]` matched positionally to `args`; each entry is one of `\"i32\"`/`\"i64\"`/`\"i16\"`/`\"u8\"`/`\"f32\"`/`\"f64\"`/`\"bool\"`, a mutable `\"str:N\"` (an in/out `char[N]` buffer, `N` a byte capacity including the null terminator), or a mutable `\"arr:TYPE:N\"` (an in/out numeric buffer, `TYPE` one of `i32`/`i64`/`f32`/`f64`/`u8`/`i16`, `N` an *exact* element count - unlike strings there's no terminator convention for numbers, so the array's length must match `N` exactly). `ret_type` is one of the same numeric names or `\"void\"` - never `\"str\"`/`\"arr\"`, since a C-returned pointer's ownership (static vs `malloc`'d, freed how) can't be known safely. With no `\"str:N\"`/`\"arr:TYPE:N\"` args, `call` returns the plain scalar named by `ret_type`; with one or more, it returns `(ret, outs)`, where `outs` is itself a tuple holding the post-call buffer contents, in the order those args appeared. rl-lang values are never mutated in place either way (rl-lang arrays/strings have no shared/reference semantics) - `outs` is how a mutation crosses back explicitly",
+    example: r#"
+get std::c::compile
+get std::c::call
+get std::c::close
+
+dec int h = std::res::result_unwrap(compile("int add(int a, int b) { return a + b; }"))
+dec int sum = std::res::result_unwrap(call(h, "add", (3, 4), ["i32", "i32"], "i32"))
+close(h)"#,
+    expected_output: None,
+    returns: "result[T] matching ret_type, or result[(T, (...))] when any str:N/arr:TYPE:N arg is used",
+    errors: Some(
+        "err(string) for an unknown handle, a missing symbol, an args/arg_types length mismatch, a value that doesn't match its declared arg type, an out-of-range int for u8/i16/arr elements, a string or array that doesn't fit its declared str:N/arr:TYPE:N capacity exactly, or an unsupported arg_types/ret_type name",
+    ),
+    see_also: &["compile", "load", "close"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/c/close.rs
+++ b/crates/rl-docs/src/entries/stdlib/c/close.rs
@@ -1,0 +1,16 @@
+use crate::entry::FnEntry;
+
+pub static CLOSE: FnEntry = FnEntry {
+    signature: "close(handle)",
+    description: "unloads the library behind `handle` (`dlclose`) and removes it from the handle table - works the same whether `handle` came from `compile` or `load`",
+    example: r#"
+get std::c::compile, std::c::close
+
+dec int h = std::res::result_unwrap(compile("void noop() {}"))
+close(h)"#,
+    expected_output: None,
+    returns: "result[null]",
+    errors: Some("err(string) if `handle` is unknown (already closed, or never valid)"),
+    see_also: &["compile", "load", "call"],
+    since: Some("v0.4.1"),
+};

--- a/crates/rl-docs/src/entries/stdlib/c/compile.rs
+++ b/crates/rl-docs/src/entries/stdlib/c/compile.rs
@@ -1,0 +1,17 @@
+use crate::entry::FnEntry;
+
+pub static COMPILE: FnEntry = FnEntry {
+    signature: "compile(source)",
+    description: "compiles C `source` with a system compiler (`cc`/`clang`/`gcc`, or `$CC`) into a shared library, caching the result by content hash, then `dlopen`s it; returns a library handle for use with `call`/`close`. No compiler is bundled, so this requires one to already be on `$PATH` (or `$CC` set explicitly)",
+    example: r#"
+get std::c::compile
+
+dec int h = std::res::result_unwrap(compile("int add(int a, int b) { return a + b; }"))"#,
+    expected_output: None,
+    returns: "result[int]",
+    errors: Some(
+        "err(string) if no C compiler is found on $PATH/$CC, compilation fails (compiler diagnostics are included), or the resulting library fails to load",
+    ),
+    see_also: &["load", "call", "close"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/c/load.rs
+++ b/crates/rl-docs/src/entries/stdlib/c/load.rs
@@ -1,0 +1,15 @@
+use crate::entry::FnEntry;
+
+pub static LOAD: FnEntry = FnEntry {
+    signature: "load(path)",
+    description: "`dlopen`s an already-built `.so`/`.dylib`/`.dll` at `path` directly, no compiler involved; shares the same handle table as `compile`, so `call`/`close` work identically on a handle from either one",
+    example: r#"
+get std::c::load
+
+dec int h = std::res::result_unwrap(load("libm.so.6"))"#,
+    expected_output: None,
+    returns: "result[int]",
+    errors: Some("err(string) if the library at `path` can't be found or loaded"),
+    see_also: &["compile", "call", "close"],
+    since: Some("v0.4.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/c/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/c/mod.rs
@@ -1,0 +1,16 @@
+use crate::entry::{FnEntry, StdEntry};
+
+mod call;
+mod close;
+mod compile;
+mod load;
+
+pub static C: StdEntry = StdEntry {
+    name: "c",
+    description: "compile or load a C shared library (via a system compiler or dlopen) and call into it through libffi",
+    functions: FUNCTIONS,
+    since: Some("v0.4.0"),
+    unstable: true,
+};
+
+static FUNCTIONS: &[&FnEntry] = &[&compile::COMPILE, &load::LOAD, &call::CALL, &close::CLOSE];

--- a/crates/rl-docs/src/entries/stdlib/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/mod.rs
@@ -1,6 +1,7 @@
 //! Standard library documentation entries, one module per file.
 pub mod array;
 pub mod bitwise;
+pub mod c;
 pub mod collections;
 pub mod debug;
 pub mod fs;

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -19,6 +19,12 @@ enum CArg {
     I64(i64),
     F32(f32),
     F64(f64),
+    Str { buf: Vec<u8>, ptr: *mut u8 },
+}
+
+enum ArgKind {
+    Num(&'static str),
+    Str(usize),
 }
 
 pub fn func(

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -151,13 +151,13 @@ pub fn func(
         match ret_type.as_str() {
             "void" => {
                 let _: () = cif.call(code_ptr, &ffi_args);
-                vok!(vnl!())
+                vnl!()
             }
-            "i32" => vok!(vi!(cif.call::<i32>(code_ptr, &ffi_args) as i64)),
-            "i64" => vok!(vi!(cif.call::<i64>(code_ptr, &ffi_args))),
-            "f32" => vok!(vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64)),
-            "f64" => vok!(vf!(cif.call::<f64>(code_ptr, &ffi_args))),
-            _ => unreachable!("ret_type validated by parse_type above"),
+            "i32" => vi!(cif.call::<i32>(code_ptr, &ffi_args) as i64),
+            "i64" => vi!(cif.call::<i64>(code_ptr, &ffi_args)),
+            "f32" => vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64),
+            "f64" => vf!(cif.call::<f64>(code_ptr, &ffi_args)),
+            _ => unreachable!("ret_type validated by parse_ret_type above"),
         }
     }
 }

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -6,20 +6,21 @@ use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string, verr, vf, vi, vnl, vok, vs},
+        common::{extract_number, extract_string, vb, verr, vf, vi, vnl, vok, vs},
     },
     values::Value,
 };
 
 /// One argument's value, converted from its rl-lang `Value` into the exact
-/// Rust type its declared C type requires. Kept as an owned value (rather
-/// than immediately building an `Arg`) so it has somewhere to live while the
-/// `Arg`s that borrow from it are assembled and passed to `Cif::call`.
+/// Rust representation its declared C type requires. Kept as an owned value
+/// (rather than immediately building an `Arg`) so it has somewhere to live
+/// while the `Arg`s that borrow from it are assembled and passed to `Cif::call`.
 enum CArg {
     I32(i32),
     I64(i64),
     F32(f32),
     F64(f64),
+    Bool(u8),
     Str { buf: Vec<u8>, ptr: *mut u8 },
 }
 
@@ -132,6 +133,7 @@ pub fn func(
             CArg::I64(v) => arg(v),
             CArg::F32(v) => arg(v),
             CArg::F64(v) => arg(v),
+            CArg::Bool(v) => arg(v),
             CArg::Str { ptr, .. } => arg(ptr),
         })
         .collect();
@@ -166,6 +168,7 @@ pub fn func(
             "i64" => vi!(cif.call::<i64>(code_ptr, &ffi_args)),
             "f32" => vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64),
             "f64" => vf!(cif.call::<f64>(code_ptr, &ffi_args)),
+            "bool" => vb!(cif.call::<u8>(code_ptr, &ffi_args) != 0),
             _ => unreachable!("ret_type validated by parse_ret_type above"),
         }
     };
@@ -200,11 +203,12 @@ pub fn func(
 
 fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
     match name {
-        "i32" | "i64" | "f32" | "f64" => Ok(ArgKind::Num(match name {
+        "i32" | "i64" | "f32" | "f64" | "bool" => Ok(ArgKind::Num(match name {
             "i32" => "i32",
             "i64" => "i64",
             "f32" => "f32",
-            _ => "f64",
+            "f64" => "f64",
+            _ => "bool",
         })),
         _ if name.starts_with("str:") => {
             let cap: usize = name["str:".len()..].parse().map_err(|_| {
@@ -227,7 +231,7 @@ fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
                 .to_string()
         ))),
         other => Err(verr!(vs!(format!(
-            "call: unsupported arg type \"{}\" (supported: i32, i64, f32, f64, str:N)",
+            "call: unsupported arg type \"{}\" (supported: i32, i64, f32, f64, bool, str:N)",
             other
         )))),
     }
@@ -238,16 +242,17 @@ fn numeric_ffi_type(name: &str) -> Type {
         "i32" => Type::i32(),
         "i64" => Type::i64(),
         "f32" => Type::f32(),
-        _ => Type::f64(),
+        "f64" => Type::f64(),
+        _ => Type::u8(), // "bool"
     }
 }
 
 fn parse_ret_type(name: &str) -> Result<Type, Value> {
     match name {
         "void" => Ok(Type::void()),
-        "i32" | "i64" | "f32" | "f64" => Ok(numeric_ffi_type(name)),
+        "i32" | "i64" | "f32" | "f64" | "bool" => Ok(numeric_ffi_type(name)),
         other => Err(verr!(vs!(format!(
-            "call: unsupported return type \"{}\" (supported: i32, i64, f32, f64, void - \
+            "call: unsupported return type \"{}\" (supported: i32, i64, f32, f64, bool, void - \
              no \"str\" return: an unmanaged C string's ownership can't be known safely)",
             other
         )))),
@@ -262,6 +267,7 @@ fn value_to_carg(value: Value, kind: &ArgKind, index: usize) -> Result<CArg, Val
         (ArgKind::Num("i64"), Value::Byte(b)) => Ok(CArg::I64(b as i64)),
         (ArgKind::Num("f32"), Value::Float(f)) => Ok(CArg::F32(f as f32)),
         (ArgKind::Num("f64"), Value::Float(f)) => Ok(CArg::F64(f)),
+        (ArgKind::Num("bool"), Value::Bool(b)) => Ok(CArg::Bool(u8::from(b))),
         (ArgKind::Num(t), other) => Err(verr!(vs!(format!(
             "call: arg {} declared as \"{}\" but got {}",
             index,

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -11,6 +11,42 @@ use crate::{
     values::Value,
 };
 
+/// The element type of an `"arr:TYPE:N"` arg.
+#[derive(Clone, Copy)]
+enum ArrElem {
+    I32,
+    I64,
+    F32,
+    F64,
+    U8,
+    I16,
+}
+
+impl ArrElem {
+    fn parse(name: &str) -> Option<Self> {
+        Some(match name {
+            "i32" => ArrElem::I32,
+            "i64" => ArrElem::I64,
+            "f32" => ArrElem::F32,
+            "f64" => ArrElem::F64,
+            "u8" => ArrElem::U8,
+            "i16" => ArrElem::I16,
+            _ => return None,
+        })
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            ArrElem::I32 => "i32",
+            ArrElem::I64 => "i64",
+            ArrElem::F32 => "f32",
+            ArrElem::F64 => "f64",
+            ArrElem::U8 => "u8",
+            ArrElem::I16 => "i16",
+        }
+    }
+}
+
 /// One argument's value, converted from its rl-lang `Value` into the exact
 /// Rust representation its declared C type requires. Kept as an owned value
 /// (rather than immediately building an `Arg`) so it has somewhere to live
@@ -24,12 +60,19 @@ enum CArg {
     U8(u8),
     I16(i16),
     Str { buf: Vec<u8>, ptr: *mut u8 },
+    ArrI32 { buf: Vec<i32>, ptr: *mut u8 },
+    ArrI64 { buf: Vec<i64>, ptr: *mut u8 },
+    ArrF32 { buf: Vec<f32>, ptr: *mut u8 },
+    ArrF64 { buf: Vec<f64>, ptr: *mut u8 },
+    ArrU8 { buf: Vec<u8>, ptr: *mut u8 },
+    ArrI16 { buf: Vec<i16>, ptr: *mut u8 },
 }
 
 /// A parsed `arg_types` entry.
 enum ArgKind {
     Num(&'static str),
     Str(usize),
+    Arr(ArrElem, usize),
 }
 
 pub fn func(
@@ -120,7 +163,7 @@ pub fn func(
         .iter()
         .map(|k| match k {
             ArgKind::Num(name) => numeric_ffi_type(name),
-            ArgKind::Str(_) => Type::pointer(),
+            ArgKind::Str(_) | ArgKind::Arr(_, _) => Type::pointer(),
         })
         .collect();
 
@@ -140,6 +183,12 @@ pub fn func(
             CArg::U8(v) => arg(v),
             CArg::I16(v) => arg(v),
             CArg::Str { ptr, .. } => arg(ptr),
+            CArg::ArrI32 { ptr, .. } => arg(ptr),
+            CArg::ArrI64 { ptr, .. } => arg(ptr),
+            CArg::ArrF32 { ptr, .. } => arg(ptr),
+            CArg::ArrF64 { ptr, .. } => arg(ptr),
+            CArg::ArrU8 { ptr, .. } => arg(ptr),
+            CArg::ArrI16 { ptr, .. } => arg(ptr),
         })
         .collect();
 
@@ -147,11 +196,12 @@ pub fn func(
 
     // SAFETY: `cif`'s arg/return types come directly from `arg_types`/`ret_type`
     // as declared by the caller. If those don't match the real C function's
-    // signature, this is UB - same contract as any FFI call. For `str` args,
-    // the buffer is sized to the declared capacity and C is trusted to
-    // respect it (there's no way to enforce that from the caller's side -
-    // same as passing any buffer+length pair to C in C itself). Getting the
-    // symbol (`lib.get`) is also unsafe per `libloading`'s contract.
+    // signature, this is UB - same contract as any FFI call. For `str`/`arr`
+    // args, the buffer is sized to the declared capacity/count and C is
+    // trusted to respect it (there's no way to enforce that from the
+    // caller's side - same as passing any buffer+length pair to C in C
+    // itself). Getting the symbol (`lib.get`) is also unsafe per
+    // `libloading`'s contract.
     let ret_value: Value = unsafe {
         let sym: Symbol<unsafe extern "C" fn()> = match lib.get(fn_name.as_bytes()) {
             Ok(s) => s,
@@ -180,10 +230,12 @@ pub fn func(
         }
     };
 
-    // Read back any `str` buffers C may have written into, in the order
-    // their args appeared`.
-    let mutated_strs: Vec<Value> = c_args
-        .iter()
+    // Read back any `str`/`arr` buffers C may have written into, in the
+    // order their args appeared - this is the only "mutation" that crosses
+    // back into rl-lang, and only because the caller explicitly opted an
+    // arg into it via `"str:N"`/`"arr:TYPE:N"`.
+    let mutated_outs: Vec<Value> = c_args
+        .into_iter()
         .filter_map(|c| match c {
             CArg::Str { buf, .. } => {
                 let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
@@ -191,20 +243,38 @@ pub fn func(
                     String::from_utf8_lossy(&buf[..end]).into_owned(),
                 ))
             }
+            CArg::ArrI32 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Int,
+                items: buf.into_iter().map(|v| Value::Integer(v as i64)).collect(),
+            }),
+            CArg::ArrI64 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Int,
+                items: buf.into_iter().map(Value::Integer).collect(),
+            }),
+            CArg::ArrI16 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Int,
+                items: buf.into_iter().map(|v| Value::Integer(v as i64)).collect(),
+            }),
+            CArg::ArrU8 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Byte,
+                items: buf.into_iter().map(Value::Byte).collect(),
+            }),
+            CArg::ArrF32 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Float,
+                items: buf.into_iter().map(|v| Value::Float(v as f64)).collect(),
+            }),
+            CArg::ArrF64 { buf, .. } => Some(Value::Values {
+                items_type: TypeAnnotation::Float,
+                items: buf.into_iter().map(Value::Float).collect(),
+            }),
             _ => None,
         })
         .collect();
 
-    if mutated_strs.is_empty() {
+    if mutated_outs.is_empty() {
         vok!(ret_value)
     } else {
-        vok!(Value::Tuple(vec![
-            ret_value,
-            Value::Values {
-                items_type: TypeAnnotation::String,
-                items: mutated_strs,
-            },
-        ]))
+        vok!(Value::Tuple(vec![ret_value, Value::Tuple(mutated_outs)]))
     }
 }
 
@@ -239,8 +309,38 @@ fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
              there's no safe default to write past"
                 .to_string()
         ))),
+        _ if name.starts_with("arr:") => {
+            let rest = &name["arr:".len()..];
+            let (elem_name, count_str) = rest.split_once(':').ok_or_else(|| {
+                verr!(vs!(format!(
+                    "call: invalid arr type \"{}\" (expected e.g. \"arr:i32:8\")",
+                    name
+                )))
+            })?;
+            let elem = ArrElem::parse(elem_name).ok_or_else(|| {
+                verr!(vs!(format!(
+                    "call: unsupported arr element type \"{}\" in \"{}\" \
+                     (supported: i32, i64, f32, f64, u8, i16)",
+                    elem_name, name
+                )))
+            })?;
+            let count: usize = count_str.parse().map_err(|_| {
+                verr!(vs!(format!(
+                    "call: invalid arr element count in \"{}\" (expected e.g. \"arr:i32:8\")",
+                    name
+                )))
+            })?;
+            if count == 0 {
+                return Err(verr!(vs!(format!(
+                    "call: arr element count in \"{}\" must be at least 1",
+                    name
+                ))));
+            }
+            Ok(ArgKind::Arr(elem, count))
+        }
         other => Err(verr!(vs!(format!(
-            "call: unsupported arg type \"{}\" (supported: i32, i64, i16, u8, f32, f64, bool, str:N)",
+            "call: unsupported arg type \"{}\" \
+             (supported: i32, i64, i16, u8, f32, f64, bool, str:N, arr:TYPE:N)",
             other
         )))),
     }
@@ -267,9 +367,106 @@ fn parse_ret_type(name: &str) -> Result<Type, Value> {
         "i32" | "i64" | "i16" | "u8" | "f32" | "f64" | "bool" => Ok(numeric_ffi_type(name)),
         other => Err(verr!(vs!(format!(
             "call: unsupported return type \"{}\" (supported: i32, i64, i16, u8, f32, f64, bool, \
-             void - no \"str\" return: an unmanaged C string's ownership can't be known safely)",
+             void - no \"str\"/\"arr\" return: unmanaged C memory's ownership can't be known safely)",
             other
         )))),
+    }
+}
+
+/// Builds one `"arr:TYPE:N"` argument's buffer from an rl-lang `arr[T]`,
+/// checking every element's type and that the length is exactly `count`.
+fn arr_value_to_carg(
+    value: Value,
+    elem: ArrElem,
+    count: usize,
+    index: usize,
+) -> Result<CArg, Value> {
+    let items = match value {
+        Value::Values { items, .. } => items,
+        other => {
+            return Err(verr!(vs!(format!(
+                "call: arg {} declared as arr:{}:{} but got {}",
+                index,
+                elem.name(),
+                count,
+                other.type_name()
+            ))));
+        }
+    };
+    if items.len() != count {
+        return Err(verr!(vs!(format!(
+            "call: arg {} is arr:{}:{} but the array has {} element(s), not {}",
+            index,
+            elem.name(),
+            count,
+            items.len(),
+            count
+        ))));
+    }
+
+    macro_rules! build_int_buf {
+        ($variant:ident, $ty:ty, $range:expr) => {{
+            let mut buf: Vec<$ty> = Vec::with_capacity(count);
+            for (i, item) in items.into_iter().enumerate() {
+                let v: i64 = match item {
+                    Value::Integer(n) => n,
+                    Value::Byte(b) => b as i64,
+                    other => {
+                        return Err(verr!(vs!(format!(
+                            "call: arg {} element {} declared as {} but got {}",
+                            index,
+                            i,
+                            elem.name(),
+                            other.type_name()
+                        ))));
+                    }
+                };
+                if !$range.contains(&v) {
+                    return Err(verr!(vs!(format!(
+                        "call: arg {} element {} is {} but \"{}\" only holds {:?}",
+                        index,
+                        i,
+                        v,
+                        elem.name(),
+                        $range
+                    ))));
+                }
+                buf.push(v as $ty);
+            }
+            let ptr = buf.as_mut_ptr() as *mut u8;
+            Ok(CArg::$variant { buf, ptr })
+        }};
+    }
+
+    macro_rules! build_float_buf {
+        ($variant:ident, $ty:ty) => {{
+            let mut buf: Vec<$ty> = Vec::with_capacity(count);
+            for (i, item) in items.into_iter().enumerate() {
+                match item {
+                    Value::Float(f) => buf.push(f as $ty),
+                    other => {
+                        return Err(verr!(vs!(format!(
+                            "call: arg {} element {} declared as {} but got {}",
+                            index,
+                            i,
+                            elem.name(),
+                            other.type_name()
+                        ))));
+                    }
+                }
+            }
+            let ptr = buf.as_mut_ptr() as *mut u8;
+            Ok(CArg::$variant { buf, ptr })
+        }};
+    }
+
+    match elem {
+        ArrElem::I32 => build_int_buf!(ArrI32, i32, (i32::MIN as i64..=i32::MAX as i64)),
+        ArrElem::I64 => build_int_buf!(ArrI64, i64, (i64::MIN..=i64::MAX)),
+        ArrElem::I16 => build_int_buf!(ArrI16, i16, (i16::MIN as i64..=i16::MAX as i64)),
+        ArrElem::U8 => build_int_buf!(ArrU8, u8, (0i64..=255)),
+        ArrElem::F32 => build_float_buf!(ArrF32, f32),
+        ArrElem::F64 => build_float_buf!(ArrF64, f64),
     }
 }
 
@@ -331,5 +528,6 @@ fn value_to_carg(value: Value, kind: &ArgKind, index: usize) -> Result<CArg, Val
             index,
             other.type_name()
         )))),
+        (ArgKind::Arr(elem, count), value) => arr_value_to_carg(value, *elem, *count, index),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -6,7 +6,7 @@ use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string, vb, verr, vf, vi, vnl, vok, vs},
+        common::{extract_number, extract_string, vb, vby, verr, vf, vi, vnl, vok, vs},
     },
     values::Value,
 };
@@ -21,9 +21,12 @@ enum CArg {
     F32(f32),
     F64(f64),
     Bool(u8),
+    U8(u8),
+    I16(i16),
     Str { buf: Vec<u8>, ptr: *mut u8 },
 }
 
+/// A parsed `arg_types` entry.
 enum ArgKind {
     Num(&'static str),
     Str(usize),
@@ -134,6 +137,8 @@ pub fn func(
             CArg::F32(v) => arg(v),
             CArg::F64(v) => arg(v),
             CArg::Bool(v) => arg(v),
+            CArg::U8(v) => arg(v),
+            CArg::I16(v) => arg(v),
             CArg::Str { ptr, .. } => arg(ptr),
         })
         .collect();
@@ -169,6 +174,8 @@ pub fn func(
             "f32" => vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64),
             "f64" => vf!(cif.call::<f64>(code_ptr, &ffi_args)),
             "bool" => vb!(cif.call::<u8>(code_ptr, &ffi_args) != 0),
+            "u8" => vby!(cif.call::<u8>(code_ptr, &ffi_args)),
+            "i16" => vi!(cif.call::<i16>(code_ptr, &ffi_args) as i64),
             _ => unreachable!("ret_type validated by parse_ret_type above"),
         }
     };
@@ -203,12 +210,14 @@ pub fn func(
 
 fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
     match name {
-        "i32" | "i64" | "f32" | "f64" | "bool" => Ok(ArgKind::Num(match name {
+        "i32" | "i64" | "f32" | "f64" | "bool" | "u8" | "i16" => Ok(ArgKind::Num(match name {
             "i32" => "i32",
             "i64" => "i64",
             "f32" => "f32",
             "f64" => "f64",
-            _ => "bool",
+            "bool" => "bool",
+            "u8" => "u8",
+            _ => "i16",
         })),
         _ if name.starts_with("str:") => {
             let cap: usize = name["str:".len()..].parse().map_err(|_| {
@@ -231,7 +240,7 @@ fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
                 .to_string()
         ))),
         other => Err(verr!(vs!(format!(
-            "call: unsupported arg type \"{}\" (supported: i32, i64, f32, f64, bool, str:N)",
+            "call: unsupported arg type \"{}\" (supported: i32, i64, i16, u8, f32, f64, bool, str:N)",
             other
         )))),
     }
@@ -243,17 +252,22 @@ fn numeric_ffi_type(name: &str) -> Type {
         "i64" => Type::i64(),
         "f32" => Type::f32(),
         "f64" => Type::f64(),
-        _ => Type::u8(), // "bool"
+        "i16" => Type::i16(),
+        "u8" | "bool" => Type::u8(),
+        other => unreachable!(
+            "numeric_ffi_type called with unvalidated name \"{}\"",
+            other
+        ),
     }
 }
 
 fn parse_ret_type(name: &str) -> Result<Type, Value> {
     match name {
         "void" => Ok(Type::void()),
-        "i32" | "i64" | "f32" | "f64" | "bool" => Ok(numeric_ffi_type(name)),
+        "i32" | "i64" | "i16" | "u8" | "f32" | "f64" | "bool" => Ok(numeric_ffi_type(name)),
         other => Err(verr!(vs!(format!(
-            "call: unsupported return type \"{}\" (supported: i32, i64, f32, f64, bool, void - \
-             no \"str\" return: an unmanaged C string's ownership can't be known safely)",
+            "call: unsupported return type \"{}\" (supported: i32, i64, i16, u8, f32, f64, bool, \
+             void - no \"str\" return: an unmanaged C string's ownership can't be known safely)",
             other
         )))),
     }
@@ -268,6 +282,28 @@ fn value_to_carg(value: Value, kind: &ArgKind, index: usize) -> Result<CArg, Val
         (ArgKind::Num("f32"), Value::Float(f)) => Ok(CArg::F32(f as f32)),
         (ArgKind::Num("f64"), Value::Float(f)) => Ok(CArg::F64(f)),
         (ArgKind::Num("bool"), Value::Bool(b)) => Ok(CArg::Bool(u8::from(b))),
+        (ArgKind::Num("u8"), Value::Byte(b)) => Ok(CArg::U8(b)),
+        (ArgKind::Num("u8"), Value::Integer(i)) => {
+            if !(0..=255).contains(&i) {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} but \"u8\" only holds 0..=255",
+                    index, i
+                ))));
+            }
+            Ok(CArg::U8(i as u8))
+        }
+        (ArgKind::Num("i16"), Value::Integer(i)) => {
+            if !(i16::MIN as i64..=i16::MAX as i64).contains(&i) {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} but \"i16\" only holds {}..={}",
+                    index,
+                    i,
+                    i16::MIN,
+                    i16::MAX
+                ))));
+            }
+            Ok(CArg::I16(i as i16))
+        }
         (ArgKind::Num(t), other) => Err(verr!(vs!(format!(
             "call: arg {} declared as \"{}\" but got {}",
             index,

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -1,5 +1,6 @@
 use libffi::middle::{Arg, Cif, CodePtr, Type, arg};
 use libloading::Symbol;
+use rl_ast::statements::TypeAnnotation;
 
 use crate::{
     evaluator::Evaluator,
@@ -167,6 +168,33 @@ pub fn func(
             "f64" => vf!(cif.call::<f64>(code_ptr, &ffi_args)),
             _ => unreachable!("ret_type validated by parse_ret_type above"),
         }
+    };
+
+    // Read back any `str` buffers C may have written into, in the order
+    // their args appeared`.
+    let mutated_strs: Vec<Value> = c_args
+        .iter()
+        .filter_map(|c| match c {
+            CArg::Str { buf, .. } => {
+                let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+                Some(Value::String(
+                    String::from_utf8_lossy(&buf[..end]).into_owned(),
+                ))
+            }
+            _ => None,
+        })
+        .collect();
+
+    if mutated_strs.is_empty() {
+        vok!(ret_value)
+    } else {
+        vok!(Value::Tuple(vec![
+            ret_value,
+            Value::Values {
+                items_type: TypeAnnotation::String,
+                items: mutated_strs,
+            },
+        ]))
     }
 }
 

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -67,10 +67,10 @@ pub fn func(
     };
 
     let arg_values: Vec<Value> = match args {
-        Value::Values { items, .. } => items,
+        Value::Tuple(items) => items,
         other => {
             return verr!(vs!(format!(
-                "call: expected an array of args, found {}",
+                "call: expected a tuple of args (e.g. (\"hello\", 16)), found {}",
                 other.type_name()
             )));
         }

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -90,30 +90,34 @@ pub fn func(
         )));
     }
 
+    let mut arg_kinds: Vec<ArgKind> = Vec::with_capacity(arg_type_names.len());
+    for type_name in &arg_type_names {
+        match parse_arg_kind(type_name) {
+            Ok(k) => arg_kinds.push(k),
+            Err(e) => return e,
+        }
+    }
+
+    let ret_ffi_type = match parse_ret_type(&ret_type) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+
     let mut c_args: Vec<CArg> = Vec::with_capacity(arg_values.len());
-    for (i, (value, type_name)) in arg_values.into_iter().zip(&arg_type_names).enumerate() {
-        match value_to_carg(value, type_name, i) {
+    for (i, (value, kind)) in arg_values.into_iter().zip(&arg_kinds).enumerate() {
+        match value_to_carg(value, kind, i) {
             Ok(c_arg) => c_args.push(c_arg),
             Err(e) => return e,
         }
     }
 
-    let mut arg_ffi_types: Vec<Type> = Vec::with_capacity(arg_type_names.len());
-    for type_name in &arg_type_names {
-        match parse_type(type_name, "arg") {
-            Ok(t) => arg_ffi_types.push(t),
-            Err(e) => return e,
-        }
-    }
-
-    let ret_ffi_type = if ret_type == "void" {
-        Type::void()
-    } else {
-        match parse_type(&ret_type, "return") {
-            Ok(t) => t,
-            Err(e) => return e,
-        }
-    };
+    let arg_ffi_types: Vec<Type> = arg_kinds
+        .iter()
+        .map(|k| match k {
+            ArgKind::Num(name) => numeric_ffi_type(name),
+            ArgKind::Str(_) => Type::pointer(),
+        })
+        .collect();
 
     let CHandle::Library(lib) = match eval.c_handles.get(&handle_id) {
         Some(h) => h,
@@ -127,6 +131,7 @@ pub fn func(
             CArg::I64(v) => arg(v),
             CArg::F32(v) => arg(v),
             CArg::F64(v) => arg(v),
+            CArg::Str { ptr, .. } => arg(ptr),
         })
         .collect();
 
@@ -134,9 +139,12 @@ pub fn func(
 
     // SAFETY: `cif`'s arg/return types come directly from `arg_types`/`ret_type`
     // as declared by the caller. If those don't match the real C function's
-    // signature, this is UB - same contract as any FFI call. Getting the
-    // symbol itself (`lib.get`) is also unsafe per `libloading`'s contract.
-    unsafe {
+    // signature, this is UB - same contract as any FFI call. For `str` args,
+    // the buffer is sized to the declared capacity and C is trusted to
+    // respect it (there's no way to enforce that from the caller's side -
+    // same as passing any buffer+length pair to C in C itself). Getting the
+    // symbol (`lib.get`) is also unsafe per `libloading`'s contract.
+    let ret_value: Value = unsafe {
         let sym: Symbol<unsafe extern "C" fn()> = match lib.get(fn_name.as_bytes()) {
             Ok(s) => s,
             Err(e) => {

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -162,31 +162,95 @@ pub fn func(
     }
 }
 
-fn parse_type(name: &str, context: &str) -> Result<Type, Value> {
+fn parse_arg_kind(name: &str) -> Result<ArgKind, Value> {
     match name {
-        "i32" => Ok(Type::i32()),
-        "i64" => Ok(Type::i64()),
-        "f32" => Ok(Type::f32()),
-        "f64" => Ok(Type::f64()),
+        "i32" | "i64" | "f32" | "f64" => Ok(ArgKind::Num(match name {
+            "i32" => "i32",
+            "i64" => "i64",
+            "f32" => "f32",
+            _ => "f64",
+        })),
+        _ if name.starts_with("str:") => {
+            let cap: usize = name["str:".len()..].parse().map_err(|_| {
+                verr!(vs!(format!(
+                    "call: invalid str capacity in \"{}\" (expected e.g. \"str:64\")",
+                    name
+                )))
+            })?;
+            if cap == 0 {
+                return Err(verr!(vs!(format!(
+                    "call: str capacity in \"{}\" must be at least 1",
+                    name
+                ))));
+            }
+            Ok(ArgKind::Str(cap))
+        }
+        "str" => Err(verr!(vs!(
+            "call: \"str\" needs an explicit capacity, e.g. \"str:64\" - \
+             there's no safe default to write past"
+                .to_string()
+        ))),
         other => Err(verr!(vs!(format!(
-            "call: unsupported {} type \"{}\" (supported: i32, i64, f32, f64)",
-            context, other
+            "call: unsupported arg type \"{}\" (supported: i32, i64, f32, f64, str:N)",
+            other
         )))),
     }
 }
 
-fn value_to_carg(value: Value, type_name: &str, index: usize) -> Result<CArg, Value> {
-    match (type_name, &value) {
-        ("i32", Value::Integer(i)) => Ok(CArg::I32(*i as i32)),
-        ("i32", Value::Byte(b)) => Ok(CArg::I32(*b as i32)),
-        ("i64", Value::Integer(i)) => Ok(CArg::I64(*i)),
-        ("i64", Value::Byte(b)) => Ok(CArg::I64(*b as i64)),
-        ("f32", Value::Float(f)) => Ok(CArg::F32(*f as f32)),
-        ("f64", Value::Float(f)) => Ok(CArg::F64(*f)),
-        (t, other) => Err(verr!(vs!(format!(
+fn numeric_ffi_type(name: &str) -> Type {
+    match name {
+        "i32" => Type::i32(),
+        "i64" => Type::i64(),
+        "f32" => Type::f32(),
+        _ => Type::f64(),
+    }
+}
+
+fn parse_ret_type(name: &str) -> Result<Type, Value> {
+    match name {
+        "void" => Ok(Type::void()),
+        "i32" | "i64" | "f32" | "f64" => Ok(numeric_ffi_type(name)),
+        other => Err(verr!(vs!(format!(
+            "call: unsupported return type \"{}\" (supported: i32, i64, f32, f64, void - \
+             no \"str\" return: an unmanaged C string's ownership can't be known safely)",
+            other
+        )))),
+    }
+}
+
+fn value_to_carg(value: Value, kind: &ArgKind, index: usize) -> Result<CArg, Value> {
+    match (kind, value) {
+        (ArgKind::Num("i32"), Value::Integer(i)) => Ok(CArg::I32(i as i32)),
+        (ArgKind::Num("i32"), Value::Byte(b)) => Ok(CArg::I32(b as i32)),
+        (ArgKind::Num("i64"), Value::Integer(i)) => Ok(CArg::I64(i)),
+        (ArgKind::Num("i64"), Value::Byte(b)) => Ok(CArg::I64(b as i64)),
+        (ArgKind::Num("f32"), Value::Float(f)) => Ok(CArg::F32(f as f32)),
+        (ArgKind::Num("f64"), Value::Float(f)) => Ok(CArg::F64(f)),
+        (ArgKind::Num(t), other) => Err(verr!(vs!(format!(
             "call: arg {} declared as \"{}\" but got {}",
             index,
             t,
+            other.type_name()
+        )))),
+        (ArgKind::Str(cap), Value::String(s)) => {
+            let cap = *cap;
+            if s.len() >= cap {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} byte(s) but its str buffer capacity is only {} \
+                     (need room for a null terminator - raise the \"str:N\")",
+                    index,
+                    s.len(),
+                    cap
+                ))));
+            }
+            let mut buf = vec![0u8; cap];
+            buf[..s.len()].copy_from_slice(s.as_bytes());
+            let ptr = buf.as_mut_ptr();
+            Ok(CArg::Str { buf, ptr })
+        }
+        (ArgKind::Str(_), other) => Err(verr!(vs!(format!(
+            "call: arg {} declared as str but got {}",
+            index,
             other.type_name()
         )))),
     }

--- a/crates/rl-interpreter/src/stdlib/c/load.rs
+++ b/crates/rl-interpreter/src/stdlib/c/load.rs
@@ -1,0 +1,29 @@
+use crate::{
+    evaluator::Evaluator,
+    stdlib::{
+        c::{CHandle, common::insert_handle},
+        common::{extract_string, verr, vi, vok, vs},
+    },
+    values::Value,
+};
+
+pub fn func(eval: &mut Evaluator, path: Value) -> Value {
+    let path = match extract_string(path, "load") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("load: {}", e))),
+    };
+
+    // SAFETY: loading a library the caller pointed us at by path. Its static
+    // initializers (if any) run here, same as `compile`'s load step and same
+    // as `dlopen` in C itself - this is inherently trusting whatever code is
+    // at that path, not something a Rust-side check can make "safe".
+    let lib = match unsafe { libloading::Library::new(&path) } {
+        Ok(l) => l,
+        Err(e) => {
+            return verr!(vs!(format!("load: failed to load \"{}\": {}", path, e)));
+        }
+    };
+
+    let id = insert_handle(eval, CHandle::Library(lib));
+    vok!(vi!(id))
+}

--- a/crates/rl-interpreter/src/stdlib/c/mod.rs
+++ b/crates/rl-interpreter/src/stdlib/c/mod.rs
@@ -1,4 +1,4 @@
-//! `std::c` - compile C source with the system compiler and call into it.
+//! `std::c` - compile C source with the system compiler or load library and call into it.
 
 use crate::native::Module;
 use libloading::Library;
@@ -7,6 +7,7 @@ mod call;
 mod close;
 mod common;
 mod compile;
+mod load;
 
 pub use rl_commons::keywords::c::KEYWORDS;
 
@@ -18,6 +19,7 @@ pub enum CHandle {
 pub fn module() -> Module {
     Module::new("c")
         .with_function("compile", compile::func)
+        .with_function("load", load::func)
         .with_function("call", call::func)
         .with_function("close", close::func)
 }

--- a/crates/rl-vm/Cargo.toml
+++ b/crates/rl-vm/Cargo.toml
@@ -12,3 +12,5 @@ rl-ast.workspace = true
 rl-lexer.workspace = true
 rl-utils.workspace = true
 zstd.workspace = true
+libloading.workspace = true
+libffi.workspace = true

--- a/crates/rl-vm/src/stdlib/c/call.rs
+++ b/crates/rl-vm/src/stdlib/c/call.rs
@@ -1,0 +1,527 @@
+use libffi::middle::{Arg, Cif, CodePtr, Type, arg};
+use libloading::Symbol;
+use std::rc::Rc;
+
+use crate::{
+    Vm,
+    stdlib::{
+        c::CHandle,
+        common::{extract_number, extract_string},
+        macros::{vb, vby, verr, vf, vi, vnl, vok, vs},
+    },
+    values::VmValue,
+};
+
+/// The element type of an `"arr:TYPE:N"` arg.
+#[derive(Clone, Copy)]
+enum ArrElem {
+    I32,
+    I64,
+    F32,
+    F64,
+    U8,
+    I16,
+}
+
+impl ArrElem {
+    fn parse(name: &str) -> Option<Self> {
+        Some(match name {
+            "i32" => ArrElem::I32,
+            "i64" => ArrElem::I64,
+            "f32" => ArrElem::F32,
+            "f64" => ArrElem::F64,
+            "u8" => ArrElem::U8,
+            "i16" => ArrElem::I16,
+            _ => return None,
+        })
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            ArrElem::I32 => "i32",
+            ArrElem::I64 => "i64",
+            ArrElem::F32 => "f32",
+            ArrElem::F64 => "f64",
+            ArrElem::U8 => "u8",
+            ArrElem::I16 => "i16",
+        }
+    }
+}
+
+/// One argument's value, converted from its rl-lang `VmValue` into the exact
+/// Rust representation its declared C type requires. Kept as an owned value
+/// (rather than immediately building an `Arg`) so it has somewhere to live
+/// while the `Arg`s that borrow from it are assembled and passed to `Cif::call`.
+enum CArg {
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+    Bool(u8),
+    U8(u8),
+    I16(i16),
+    Str { buf: Vec<u8>, ptr: *mut u8 },
+    ArrI32 { buf: Vec<i32>, ptr: *mut u8 },
+    ArrI64 { buf: Vec<i64>, ptr: *mut u8 },
+    ArrF32 { buf: Vec<f32>, ptr: *mut u8 },
+    ArrF64 { buf: Vec<f64>, ptr: *mut u8 },
+    ArrU8 { buf: Vec<u8>, ptr: *mut u8 },
+    ArrI16 { buf: Vec<i16>, ptr: *mut u8 },
+}
+
+/// A parsed `arg_types` entry.
+enum ArgKind {
+    Num(&'static str),
+    Str(usize),
+    Arr(ArrElem, usize),
+}
+
+pub fn std_call(
+    vm: &mut Vm,
+    handle: VmValue,
+    fn_name: VmValue,
+    args: VmValue,
+    arg_types: VmValue,
+    ret_type: VmValue,
+) -> VmValue {
+    let handle_id = match extract_number(handle, "call") {
+        Ok(n) => n as i64,
+        Err(e) => return verr!(vs!(format!("call: {}", e))),
+    };
+    let fn_name = match extract_string(fn_name, "call") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("call: {}", e))),
+    };
+    let ret_type = match extract_string(ret_type, "call") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("call: {}", e))),
+    };
+
+    let arg_type_names: Vec<String> = match arg_types {
+        VmValue::Arr(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                match item {
+                    VmValue::Str(s) => out.push(s.to_string()),
+                    other => {
+                        return verr!(vs!(format!(
+                            "call: arg_types must be an array of string, found {}",
+                            other.type_name()
+                        )));
+                    }
+                }
+            }
+            out
+        }
+        other => {
+            return verr!(vs!(format!(
+                "call: expected an array of string for arg_types, found {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    let arg_values: Vec<VmValue> = match args {
+        VmValue::Tuple(items) => (*items).clone(),
+        other => {
+            return verr!(vs!(format!(
+                "call: expected a tuple of args (e.g. (\"hello\", 16)), found {}",
+                other.type_name()
+            )));
+        }
+    };
+
+    if arg_values.len() != arg_type_names.len() {
+        return verr!(vs!(format!(
+            "call: {} arg(s) but {} arg_type(s) given",
+            arg_values.len(),
+            arg_type_names.len()
+        )));
+    }
+
+    let mut arg_kinds: Vec<ArgKind> = Vec::with_capacity(arg_type_names.len());
+    for type_name in &arg_type_names {
+        match parse_arg_kind(type_name) {
+            Ok(k) => arg_kinds.push(k),
+            Err(e) => return e,
+        }
+    }
+
+    let ret_ffi_type = match parse_ret_type(&ret_type) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
+
+    let mut c_args: Vec<CArg> = Vec::with_capacity(arg_values.len());
+    for (i, (value, kind)) in arg_values.into_iter().zip(&arg_kinds).enumerate() {
+        match value_to_carg(value, kind, i) {
+            Ok(c_arg) => c_args.push(c_arg),
+            Err(e) => return e,
+        }
+    }
+
+    let arg_ffi_types: Vec<Type> = arg_kinds
+        .iter()
+        .map(|k| match k {
+            ArgKind::Num(name) => numeric_ffi_type(name),
+            ArgKind::Str(_) | ArgKind::Arr(_, _) => Type::pointer(),
+        })
+        .collect();
+
+    let CHandle::Library(lib) = match vm.c_handles.get(&handle_id) {
+        Some(h) => h,
+        None => return verr!(vs!(format!("call: unknown handle {}", handle_id))),
+    };
+
+    let ffi_args: Vec<Arg> = c_args
+        .iter()
+        .map(|c| match c {
+            CArg::I32(v) => arg(v),
+            CArg::I64(v) => arg(v),
+            CArg::F32(v) => arg(v),
+            CArg::F64(v) => arg(v),
+            CArg::Bool(v) => arg(v),
+            CArg::U8(v) => arg(v),
+            CArg::I16(v) => arg(v),
+            CArg::Str { ptr, .. } => arg(ptr),
+            CArg::ArrI32 { ptr, .. } => arg(ptr),
+            CArg::ArrI64 { ptr, .. } => arg(ptr),
+            CArg::ArrF32 { ptr, .. } => arg(ptr),
+            CArg::ArrF64 { ptr, .. } => arg(ptr),
+            CArg::ArrU8 { ptr, .. } => arg(ptr),
+            CArg::ArrI16 { ptr, .. } => arg(ptr),
+        })
+        .collect();
+
+    let cif = Cif::new(arg_ffi_types, ret_ffi_type);
+
+    // SAFETY: `cif`'s arg/return types come directly from `arg_types`/`ret_type`
+    // as declared by the caller. If those don't match the real C function's
+    // signature, this is UB - same contract as any FFI call. For `str`/`arr`
+    // args, the buffer is sized to the declared capacity/count and C is
+    // trusted to respect it (there's no way to enforce that from the
+    // caller's side - same as passing any buffer+length pair to C in C
+    // itself). Getting the symbol (`lib.get`) is also unsafe per
+    // `libloading`'s contract.
+    let ret_value: VmValue = unsafe {
+        let sym: Symbol<'_, unsafe extern "C" fn()> = match lib.get(fn_name.as_bytes()) {
+            Ok(s) => s,
+            Err(e) => {
+                return verr!(vs!(format!(
+                    "call: symbol \"{}\" not found: {}",
+                    fn_name, e
+                )));
+            }
+        };
+        let code_ptr = CodePtr::from_fun(*sym);
+
+        match ret_type.as_str() {
+            "void" => {
+                let _: () = cif.call(code_ptr, &ffi_args);
+                vnl!()
+            }
+            "i32" => vi!(cif.call::<i32>(code_ptr, &ffi_args) as i64),
+            "i64" => vi!(cif.call::<i64>(code_ptr, &ffi_args)),
+            "f32" => vf!(cif.call::<f32>(code_ptr, &ffi_args) as f64),
+            "f64" => vf!(cif.call::<f64>(code_ptr, &ffi_args)),
+            "bool" => vb!(cif.call::<u8>(code_ptr, &ffi_args) != 0),
+            "u8" => vby!(cif.call::<u8>(code_ptr, &ffi_args)),
+            "i16" => vi!(cif.call::<i16>(code_ptr, &ffi_args) as i64),
+            _ => unreachable!("ret_type validated by parse_ret_type above"),
+        }
+    };
+
+    // Read back any `str`/`arr` buffers C may have written into, in the
+    // order their args appeared - this is the only "mutation" that crosses
+    // back into rl-lang, and only because the caller explicitly opted an
+    // arg into it via `"str:N"`/`"arr:TYPE:N"`.
+    let mutated_outs: Vec<VmValue> = c_args
+        .into_iter()
+        .filter_map(|c| match c {
+            CArg::Str { buf, .. } => {
+                let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+                Some(vs!(String::from_utf8_lossy(&buf[..end]).into_owned()))
+            }
+            CArg::ArrI32 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(|v| VmValue::Int(v as i64)).collect(),
+            ))),
+            CArg::ArrI64 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(VmValue::Int).collect(),
+            ))),
+            CArg::ArrI16 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(|v| VmValue::Int(v as i64)).collect(),
+            ))),
+            CArg::ArrU8 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(VmValue::Byte).collect(),
+            ))),
+            CArg::ArrF32 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(|v| VmValue::Float(v as f64)).collect(),
+            ))),
+            CArg::ArrF64 { buf, .. } => Some(VmValue::Arr(Rc::new(
+                buf.into_iter().map(VmValue::Float).collect(),
+            ))),
+            _ => None,
+        })
+        .collect();
+
+    if mutated_outs.is_empty() {
+        vok!(ret_value)
+    } else {
+        vok!(VmValue::Tuple(Rc::new(vec![
+            ret_value,
+            VmValue::Tuple(Rc::new(mutated_outs)),
+        ])))
+    }
+}
+
+fn parse_arg_kind(name: &str) -> Result<ArgKind, VmValue> {
+    match name {
+        "i32" | "i64" | "f32" | "f64" | "bool" | "u8" | "i16" => Ok(ArgKind::Num(match name {
+            "i32" => "i32",
+            "i64" => "i64",
+            "f32" => "f32",
+            "f64" => "f64",
+            "bool" => "bool",
+            "u8" => "u8",
+            _ => "i16",
+        })),
+        _ if name.starts_with("str:") => {
+            let cap: usize = name["str:".len()..].parse().map_err(|_| {
+                verr!(vs!(format!(
+                    "call: invalid str capacity in \"{}\" (expected e.g. \"str:64\")",
+                    name
+                )))
+            })?;
+            if cap == 0 {
+                return Err(verr!(vs!(format!(
+                    "call: str capacity in \"{}\" must be at least 1",
+                    name
+                ))));
+            }
+            Ok(ArgKind::Str(cap))
+        }
+        "str" => Err(verr!(vs!(
+            "call: \"str\" needs an explicit capacity, e.g. \"str:64\" - \
+             there's no safe default to write past"
+                .to_string()
+        ))),
+        _ if name.starts_with("arr:") => {
+            let rest = &name["arr:".len()..];
+            let (elem_name, count_str) = rest.split_once(':').ok_or_else(|| {
+                verr!(vs!(format!(
+                    "call: invalid arr type \"{}\" (expected e.g. \"arr:i32:8\")",
+                    name
+                )))
+            })?;
+            let elem = ArrElem::parse(elem_name).ok_or_else(|| {
+                verr!(vs!(format!(
+                    "call: unsupported arr element type \"{}\" in \"{}\" \
+                     (supported: i32, i64, f32, f64, u8, i16)",
+                    elem_name, name
+                )))
+            })?;
+            let count: usize = count_str.parse().map_err(|_| {
+                verr!(vs!(format!(
+                    "call: invalid arr element count in \"{}\" (expected e.g. \"arr:i32:8\")",
+                    name
+                )))
+            })?;
+            if count == 0 {
+                return Err(verr!(vs!(format!(
+                    "call: arr element count in \"{}\" must be at least 1",
+                    name
+                ))));
+            }
+            Ok(ArgKind::Arr(elem, count))
+        }
+        other => Err(verr!(vs!(format!(
+            "call: unsupported arg type \"{}\" \
+             (supported: i32, i64, i16, u8, f32, f64, bool, str:N, arr:TYPE:N)",
+            other
+        )))),
+    }
+}
+
+fn numeric_ffi_type(name: &str) -> Type {
+    match name {
+        "i32" => Type::i32(),
+        "i64" => Type::i64(),
+        "f32" => Type::f32(),
+        "f64" => Type::f64(),
+        "i16" => Type::i16(),
+        "u8" | "bool" => Type::u8(),
+        other => unreachable!(
+            "numeric_ffi_type called with unvalidated name \"{}\"",
+            other
+        ),
+    }
+}
+
+fn parse_ret_type(name: &str) -> Result<Type, VmValue> {
+    match name {
+        "void" => Ok(Type::void()),
+        "i32" | "i64" | "i16" | "u8" | "f32" | "f64" | "bool" => Ok(numeric_ffi_type(name)),
+        other => Err(verr!(vs!(format!(
+            "call: unsupported return type \"{}\" (supported: i32, i64, i16, u8, f32, f64, bool, \
+             void - no \"str\"/\"arr\" return: unmanaged C memory's ownership can't be known safely)",
+            other
+        )))),
+    }
+}
+
+fn arr_value_to_carg(
+    value: VmValue,
+    elem: ArrElem,
+    count: usize,
+    index: usize,
+) -> Result<CArg, VmValue> {
+    let items: Vec<VmValue> = match value {
+        VmValue::Arr(items) => (*items).clone(),
+        other => {
+            return Err(verr!(vs!(format!(
+                "call: arg {} declared as arr:{}:{} but got {}",
+                index,
+                elem.name(),
+                count,
+                other.type_name()
+            ))));
+        }
+    };
+    if items.len() != count {
+        return Err(verr!(vs!(format!(
+            "call: arg {} is arr:{}:{} but the array has {} element(s), not {}",
+            index,
+            elem.name(),
+            count,
+            items.len(),
+            count
+        ))));
+    }
+
+    macro_rules! build_int_buf {
+        ($variant:ident, $ty:ty, $range:expr) => {{
+            let mut buf: Vec<$ty> = Vec::with_capacity(count);
+            for (i, item) in items.into_iter().enumerate() {
+                let v: i64 = match item {
+                    VmValue::Int(n) => n,
+                    VmValue::Byte(b) => b as i64,
+                    other => {
+                        return Err(verr!(vs!(format!(
+                            "call: arg {} element {} declared as {} but got {}",
+                            index,
+                            i,
+                            elem.name(),
+                            other.type_name()
+                        ))));
+                    }
+                };
+                if !$range.contains(&v) {
+                    return Err(verr!(vs!(format!(
+                        "call: arg {} element {} is {} but \"{}\" only holds {:?}",
+                        index,
+                        i,
+                        v,
+                        elem.name(),
+                        $range
+                    ))));
+                }
+                buf.push(v as $ty);
+            }
+            let ptr = buf.as_mut_ptr() as *mut u8;
+            Ok(CArg::$variant { buf, ptr })
+        }};
+    }
+
+    macro_rules! build_float_buf {
+        ($variant:ident, $ty:ty) => {{
+            let mut buf: Vec<$ty> = Vec::with_capacity(count);
+            for (i, item) in items.into_iter().enumerate() {
+                match item {
+                    VmValue::Float(f) => buf.push(f as $ty),
+                    other => {
+                        return Err(verr!(vs!(format!(
+                            "call: arg {} element {} declared as {} but got {}",
+                            index,
+                            i,
+                            elem.name(),
+                            other.type_name()
+                        ))));
+                    }
+                }
+            }
+            let ptr = buf.as_mut_ptr() as *mut u8;
+            Ok(CArg::$variant { buf, ptr })
+        }};
+    }
+
+    match elem {
+        ArrElem::I32 => build_int_buf!(ArrI32, i32, (i32::MIN as i64..=i32::MAX as i64)),
+        ArrElem::I64 => build_int_buf!(ArrI64, i64, (i64::MIN..=i64::MAX)),
+        ArrElem::I16 => build_int_buf!(ArrI16, i16, (i16::MIN as i64..=i16::MAX as i64)),
+        ArrElem::U8 => build_int_buf!(ArrU8, u8, (0i64..=255)),
+        ArrElem::F32 => build_float_buf!(ArrF32, f32),
+        ArrElem::F64 => build_float_buf!(ArrF64, f64),
+    }
+}
+
+fn value_to_carg(value: VmValue, kind: &ArgKind, index: usize) -> Result<CArg, VmValue> {
+    match (kind, value) {
+        (ArgKind::Num("i32"), VmValue::Int(i)) => Ok(CArg::I32(i as i32)),
+        (ArgKind::Num("i32"), VmValue::Byte(b)) => Ok(CArg::I32(b as i32)),
+        (ArgKind::Num("i64"), VmValue::Int(i)) => Ok(CArg::I64(i)),
+        (ArgKind::Num("i64"), VmValue::Byte(b)) => Ok(CArg::I64(b as i64)),
+        (ArgKind::Num("f32"), VmValue::Float(f)) => Ok(CArg::F32(f as f32)),
+        (ArgKind::Num("f64"), VmValue::Float(f)) => Ok(CArg::F64(f)),
+        (ArgKind::Num("bool"), VmValue::Bool(b)) => Ok(CArg::Bool(u8::from(b))),
+        (ArgKind::Num("u8"), VmValue::Byte(b)) => Ok(CArg::U8(b)),
+        (ArgKind::Num("u8"), VmValue::Int(i)) => {
+            if !(0..=255).contains(&i) {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} but \"u8\" only holds 0..=255",
+                    index, i
+                ))));
+            }
+            Ok(CArg::U8(i as u8))
+        }
+        (ArgKind::Num("i16"), VmValue::Int(i)) => {
+            if !(i16::MIN as i64..=i16::MAX as i64).contains(&i) {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} but \"i16\" only holds {}..={}",
+                    index,
+                    i,
+                    i16::MIN,
+                    i16::MAX
+                ))));
+            }
+            Ok(CArg::I16(i as i16))
+        }
+        (ArgKind::Num(t), other) => Err(verr!(vs!(format!(
+            "call: arg {} declared as \"{}\" but got {}",
+            index,
+            t,
+            other.type_name()
+        )))),
+        (ArgKind::Str(cap), VmValue::Str(s)) => {
+            let cap = *cap;
+            if s.len() >= cap {
+                return Err(verr!(vs!(format!(
+                    "call: arg {} is {} byte(s) but its str buffer capacity is only {} \
+                     (need room for a null terminator - raise the \"str:N\")",
+                    index,
+                    s.len(),
+                    cap
+                ))));
+            }
+            let mut buf = vec![0u8; cap];
+            buf[..s.len()].copy_from_slice(s.as_bytes());
+            let ptr = buf.as_mut_ptr();
+            Ok(CArg::Str { buf, ptr })
+        }
+        (ArgKind::Str(_), other) => Err(verr!(vs!(format!(
+            "call: arg {} declared as str but got {}",
+            index,
+            other.type_name()
+        )))),
+        (ArgKind::Arr(elem, count), value) => arr_value_to_carg(value, *elem, *count, index),
+    }
+}

--- a/crates/rl-vm/src/stdlib/c/close.rs
+++ b/crates/rl-vm/src/stdlib/c/close.rs
@@ -1,0 +1,20 @@
+use crate::{
+    Vm,
+    stdlib::{
+        common::extract_number,
+        macros::{verr, vnl, vok, vs},
+    },
+    values::VmValue,
+};
+
+pub fn std_close(vm: &mut Vm, handle: VmValue) -> VmValue {
+    let handle_id = match extract_number(handle, "close") {
+        Ok(n) => n as i64,
+        Err(e) => return verr!(vs!(format!("close: {}", e))),
+    };
+
+    match vm.c_handles.remove(&handle_id) {
+        Some(_) => vok!(vnl!()),
+        None => verr!(vs!(format!("close: unknown handle {}", handle_id))),
+    }
+}

--- a/crates/rl-vm/src/stdlib/c/common.rs
+++ b/crates/rl-vm/src/stdlib/c/common.rs
@@ -1,0 +1,10 @@
+use crate::Vm;
+use crate::stdlib::c::CHandle;
+
+/// Registers a new handle and returns its id.
+pub fn insert_handle(vm: &mut Vm, handle: CHandle) -> i64 {
+    let id = vm.c_next_handle;
+    vm.c_next_handle += 1;
+    vm.c_handles.insert(id, handle);
+    id
+}

--- a/crates/rl-vm/src/stdlib/c/compile.rs
+++ b/crates/rl-vm/src/stdlib/c/compile.rs
@@ -1,0 +1,118 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::{
+    Vm,
+    stdlib::{
+        c::{CHandle, common::insert_handle},
+        common::extract_string,
+        macros::{verr, vi, vok, vs},
+    },
+    values::VmValue,
+};
+
+#[cfg(target_os = "windows")]
+const SHARED_LIB_EXT: &str = "dll";
+#[cfg(target_os = "macos")]
+const SHARED_LIB_EXT: &str = "dylib";
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+const SHARED_LIB_EXT: &str = "so";
+
+/// Builds the compiler invocation for turning `src` into `out` on this platform.
+/// macOS wants `-dynamiclib`; everything else (incl. mingw-w64 `cc`/`gcc` on
+/// Windows) accepts `-shared -fPIC`. Native MSVC (`cl.exe`) is not supported.
+fn compiler_command(compiler: &str, src: &PathBuf, out: &PathBuf) -> Command {
+    let mut cmd = Command::new(compiler);
+    #[cfg(target_os = "macos")]
+    {
+        cmd.args(["-dynamiclib", "-O2", "-o"]).arg(out).arg(src);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        cmd.args(["-shared", "-fPIC", "-O2", "-o"])
+            .arg(out)
+            .arg(src);
+    }
+    cmd
+}
+
+fn find_compiler() -> String {
+    std::env::var("CC").unwrap_or_else(|_| "cc".to_string())
+}
+
+fn cache_dir() -> PathBuf {
+    std::env::temp_dir().join("rl_std_c_cache")
+}
+
+pub fn std_compile(vm: &mut Vm, source: VmValue) -> VmValue {
+    let source = match extract_string(source, "compile") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("compile: {}", e))),
+    };
+
+    let mut hasher = DefaultHasher::new();
+    source.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let dir = cache_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        return verr!(vs!(format!(
+            "compile: failed to create cache dir {}: {}",
+            dir.display(),
+            e
+        )));
+    }
+
+    let src_path = dir.join(format!("{:016x}.c", hash));
+    let out_path = dir.join(format!("{:016x}.{}", hash, SHARED_LIB_EXT));
+
+    // Cache hit: skip both writing the source and recompiling.
+    if !out_path.exists() {
+        if let Err(e) = std::fs::write(&src_path, &source) {
+            return verr!(vs!(format!(
+                "compile: failed to write {}: {}",
+                src_path.display(),
+                e
+            )));
+        }
+
+        let compiler = find_compiler();
+        let output = compiler_command(&compiler, &src_path, &out_path).output();
+
+        match output {
+            Ok(o) if o.status.success() => {}
+            Ok(o) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                return verr!(vs!(format!(
+                    "compile: `{}` failed:\n{}",
+                    compiler,
+                    stderr.trim_end()
+                )));
+            }
+            Err(e) => {
+                return verr!(vs!(format!(
+                    "compile: couldn't run `{}` (set $CC to point at a C compiler if it's not on $PATH): {}",
+                    compiler, e
+                )));
+            }
+        }
+    }
+
+    // SAFETY: loading the shared library we just compiled from a fixed cache
+    // path. The library's static initializers (if any) run here.
+    let lib = match unsafe { libloading::Library::new(&out_path) } {
+        Ok(l) => l,
+        Err(e) => {
+            return verr!(vs!(format!(
+                "compile: failed to load compiled library {}: {}",
+                out_path.display(),
+                e
+            )));
+        }
+    };
+
+    let id = insert_handle(vm, CHandle::Library(lib));
+    vok!(vi!(id))
+}

--- a/crates/rl-vm/src/stdlib/c/load.rs
+++ b/crates/rl-vm/src/stdlib/c/load.rs
@@ -1,0 +1,30 @@
+use crate::{
+    Vm,
+    stdlib::{
+        c::{CHandle, common::insert_handle},
+        common::extract_string,
+        macros::{verr, vi, vok, vs},
+    },
+    values::VmValue,
+};
+
+pub fn std_load(vm: &mut Vm, path: VmValue) -> VmValue {
+    let path = match extract_string(path, "load") {
+        Ok(s) => s,
+        Err(e) => return verr!(vs!(format!("load: {}", e))),
+    };
+
+    // SAFETY: loading a library the caller pointed us at by path. Its static
+    // initializers (if any) run here, same as `compile`'s load step and same
+    // as `dlopen` in C itself - this is inherently trusting whatever code is
+    // at that path, not something a Rust-side check can make "safe".
+    let lib = match unsafe { libloading::Library::new(&path) } {
+        Ok(l) => l,
+        Err(e) => {
+            return verr!(vs!(format!("load: failed to load \"{}\": {}", path, e)));
+        }
+    };
+
+    let id = insert_handle(vm, CHandle::Library(lib));
+    vok!(vi!(id))
+}

--- a/crates/rl-vm/src/stdlib/c/mod.rs
+++ b/crates/rl-vm/src/stdlib/c/mod.rs
@@ -5,6 +5,7 @@ use libloading::Library;
 
 mod close;
 mod common;
+mod compile;
 mod load;
 
 /// A single native C-interop resource, stored behind an `int` handle.
@@ -12,3 +13,9 @@ pub enum CHandle {
     Library(Library),
 }
 
+pub fn module() -> Module {
+    Module::new("c")
+        .with_function("compile", compile::std_compile)
+        .with_function("load", load::std_load)
+        .with_function("close", close::std_close)
+}

--- a/crates/rl-vm/src/stdlib/c/mod.rs
+++ b/crates/rl-vm/src/stdlib/c/mod.rs
@@ -3,6 +3,7 @@
 use crate::native::Module;
 use libloading::Library;
 
+mod call;
 mod close;
 mod common;
 mod compile;
@@ -17,5 +18,6 @@ pub fn module() -> Module {
     Module::new("c")
         .with_function("compile", compile::std_compile)
         .with_function("load", load::std_load)
+        .with_function("call", call::std_call)
         .with_function("close", close::std_close)
 }

--- a/crates/rl-vm/src/stdlib/c/mod.rs
+++ b/crates/rl-vm/src/stdlib/c/mod.rs
@@ -3,6 +3,10 @@
 use crate::native::Module;
 use libloading::Library;
 
+mod close;
+mod common;
+mod load;
+
 /// A single native C-interop resource, stored behind an `int` handle.
 pub enum CHandle {
     Library(Library),

--- a/crates/rl-vm/src/stdlib/c/mod.rs
+++ b/crates/rl-vm/src/stdlib/c/mod.rs
@@ -1,0 +1,10 @@
+//! `std::c` - compile or load a C shared library and call into it.
+
+use crate::native::Module;
+use libloading::Library;
+
+/// A single native C-interop resource, stored behind an `int` handle.
+pub enum CHandle {
+    Library(Library),
+}
+

--- a/crates/rl-vm/src/stdlib/mod.rs
+++ b/crates/rl-vm/src/stdlib/mod.rs
@@ -1,9 +1,9 @@
 //! The VM's standard library - built-in modules registered under `std::*`.
 //!
-//! Only `io` exists so far (`print`/`println`). Everything else in
-//! `rl-interpreter`'s stdlib (math, string, array, fs, ...) hasn't been
-//! ported yet - most of it needs `VmValue` to grow array/tuple/error
-//! variants first.
+//! `io`, `collections`, `array`, and `c` exist so far. Everything else in
+//! `rl-interpreter`'s stdlib (math, string, fs, net, http, process, ...)
+//! hasn't been ported yet - most of it needs `VmValue` to grow more
+//! variants or `FromValue`/`IntoValue` impls first.
 
 mod array;
 pub(crate) mod c;
@@ -22,6 +22,7 @@ pub fn root() -> Module {
         Module::new("std")
             .with_module(io::module())
             .with_module(collections::module())
-            .with_module(array::module()),
+            .with_module(array::module())
+            .with_module(c::module()),
     )
 }

--- a/crates/rl-vm/src/stdlib/mod.rs
+++ b/crates/rl-vm/src/stdlib/mod.rs
@@ -6,6 +6,7 @@
 //! variants first.
 
 mod array;
+pub(crate) mod c;
 mod collections;
 pub mod common;
 mod io;

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -60,6 +60,13 @@ pub struct Vm {
     /// functions, `Record::method(...)`) and `OpCode::LookupMethod`
     /// (instance methods, `value.method(...)`).
     impl_methods: HashMap<String, Rc<VmFunction>>,
+    /// Side-table of native C-interop resources (`std::c`), keyed by handle
+    /// id. `pub(crate)` (unlike every field above) because, unlike every
+    /// other native function so far, `std::c`'s functions need persistent
+    /// state across calls, not just their own arguments - see `stdlib::c`.
+    pub(crate) c_handles: HashMap<i64, crate::stdlib::c::CHandle>,
+    /// Next handle id to hand out for `std::c` resources; only ever increments.
+    pub(crate) c_next_handle: i64,
 }
 
 impl Vm {
@@ -73,6 +80,8 @@ impl Vm {
             source: None,
             line_index: None,
             impl_methods: HashMap::new(),
+            c_handles: HashMap::new(),
+            c_next_handle: 1,
         }
     }
 


### PR DESCRIPTION
## What does this PR do?
Change `std::c::call` to accept `tuple` instead of `arr[T]` for different argument types
Add support for `string` type
Add support for `bool` type
Add support for `i16` and `u8` (`bool`) types
Add support for `arr[T]` for types: `u8`, `i16`, `i32`, `i64`, `f32` and `f64`
Add docs entry for `std::c`
Mirror `std::c` to `rl-vm`