### PR TITLE
Fix/imports

### DIFF
--- a/crates/rl-checker/src/statements/statement.rs
+++ b/crates/rl-checker/src/statements/statement.rs
@@ -871,6 +871,24 @@ impl TypeChecker {
                     self.tags.insert(name.clone(), variants.clone());
                 }
 
+                StatementKind::ImplBlock { record, methods } if wanted(record) => {
+                    for m in methods {
+                        if let StatementKind::FunctionDeclaration {
+                            name,
+                            params,
+                            return_type,
+                            ..
+                        } = &m.kind
+                        {
+                            let fn_type = CheckType::Function {
+                                params: params.iter().map(|p| p.param_type.clone()).collect(),
+                                return_type: return_type.clone(),
+                            };
+                            self.methods.insert((record.clone(), name.clone()), fn_type);
+                        }
+                    }
+                }
+
                 StatementKind::ImportFile { path: nested } => {
                     self.import_module(nested, None, stmt.span);
                 }

--- a/crates/rl-resolver/src/lib.rs
+++ b/crates/rl-resolver/src/lib.rs
@@ -12,7 +12,9 @@
 //! Function and lambda bodies are resolved in their own pushed scope.
 //! Import statements are read from disk, lexed, parsed, and resolved inline.
 
-use rl_ast::Ast;
+use rl_ast::{Ast, statements::Statement};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 mod expressions;
 mod statements;
@@ -24,6 +26,20 @@ pub struct Resolver {
     scopes: Vec<Vec<String>>,
     pub current_dir: std::path::PathBuf,
     pub ast_arena: Ast,
+    /// Canonical paths of files currently being resolved, from the entry
+    /// file down to whatever `get` statement is on the stack right now.
+    /// Guards against `A imports B imports A` recursing forever - each
+    /// `ImportFile`/`ImportFileNamed` pushes its canonical path before
+    /// recursing into the body and pops it after. Reporting the cycle as
+    /// an error is the checker's job; the resolver just needs to not
+    /// blow the stack, so a repeat here silently stops the recursion.
+    importing: HashSet<PathBuf>,
+    /// Caches the merged (parsed + arena-remapped, but not yet slot-resolved)
+    /// statements for each canonical file path, so a module imported from
+    /// several call sites is only read/lexed/parsed/merged once. Each call
+    /// site still clones its own copy and resolves it independently, since
+    /// slot numbers depend on the importing scope, not the file.
+    import_cache: HashMap<PathBuf, Vec<Statement>>,
 }
 
 impl Default for Resolver {
@@ -39,6 +55,8 @@ impl Resolver {
             scopes: vec![vec![]],
             current_dir: std::path::PathBuf::new(),
             ast_arena: Ast::new(),
+            importing: HashSet::new(),
+            import_cache: HashMap::new(),
         }
     }
 

--- a/crates/rl-resolver/src/statements.rs
+++ b/crates/rl-resolver/src/statements.rs
@@ -12,8 +12,16 @@
 //! - `ImportFile` / `ImportFileNamed`: reads the file from disk, lexes, parses,
 //!   and resolves it inline - the result replaces the import statement with
 //!   `ResolvedImportFile { body }` containing the fully resolved statements.
-//!   `ImportFileNamed` additionally filters to only the requested names before resolving.
-//!   Both silently return the original unresolved statement on any IO/parse failure
+//!   `ImportFileNamed` additionally filters to only the requested names before
+//!   resolving (records pull their `ImplBlock` methods along automatically).
+//!   Both silently return the original unresolved statement on any IO/parse
+//!   failure, or if the file is already being resolved further up the import
+//!   chain (an import cycle - `self.importing` guards against this so a
+//!   circular `get` can't blow the stack; reporting it as a real error is
+//!   the checker's job). Parsed files are cached per canonical path in
+//!   `self.import_cache` so a module imported from multiple places is only
+//!   read/lexed/parsed/merged once - each import site still resolves its own
+//!   clone, since slot numbers depend on the importing scope.
 
 use crate::Resolver;
 use rl_ast::{
@@ -36,6 +44,46 @@ impl Resolver {
             .into_iter()
             .map(|statement| self.resolve_statement(statement))
             .collect()
+    }
+
+    /// Resolves `path` (e.g. `["mymodule", "sub"]`) to a `.rl` file relative
+    /// to `self.current_dir`, and returns its canonical path, the directory
+    /// it lives in, and its parsed statements with expression ids already
+    /// remapped into `self.ast_arena`.
+    ///
+    /// The parsed-and-merged statement list is cached per canonical path, so
+    /// importing the same file from several places only reads/lexes/parses/
+    /// merges it once; callers still get their own clone to resolve with
+    /// fresh slots, since slot numbers are specific to the importing scope.
+    ///
+    /// Returns `None` on any IO or parse failure, matching the previous
+    /// behavior of silently falling back to the unresolved import statement.
+    fn load_import_file(
+        &mut self,
+        path: &[String],
+    ) -> Option<(std::path::PathBuf, std::path::PathBuf, Vec<Statement>)> {
+        let import_name = format!("{}.rl", path.join("/"));
+        let file_path = self.current_dir.join(&import_name);
+        let canonical = file_path
+            .canonicalize()
+            .unwrap_or_else(|_| file_path.clone());
+        let imported_dir = file_path
+            .parent()
+            .unwrap_or(std::path::Path::new(""))
+            .to_path_buf();
+
+        if let Some(cached) = self.import_cache.get(&canonical) {
+            return Some((canonical, imported_dir, cached.clone()));
+        }
+
+        let source_text = std::fs::read_to_string(&file_path).ok()?;
+        let source_file = SourceFile::new(file_path.to_string_lossy().as_ref(), source_text);
+        let tokens = Tokenizer::lex(source_file.clone()).ok()?;
+        let (imported_ast, stmts) = Parser::parse(tokens, source_file).ok()?;
+        let stmts = self.ast_arena.merge_statements(imported_ast, stmts);
+
+        self.import_cache.insert(canonical.clone(), stmts.clone());
+        Some((canonical, imported_dir, stmts))
     }
 
     fn resolve_statement(&mut self, stmt: Statement) -> Statement {
@@ -378,29 +426,17 @@ impl Resolver {
             }
 
             StatementKind::ImportFile { path } => {
-                let import_name = format!("{}.rl", path.join("/"));
-                let file_path = self.current_dir.join(&import_name);
-                let Ok(source_text) = std::fs::read_to_string(&file_path) else {
+                let Some((canonical, imported_dir, stmts)) = self.load_import_file(&path) else {
                     return Statement::new(StatementKind::ImportFile { path }, span);
                 };
-                let source_file =
-                    SourceFile::new(file_path.to_string_lossy().as_ref(), source_text);
-                let Ok(tokens) = Tokenizer::lex(source_file.clone()) else {
+                if !self.importing.insert(canonical.clone()) {
                     return Statement::new(StatementKind::ImportFile { path }, span);
-                };
-                let Ok((imported_ast, stmts)) = Parser::parse(tokens, source_file) else {
-                    return Statement::new(StatementKind::ImportFile { path }, span);
-                };
+                }
 
-                let stmts = self.ast_arena.merge_statements(imported_ast, stmts);
-
-                let imported_dir = file_path
-                    .parent()
-                    .unwrap_or(std::path::Path::new(""))
-                    .to_path_buf();
                 let prev_dir = std::mem::replace(&mut self.current_dir, imported_dir);
                 let resolved = self.resolve_statements(stmts);
                 self.current_dir = prev_dir;
+                self.importing.remove(&canonical);
 
                 StatementKind::ResolvedImportFile {
                     path,
@@ -409,19 +445,13 @@ impl Resolver {
             }
 
             StatementKind::ImportFileNamed { path, names } => {
-                let import_name = format!("{}.rl", path.join("/"));
-                let file_path = self.current_dir.join(&import_name);
-                let Ok(source_text) = std::fs::read_to_string(&file_path) else {
+                let Some((canonical, imported_dir, stmts)) = self.load_import_file(&path) else {
                     return Statement::new(StatementKind::ImportFileNamed { path, names }, span);
                 };
-                let source_file =
-                    SourceFile::new(file_path.to_string_lossy().as_ref(), source_text);
-                let Ok(tokens) = Tokenizer::lex(source_file.clone()) else {
+                if !self.importing.insert(canonical.clone()) {
                     return Statement::new(StatementKind::ImportFileNamed { path, names }, span);
-                };
-                let Ok((imported_ast, stmts)) = Parser::parse(tokens, source_file) else {
-                    return Statement::new(StatementKind::ImportFileNamed { path, names }, span);
-                };
+                }
+
                 let stmts: Vec<_> = stmts
                     .into_iter()
                     .filter(|s| match &s.kind {
@@ -436,19 +466,15 @@ impl Resolver {
                         | StatementKind::ConstantSet { name, .. } => names.contains(name),
                         StatementKind::RecordDeclaration { name, .. }
                         | StatementKind::TagDeclaration { name, .. } => names.contains(name),
+                        StatementKind::ImplBlock { record, .. } => names.contains(record),
                         _ => false,
                     })
                     .collect();
 
-                let stmts = self.ast_arena.merge_statements(imported_ast, stmts);
-
-                let imported_dir = file_path
-                    .parent()
-                    .unwrap_or(std::path::Path::new(""))
-                    .to_path_buf();
                 let prev_dir = std::mem::replace(&mut self.current_dir, imported_dir);
                 let body = self.resolve_statements(stmts);
                 self.current_dir = prev_dir;
+                self.importing.remove(&canonical);
 
                 StatementKind::ResolvedImportFile { path, body }
             }


### PR DESCRIPTION
## What does this PR do?
add cycle guard for imports in `resolver` module
correctly register `record`s methods in `checker` module