### PR TITLE
Feat/types/handle

### DIFF
--- a/crates/rl-ast/src/statements.rs
+++ b/crates/rl-ast/src/statements.rs
@@ -27,6 +27,15 @@ pub struct Statement {
     pub span: Span,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HandleKind {
+    C = 0,
+    Net = 1,
+    Http = 2,
+    Audio = 3,
+}
+
 impl Statement {
     pub fn new(kind: StatementKind, span: Span) -> Self {
         Self { kind, span }
@@ -396,6 +405,9 @@ pub enum TypeAnnotation {
 
     Generic(String),
     Callback(Vec<TypeAnnotation>, Box<TypeAnnotation>),
+
+    // ---std-specific---
+    Handle(HandleKind),
 }
 
 /// A single function or lambda parameter: a name and its type annotation.

--- a/crates/rl-checker/src/types.rs
+++ b/crates/rl-checker/src/types.rs
@@ -88,6 +88,7 @@ impl CheckType {
                     || record_matches(a, b)
                     || enum_matches(a, b)
                     || set_matches(a, b)
+                    || handle_matches(a, b)
             }
 
             _ => false,
@@ -132,6 +133,14 @@ fn null_array_elision(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {
         }),
         _ => false,
     }
+}
+
+/// Returns `true` if `a` and `b` are handles from the same module.
+fn handle_matches(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {
+    matches!(
+        (a, b),
+        (TypeAnnotation::Handle(x), TypeAnnotation::Handle(y)) if x == y
+    )
 }
 
 fn null_map_elision(a: &TypeAnnotation, b: &TypeAnnotation) -> bool {

--- a/crates/rl-commons/src/stdlib_signatures/audio.rs
+++ b/crates/rl-commons/src/stdlib_signatures/audio.rs
@@ -2,7 +2,7 @@
 
 use super::{handle, overloads, params, result};
 use crate::{ModuleNames, StdFn};
-use rl_ast::statements::TypeAnnotation as T;
+use rl_ast::statements::{HandleKind, TypeAnnotation as T};
 
 pub fn module() -> ModuleNames {
     ModuleNames::new("audio")
@@ -36,7 +36,10 @@ fn play_file() -> StdFn {
 fn play_file_async() -> StdFn {
     StdFn::typed(
         "play_file_async",
-        vec![(params(vec![T::String]), result(T::Int))],
+        vec![(
+            params(vec![T::String]),
+            result(T::Handle(HandleKind::Audio)),
+        )],
     )
 }
 
@@ -48,70 +51,88 @@ fn beep() -> StdFn {
 }
 
 fn sound_pause() -> StdFn {
-    StdFn::typed("sound_pause", overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        "sound_pause",
+        overloads(vec![handle(HandleKind::Audio)], result(T::Null)),
+    )
 }
 
 fn sound_resume() -> StdFn {
-    StdFn::typed("sound_resume", overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        "sound_resume",
+        overloads(vec![handle(HandleKind::Audio)], result(T::Null)),
+    )
 }
 
 fn sound_stop() -> StdFn {
-    StdFn::typed("sound_stop", overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        "sound_stop",
+        overloads(vec![handle(HandleKind::Audio)], result(T::Null)),
+    )
 }
 
 fn sound_is_paused() -> StdFn {
     StdFn::typed(
         "sound_is_paused",
-        overloads(vec![handle()], result(T::Bool)),
+        overloads(vec![handle(HandleKind::Audio)], result(T::Bool)),
     )
 }
 
 fn sound_set_volume() -> StdFn {
     StdFn::typed(
         "sound_set_volume",
-        overloads(vec![handle(), vec![T::Float]], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Audio), vec![T::Float]],
+            result(T::Null),
+        ),
     )
 }
 
 fn sound_get_volume() -> StdFn {
     StdFn::typed(
         "sound_get_volume",
-        overloads(vec![handle()], result(T::Float)),
+        overloads(vec![handle(HandleKind::Audio)], result(T::Float)),
     )
 }
 
 fn sound_set_speed() -> StdFn {
     StdFn::typed(
         "sound_set_speed",
-        overloads(vec![handle(), vec![T::Float]], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Audio), vec![T::Float]],
+            result(T::Null),
+        ),
     )
 }
 
 fn sound_seek() -> StdFn {
     StdFn::typed(
         "sound_seek",
-        overloads(vec![handle(), vec![T::Int]], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Audio), vec![T::Int]],
+            result(T::Null),
+        ),
     )
 }
 
 fn sound_is_finished() -> StdFn {
     StdFn::typed(
         "sound_is_finished",
-        overloads(vec![handle()], result(T::Bool)),
+        overloads(vec![handle(HandleKind::Audio)], result(T::Bool)),
     )
 }
 
 fn sound_wait() -> StdFn {
-    StdFn::typed("sound_wait", overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        "sound_wait",
+        overloads(vec![handle(HandleKind::Audio)], result(T::Null)),
+    )
 }
 
 fn list_output_devices() -> StdFn {
     StdFn::typed(
         "list_output_devices",
-        vec![(
-            params(vec![]),
-            result(T::Array(Box::new(T::String))),
-        )],
+        vec![(params(vec![]), result(T::Array(Box::new(T::String))))],
     )
 }
 

--- a/crates/rl-commons/src/stdlib_signatures/c.rs
+++ b/crates/rl-commons/src/stdlib_signatures/c.rs
@@ -2,7 +2,7 @@
 
 use super::{fixed, handle, overloads, params, result};
 use crate::{ModuleNames, StdFn};
-use rl_ast::statements::TypeAnnotation as T;
+use rl_ast::statements::{HandleKind, TypeAnnotation as T};
 
 pub fn module() -> ModuleNames {
     ModuleNames::new("c")
@@ -15,11 +15,17 @@ pub fn module() -> ModuleNames {
 }
 
 fn compile() -> StdFn {
-    StdFn::typed("compile", vec![(params(vec![T::String]), result(T::Int))])
+    StdFn::typed(
+        "compile",
+        vec![(params(vec![T::String]), result(T::Handle(HandleKind::C)))],
+    )
 }
 
 fn load() -> StdFn {
-    StdFn::typed("load", vec![(params(vec![T::String]), result(T::Int))])
+    StdFn::typed(
+        "load",
+        vec![(params(vec![T::String]), result(T::Handle(HandleKind::C)))],
+    )
 }
 
 fn call() -> StdFn {
@@ -29,12 +35,18 @@ fn call() -> StdFn {
 fn has_symbol() -> StdFn {
     StdFn::typed(
         "has_symbol",
-        overloads(vec![handle(), fixed(T::String)], result(T::Bool)),
+        overloads(
+            vec![handle(HandleKind::C), fixed(T::String)],
+            result(T::Bool),
+        ),
     )
 }
 
 fn close() -> StdFn {
-    StdFn::typed("close", overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        "close",
+        overloads(vec![handle(HandleKind::C)], result(T::Null)),
+    )
 }
 
 fn clear_cache() -> StdFn {

--- a/crates/rl-commons/src/stdlib_signatures/http.rs
+++ b/crates/rl-commons/src/stdlib_signatures/http.rs
@@ -2,7 +2,7 @@
 
 use super::{fixed, handle, handle_to_string, overloads, params, result};
 use crate::{ModuleNames, StdFn};
-use rl_ast::statements::TypeAnnotation as T;
+use rl_ast::statements::{HandleKind, TypeAnnotation as T};
 use std::rc::Rc;
 
 pub fn module() -> ModuleNames {
@@ -28,41 +28,54 @@ fn status_and_body() -> T {
 fn http_server_start() -> StdFn {
     StdFn::typed(
         "http_server_start",
-        vec![(params(vec![T::String]), result(T::Int))],
+        vec![(params(vec![T::String]), result(T::Handle(HandleKind::Http)))],
     )
 }
 
 fn http_server_recv() -> StdFn {
     StdFn::typed(
         "http_server_recv",
-        overloads(vec![handle()], result(T::Int)),
+        overloads(
+            vec![handle(HandleKind::Http)],
+            result(T::Handle(HandleKind::Http)),
+        ),
     )
 }
 
 fn http_request_method() -> StdFn {
-    handle_to_string("http_request_method")
+    handle_to_string("http_request_method", HandleKind::Http)
 }
+
 fn http_request_url() -> StdFn {
-    handle_to_string("http_request_url")
+    handle_to_string("http_request_url", HandleKind::Http)
 }
+
 fn http_request_body() -> StdFn {
-    handle_to_string("http_request_body")
+    handle_to_string("http_request_body", HandleKind::Http)
 }
 
 fn http_request_header() -> StdFn {
     StdFn::typed(
         "http_request_header",
-        overloads(vec![handle(), fixed(T::String)], result(T::String)),
+        overloads(
+            vec![handle(HandleKind::Http), fixed(T::String)],
+            result(T::String),
+        ),
     )
 }
 
 fn http_respond() -> StdFn {
     let mut signatures = overloads(
-        vec![handle(), fixed(T::Int), fixed(T::String)],
+        vec![handle(HandleKind::Http), fixed(T::Int), fixed(T::String)],
         result(T::Null),
     );
     signatures.extend(overloads(
-        vec![handle(), fixed(T::Int), fixed(T::String), fixed(T::String)],
+        vec![
+            handle(HandleKind::Http),
+            fixed(T::Int),
+            fixed(T::String),
+            fixed(T::String),
+        ],
         result(T::Null),
     ));
     StdFn::typed("http_respond", signatures)
@@ -71,7 +84,7 @@ fn http_respond() -> StdFn {
 fn http_server_stop() -> StdFn {
     StdFn::typed(
         "http_server_stop",
-        overloads(vec![handle()], result(T::Null)),
+        overloads(vec![handle(HandleKind::Http)], result(T::Null)),
     )
 }
 

--- a/crates/rl-commons/src/stdlib_signatures/mod.rs
+++ b/crates/rl-commons/src/stdlib_signatures/mod.rs
@@ -7,7 +7,7 @@
 //! unchecked) in [`crate::stdlib_names`].
 
 use crate::StdFn;
-use rl_ast::statements::TypeAnnotation as T;
+use rl_ast::statements::{HandleKind, TypeAnnotation as T};
 use std::rc::Rc;
 
 pub mod array;
@@ -60,10 +60,9 @@ pub fn arr_t() -> T {
     T::Array(Box::new(t()))
 }
 
-/// A handle-typed argument slot, accepted as either `int` or `byte`.
-/// Shared by `http`/`net`, whose functions take socket/connection handles.
-pub fn handle() -> Vec<T> {
-    vec![T::Int, T::Byte]
+/// A single handle-typed argument slot, scoped to `kind`'s module.
+pub fn handle(kind: HandleKind) -> Vec<T> {
+    vec![T::Handle(kind)]
 }
 
 /// A single fixed-type argument slot, for use alongside [`handle`] in
@@ -100,8 +99,8 @@ pub fn overloads(parts: Vec<Vec<T>>, ret: T) -> Vec<(T, T)> {
 
 /// `handle_arg -> Result[string]` - a handle-only call that yields a
 /// string (e.g. an address, a header value). Shared by `http`/`net`.
-pub fn handle_to_string(name: &'static str) -> StdFn {
-    StdFn::typed(name, overloads(vec![handle()], result(T::String)))
+pub fn handle_to_string(name: &'static str, kind: HandleKind) -> StdFn {
+    StdFn::typed(name, overloads(vec![handle(kind)], result(T::String)))
 }
 
 /// `(string) -> string` - shared by `path` and `str` for their many

--- a/crates/rl-commons/src/stdlib_signatures/net.rs
+++ b/crates/rl-commons/src/stdlib_signatures/net.rs
@@ -2,7 +2,7 @@
 
 use super::{fixed, handle, handle_to_string, overloads, params, result};
 use crate::{ModuleNames, StdFn};
-use rl_ast::statements::TypeAnnotation as T;
+use rl_ast::statements::{HandleKind, TypeAnnotation as T};
 use std::rc::Rc;
 
 pub fn module() -> ModuleNames {
@@ -31,69 +31,96 @@ pub fn module() -> ModuleNames {
 fn tcp_listen() -> StdFn {
     StdFn::typed(
         "tcp_listen",
-        vec![(params(vec![T::String]), result(T::Int))],
+        vec![(params(vec![T::String]), result(T::Handle(HandleKind::Net)))],
     )
 }
 
 fn tcp_accept() -> StdFn {
-    StdFn::typed("tcp_accept", overloads(vec![handle()], result(T::Int)))
+    StdFn::typed(
+        "tcp_accept",
+        overloads(
+            vec![handle(HandleKind::Net)],
+            result(T::Handle(HandleKind::Net)),
+        ),
+    )
 }
 
 fn tcp_connect() -> StdFn {
     StdFn::typed(
         "tcp_connect",
-        vec![(params(vec![T::String]), result(T::Int))],
+        vec![(params(vec![T::String]), result(T::Handle(HandleKind::Net)))],
     )
 }
 
 fn tcp_read() -> StdFn {
     StdFn::typed(
         "tcp_read",
-        overloads(vec![handle(), handle()], result(T::String)),
+        overloads(
+            vec![handle(HandleKind::Net), handle(HandleKind::Net)],
+            result(T::String),
+        ),
     )
 }
 
 fn tcp_write() -> StdFn {
     StdFn::typed(
         "tcp_write",
-        overloads(vec![handle(), fixed(T::String)], result(T::Int)),
+        overloads(
+            vec![handle(HandleKind::Net), fixed(T::String)],
+            result(T::Int),
+        ),
     )
 }
 
 fn tcp_peer_addr() -> StdFn {
-    handle_to_string("tcp_peer_addr")
+    handle_to_string("tcp_peer_addr", HandleKind::Net)
 }
+
 fn tcp_local_addr() -> StdFn {
-    handle_to_string("tcp_local_addr")
+    handle_to_string("tcp_local_addr", HandleKind::Net)
 }
 
 fn tcp_set_timeout() -> StdFn {
     StdFn::typed(
         "tcp_set_timeout",
-        overloads(vec![handle(), handle()], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Net), handle(HandleKind::Net)],
+            result(T::Null),
+        ),
     )
 }
 
 fn tcp_set_nonblocking() -> StdFn {
     StdFn::typed(
         "tcp_set_nonblocking",
-        overloads(vec![handle(), fixed(T::Bool)], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Net), fixed(T::Bool)],
+            result(T::Null),
+        ),
     )
 }
 
 fn tcp_shutdown() -> StdFn {
     StdFn::typed(
         "tcp_shutdown",
-        overloads(vec![handle(), fixed(T::String)], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Net), fixed(T::String)],
+            result(T::Null),
+        ),
     )
 }
 
 fn close(name: &'static str) -> StdFn {
-    StdFn::typed(name, overloads(vec![handle()], result(T::Null)))
+    StdFn::typed(
+        name,
+        overloads(vec![handle(HandleKind::Net)], result(T::Null)),
+    )
 }
+
 fn tcp_close() -> StdFn {
     close("tcp_close")
 }
+
 fn udp_close() -> StdFn {
     close("udp_close")
 }
@@ -105,14 +132,20 @@ fn udp_bind() -> StdFn {
 fn udp_connect() -> StdFn {
     StdFn::typed(
         "udp_connect",
-        overloads(vec![handle(), fixed(T::String)], result(T::Null)),
+        overloads(
+            vec![handle(HandleKind::Net), fixed(T::String)],
+            result(T::Null),
+        ),
     )
 }
 
 fn udp_send() -> StdFn {
     StdFn::typed(
         "udp_send",
-        overloads(vec![handle(), fixed(T::String)], result(T::Int)),
+        overloads(
+            vec![handle(HandleKind::Net), fixed(T::String)],
+            result(T::Int),
+        ),
     )
 }
 
@@ -120,7 +153,7 @@ fn udp_send_to() -> StdFn {
     StdFn::typed(
         "udp_send_to",
         overloads(
-            vec![handle(), fixed(T::String), fixed(T::String)],
+            vec![handle(HandleKind::Net), fixed(T::String), fixed(T::String)],
             result(T::Int),
         ),
     )
@@ -129,7 +162,10 @@ fn udp_send_to() -> StdFn {
 fn udp_recv() -> StdFn {
     StdFn::typed(
         "udp_recv",
-        overloads(vec![handle(), handle()], result(T::String)),
+        overloads(
+            vec![handle(HandleKind::Net), handle(HandleKind::Net)],
+            result(T::String),
+        ),
     )
 }
 
@@ -137,7 +173,7 @@ fn udp_recv_from() -> StdFn {
     StdFn::typed(
         "udp_recv_from",
         overloads(
-            vec![handle(), handle()],
+            vec![handle(HandleKind::Net), handle(HandleKind::Net)],
             result(T::Tuple(Rc::new(vec![T::String, T::String]))),
         ),
     )

--- a/crates/rl-interpreter/src/evaluator.rs
+++ b/crates/rl-interpreter/src/evaluator.rs
@@ -78,21 +78,21 @@ pub struct Evaluator {
     // for diffrent calls
     pub user_args_offset: usize,
     /// Side-table of native networking resources (`std::net`), keyed by handle id.
-    pub net_handles: HashMap<i64, NetHandle>,
+    pub net_handles: HashMap<u64, NetHandle>,
     /// Next handle id to hand out for `std::net` resources; only ever increments.
-    pub net_next_handle: i64,
+    pub net_next_handle: u64,
     /// Side-table of native HTTP resources (`std::http`), keyed by handle id.
-    pub http_handles: HashMap<i64, HttpHandle>,
+    pub http_handles: HashMap<u64, HttpHandle>,
     /// Next handle id to hand out for `std::http` resources; only ever increments.
-    pub http_next_handle: i64,
+    pub http_next_handle: u64,
     /// Side-table of native C-interop resources (`std::c`), keyed by handle id.
-    pub c_handles: HashMap<i64, CHandle>,
+    pub c_handles: HashMap<u64, CHandle>,
     /// Next handle id to hand out for `std::c` resources; only ever increments.
-    pub c_next_handle: i64,
+    pub c_next_handle: u64,
     /// Side-table of native audio-playback resources (`std::audio`), keyed by handle id.
-    pub audio_handles: HashMap<i64, AudioHandle>,
+    pub audio_handles: HashMap<u64, AudioHandle>,
     /// Next handle id to hand out for `std::audio` resources; only ever increments.
-    pub audio_next_handle: i64,
+    pub audio_next_handle: u64,
     /// Output device selected via `std::audio::set_output_device`, if any;
     /// `None` means the system default device.
     pub audio_output_device: Option<String>,
@@ -392,6 +392,8 @@ impl Evaluator {
                     TypeAnnotation::Result(Box::new(inner_ty))
                 }
             }
+
+            Value::Handle { kind, .. } => TypeAnnotation::Handle(*kind),
         }
     }
 

--- a/crates/rl-interpreter/src/stdlib/audio/common.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/common.rs
@@ -1,13 +1,17 @@
 use cpal::traits::{DeviceTrait, HostTrait};
+use rl_ast::statements::HandleKind;
 
 use crate::{evaluator::Evaluator, stdlib::audio::AudioHandle, values::Value};
 
 /// Registers a new handle and returns its id.
-pub fn insert_handle(eval: &mut Evaluator, handle: AudioHandle) -> i64 {
+pub fn insert_handle(eval: &mut Evaluator, handle: AudioHandle) -> Value {
     let id = eval.audio_next_handle;
     eval.audio_next_handle += 1;
     eval.audio_handles.insert(id, handle);
-    id
+    Value::Handle {
+        kind: HandleKind::Audio,
+        id,
+    }
 }
 
 /// Extracts an `f64` from an `int` or `float` [`Value`].

--- a/crates/rl-interpreter/src/stdlib/audio/play_file_async.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/play_file_async.rs
@@ -7,7 +7,7 @@ use crate::{
             AudioHandle,
             common::{insert_handle, new_sink},
         },
-        common::{extract_string, verr, vi, vok, vs},
+        common::{extract_string, verr, vok, vs},
     },
     values::Value,
 };
@@ -43,5 +43,5 @@ pub fn func(eval: &mut Evaluator, path: Value) -> Value {
             base_volume: 1.0,
         },
     );
-    vok!(vi!(id))
+    vok!(id)
 }

--- a/crates/rl-interpreter/src/stdlib/audio/sound_get_volume.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_get_volume.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vf, vok, vs},
+    stdlib::common::{extract_handle, verr, vf, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_get_volume") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_get_volume: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_get_volume") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     // Returns the volume the user asked for via `sound_set_volume`, not the

--- a/crates/rl-interpreter/src/stdlib/audio/sound_is_finished.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_is_finished.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, vb, verr, vok, vs},
+    stdlib::common::{extract_handle, vb, verr, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_is_finished") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_is_finished: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_is_finished") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/audio/sound_is_paused.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_is_paused.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, vb, verr, vok, vs},
+    stdlib::common::{extract_handle, vb, verr, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_is_paused") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_is_paused: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_is_paused") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/audio/sound_pause.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_pause.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_pause") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_pause: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_pause") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/audio/sound_resume.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_resume.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_resume") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_resume: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_resume") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/audio/sound_seek.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_seek.rs
@@ -1,15 +1,17 @@
 use std::time::Duration;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, extract_number, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value, position_ms: Value) -> Value {
-    let id = match extract_number(handle, "sound_seek") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_seek: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_seek") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
     let position_ms = match extract_number(position_ms, "sound_seek") {
         Ok(n) => n,

--- a/crates/rl-interpreter/src/stdlib/audio/sound_set_speed.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_set_speed.rs
@@ -1,16 +1,18 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
         audio::common::extract_float,
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
     },
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value, speed: Value) -> Value {
-    let id = match extract_number(handle, "sound_set_speed") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_set_speed: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_set_speed") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
     let speed = match extract_float(speed, "sound_set_speed") {
         Ok(s) => s as f32,

--- a/crates/rl-interpreter/src/stdlib/audio/sound_set_volume.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_set_volume.rs
@@ -1,16 +1,18 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
         audio::common::extract_float,
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
     },
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value, volume: Value) -> Value {
-    let id = match extract_number(handle, "sound_set_volume") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_set_volume: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_set_volume") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
     let volume = match extract_float(volume, "sound_set_volume") {
         Ok(v) => v as f32,

--- a/crates/rl-interpreter/src/stdlib/audio/sound_stop.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_stop.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_stop") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_stop: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_stop") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.remove(&id) {

--- a/crates/rl-interpreter/src/stdlib/audio/sound_wait.rs
+++ b/crates/rl-interpreter/src/stdlib/audio/sound_wait.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let id = match extract_number(handle, "sound_wait") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("sound_wait: {}", e))),
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_wait") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.audio_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/c/call.rs
+++ b/crates/rl-interpreter/src/stdlib/c/call.rs
@@ -1,12 +1,12 @@
 use libffi::middle::{Arg, Cif, CodePtr, Type, arg};
 use libloading::Symbol;
-use rl_ast::statements::TypeAnnotation;
+use rl_ast::statements::{HandleKind, TypeAnnotation};
 
 use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string, vb, vby, verr, vf, vi, vnl, vok, vs},
+        common::{extract_handle, extract_string, vb, vby, verr, vf, vi, vnl, vok, vs},
     },
     values::Value,
 };
@@ -83,10 +83,11 @@ pub fn func(
     arg_types: Value,
     ret_type: Value,
 ) -> Value {
-    let handle_id = match extract_number(handle, "call") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("call: {}", e))),
+    let handle_id = match extract_handle(handle, HandleKind::C, "call") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let fn_name = match extract_string(fn_name, "call") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("call: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/c/close.rs
+++ b/crates/rl-interpreter/src/stdlib/c/close.rs
@@ -1,13 +1,15 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
-    stdlib::common::{extract_number, verr, vnl, vok, vs},
+    stdlib::common::{extract_handle, verr, vnl, vok, vs},
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
-    let handle_id = match extract_number(handle, "close") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("close: {}", e))),
+    let handle_id = match extract_handle(handle, HandleKind::C, "close") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.c_handles.remove(&handle_id) {

--- a/crates/rl-interpreter/src/stdlib/c/common.rs
+++ b/crates/rl-interpreter/src/stdlib/c/common.rs
@@ -1,14 +1,20 @@
 use std::path::PathBuf;
 
+use rl_ast::statements::HandleKind;
+
 use crate::evaluator::Evaluator;
 use crate::stdlib::c::CHandle;
+use crate::values::Value;
 
 /// Registers a new handle and returns its id.
-pub fn insert_handle(eval: &mut Evaluator, handle: CHandle) -> i64 {
+pub fn insert_handle(eval: &mut Evaluator, handle: CHandle) -> Value {
     let id = eval.c_next_handle;
     eval.c_next_handle += 1;
     eval.c_handles.insert(id, handle);
-    id
+    Value::Handle {
+        kind: HandleKind::C,
+        id,
+    }
 }
 
 /// Where `compile` caches built shared libraries by content hash, and what

--- a/crates/rl-interpreter/src/stdlib/c/compile.rs
+++ b/crates/rl-interpreter/src/stdlib/c/compile.rs
@@ -6,8 +6,11 @@ use std::process::Command;
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        c::{CHandle, common::{cache_dir, insert_handle}},
-        common::{extract_string, verr, vi, vok, vs},
+        c::{
+            CHandle,
+            common::{cache_dir, insert_handle},
+        },
+        common::{extract_string, verr, vok, vs},
     },
     values::Value,
 };
@@ -109,5 +112,5 @@ pub fn func(eval: &mut Evaluator, source: Value) -> Value {
     };
 
     let id = insert_handle(eval, CHandle::Library(lib));
-    vok!(vi!(id))
+    vok!(id)
 }

--- a/crates/rl-interpreter/src/stdlib/c/has_symbol.rs
+++ b/crates/rl-interpreter/src/stdlib/c/has_symbol.rs
@@ -1,17 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string, vb, verr, vok, vs},
+        common::{extract_handle, extract_string, vb, verr, vok, vs},
     },
     values::Value,
 };
 
 pub fn func(eval: &mut Evaluator, handle: Value, fn_name: Value) -> Value {
-    let handle_id = match extract_number(handle, "has_symbol") {
-        Ok(n) => n as i64,
-        Err(e) => return verr!(vs!(format!("has_symbol: {}", e))),
+    let handle_id = match extract_handle(handle, HandleKind::C, "has_symbol") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let fn_name = match extract_string(fn_name, "has_symbol") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("has_symbol: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/c/load.rs
+++ b/crates/rl-interpreter/src/stdlib/c/load.rs
@@ -2,7 +2,7 @@ use crate::{
     evaluator::Evaluator,
     stdlib::{
         c::{CHandle, common::insert_handle},
-        common::{extract_string, verr, vi, vok, vs},
+        common::{extract_string, verr, vok, vs},
     },
     values::Value,
 };
@@ -25,5 +25,5 @@ pub fn func(eval: &mut Evaluator, path: Value) -> Value {
     };
 
     let id = insert_handle(eval, CHandle::Library(lib));
-    vok!(vi!(id))
+    vok!(id)
 }

--- a/crates/rl-interpreter/src/stdlib/common.rs
+++ b/crates/rl-interpreter/src/stdlib/common.rs
@@ -1,4 +1,5 @@
 use crate::values::Value;
+use rl_ast::statements::HandleKind;
 use rl_utils::{
     errors::{Error, Reason},
     span::Span,
@@ -96,6 +97,25 @@ pub fn extract_number(value: Value, name: &str) -> Result<u64, String> {
         _ => {
             unreachable!()
         }
+    }
+}
+
+/// Unwraps a `Value::Handle` of the expected kind into its raw id.
+/// This is the runtime half of the checker's static rejection - it catches
+/// a wrong-module handle that reached here anyway (e.g. through an `array[?]`
+/// or anything else the static checker can't fully see through).
+pub fn extract_handle(value: Value, expected: HandleKind, name: &str) -> Result<u64, String> {
+    match value {
+        Value::Handle { kind, id } if kind == expected => Ok(id),
+        Value::Handle { kind, .. } => Err(format!(
+            "{}: expected a {:?} handle, got a {:?} handle",
+            name, expected, kind
+        )),
+        other => Err(format!(
+            "{}: expected a handle, got {}",
+            name,
+            other.type_name()
+        )),
     }
 }
 

--- a/crates/rl-interpreter/src/stdlib/http/common.rs
+++ b/crates/rl-interpreter/src/stdlib/http/common.rs
@@ -1,3 +1,5 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
@@ -24,9 +26,12 @@ pub fn ureq_result_to_value(url: &str, result: Result<ureq::Response, ureq::Erro
     }
 }
 
-pub fn insert_handle(eval: &mut Evaluator, handle: HttpHandle) -> i64 {
+pub fn insert_handle(eval: &mut Evaluator, handle: HttpHandle) -> Value {
     let id = eval.http_next_handle;
     eval.http_next_handle += 1;
     eval.http_handles.insert(id, handle);
-    id
+    Value::Handle {
+        kind: HandleKind::Http,
+        id,
+    }
 }

--- a/crates/rl-interpreter/src/stdlib/http/http_request_body.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_request_body.rs
@@ -1,22 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_request_body") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_request_body: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_request_body") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let request = match eval.http_handles.get_mut(&id) {
         Some(HttpHandle::Request(request)) => request,
         Some(_) => {

--- a/crates/rl-interpreter/src/stdlib/http/http_request_header.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_request_header.rs
@@ -1,21 +1,19 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value, name: String) -> Value {
-    let id = match extract_number(id, "http_request_header") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_request_header: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, name: String) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_request_header") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let request = match eval.http_handles.get(&id) {
         Some(HttpHandle::Request(request)) => request,
         Some(_) => {

--- a/crates/rl-interpreter/src/stdlib/http/http_request_method.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_request_method.rs
@@ -1,20 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_request_method") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_request_method: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_request_method") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.http_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/http/http_request_url.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_request_url.rs
@@ -1,20 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_request_url") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_request_url: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_request_url") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     match eval.http_handles.get(&id) {

--- a/crates/rl-interpreter/src/stdlib/http/http_respond.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_respond.rs
@@ -1,24 +1,20 @@
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{check_arity_range, extract_number, extract_string, verr, vok, vs},
+        common::{check_arity_range, extract_handle, extract_string, verr, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
+use rl_ast::statements::HandleKind;
 use rl_utils::{errors::Error, span::Span};
 
 pub fn func(eval: &mut Evaluator, args: Vec<Value>, span: Span) -> Result<Value, Error> {
     check_arity_range(&args, 3, 4, "http_post", span)?;
 
-    let id = match extract_number(args[0].clone(), "http_respond") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return Ok(verr!(vs!(
-                "http_respond: id handle cannot be negative".to_string()
-            )));
-        }
-        Err(e) => return Ok(verr!(vs!(format!("{}", e)))),
+    let id = match extract_handle(args[0].clone(), HandleKind::Http, "http_respond") {
+        Ok(id) => id,
+        Err(e) => return Ok(verr!(vs!(e))),
     };
 
     let status = match &args[1] {

--- a/crates/rl-interpreter/src/stdlib/http/http_server_recv.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_server_recv.rs
@@ -1,36 +1,34 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vi, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         http::{HttpHandle, common::insert_handle},
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_server_recv") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_server_recv: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_server_recv") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let server = match eval.http_handles.get(&id) {
         Some(HttpHandle::Server(server)) => server,
         Some(_) => {
             return verr!(vs!(format!(
-                "http_server_recv(): handle {} is not a server",
+                "http_server_recv: handle {} is not a server",
                 id
             )));
         }
-        None => return verr!(vs!(format!("http_server_recv(): unknown handle {}", id))),
+        None => return verr!(vs!(format!("http_server_recv: unknown handle {}", id))),
     };
     match server.recv() {
         Ok(request) => {
             let req_id = insert_handle(eval, HttpHandle::Request(request));
-            vok!(vi!(req_id))
+            vok!(req_id)
         }
-        Err(e) => verr!(vs!(format!("http_server_recv(): {}", e))),
+        Err(e) => verr!(vs!(format!("http_server_recv: {}", e))),
     }
 }

--- a/crates/rl-interpreter/src/stdlib/http/http_server_start.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_server_start.rs
@@ -1,7 +1,7 @@
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{verr, vi, vok, vs},
+        common::{verr, vok, vs},
         http::{HttpHandle, common::insert_handle},
     },
     values::Value,
@@ -10,7 +10,7 @@ pub fn func(eval: &mut Evaluator, addr: String) -> Value {
     match tiny_http::Server::http(&addr) {
         Ok(server) => {
             let id = insert_handle(eval, HttpHandle::Server(server));
-            vok!(vi!(id))
+            vok!(id)
         }
         Err(e) => verr!(vs!(format!("http_server_start(\"{}\"): {}", addr, e))),
     }

--- a/crates/rl-interpreter/src/stdlib/http/http_server_stop.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_server_stop.rs
@@ -1,21 +1,19 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
         http::HttpHandle,
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_server_stop") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_server_stop: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_server_stop") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     match eval.http_handles.get(&id) {
         Some(HttpHandle::Server(_)) => {
             eval.http_handles.remove(&id);

--- a/crates/rl-interpreter/src/stdlib/http/http_server_try_recv.rs
+++ b/crates/rl-interpreter/src/stdlib/http/http_server_try_recv.rs
@@ -1,20 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vi, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
         http::{HttpHandle, common::insert_handle},
     },
     values::Value,
 };
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "http_server_try_recv") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "http_server_try_recv: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Http, "http_server_try_recv") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     let server = match eval.http_handles.get(&id) {
@@ -32,7 +29,7 @@ pub fn func(eval: &mut Evaluator, id: Value) -> Value {
     match server.try_recv() {
         Ok(Some(request)) => {
             let req_id = insert_handle(eval, HttpHandle::Request(request));
-            vok!(vi!(req_id))
+            vok!(req_id)
         }
         Ok(None) => vok!(vnl!()),
         Err(e) => verr!(vs!(format!("http_server_try_recv: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/common.rs
+++ b/crates/rl-interpreter/src/stdlib/net/common.rs
@@ -1,10 +1,12 @@
-use crate::evaluator::Evaluator;
-use crate::stdlib::net::NetHandle;
+use crate::{evaluator::Evaluator, stdlib::net::NetHandle, values::Value};
+use rl_ast::statements::HandleKind;
 
-/// Registers a new handle and returns its id.
-pub fn insert_handle(eval: &mut Evaluator, handle: NetHandle) -> i64 {
+pub fn insert_handle(eval: &mut Evaluator, handle: NetHandle) -> Value {
     let id = eval.net_next_handle;
     eval.net_next_handle += 1;
     eval.net_handles.insert(id, handle);
-    id
+    Value::Handle {
+        kind: HandleKind::Net,
+        id,
+    }
 }

--- a/crates/rl-interpreter/src/stdlib/net/tcp_accept.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_accept.rs
@@ -1,17 +1,17 @@
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vi, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         net::{NetHandle, common::insert_handle},
     },
     values::Value,
 };
+use rl_ast::statements::HandleKind;
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "tcp_accept") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_accept: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_accept: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_accept") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
 
     let accept_result = match eval.net_handles.get(&id) {
@@ -27,8 +27,8 @@ pub fn func(eval: &mut Evaluator, id: Value) -> Value {
 
     match accept_result {
         Ok((stream, _addr)) => {
-            let new_id = insert_handle(eval, NetHandle::TcpStream(stream));
-            vok!(vi!(new_id))
+            let handle = insert_handle(eval, NetHandle::TcpStream(stream));
+            vok!(handle)
         }
         Err(e) => verr!(vs!(format!("tcp_accept(): {}", e))),
     }

--- a/crates/rl-interpreter/src/stdlib/net/tcp_close.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_close.rs
@@ -1,18 +1,19 @@
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
+use rl_ast::statements::HandleKind;
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "tcp_close") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_close: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_close: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_close") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     match eval.net_handles.get(&id) {
         Some(NetHandle::TcpListener(_)) | Some(NetHandle::TcpStream(_)) => {
             eval.net_handles.remove(&id);

--- a/crates/rl-interpreter/src/stdlib/net/tcp_connect.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_connect.rs
@@ -3,7 +3,7 @@ use std::net::TcpStream;
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_string, verr, vi, vok, vs},
+        common::{extract_string, verr, vok, vs},
         net::{NetHandle, common::insert_handle},
     },
     values::Value,
@@ -14,10 +14,11 @@ pub fn func(eval: &mut Evaluator, address: Value) -> Value {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("tcp_connect: {} ", e))),
     };
+
     match TcpStream::connect(&addr) {
         Ok(stream) => {
-            let id = insert_handle(eval, NetHandle::TcpStream(stream));
-            vok!(vi!(id))
+            let handle = insert_handle(eval, NetHandle::TcpStream(stream));
+            vok!(handle)
         }
         Err(e) => verr!(vs!(format!("tcp_connect(\"{}\"): {}", addr, e))),
     }

--- a/crates/rl-interpreter/src/stdlib/net/tcp_listen.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_listen.rs
@@ -3,7 +3,7 @@ use std::net::TcpListener;
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_string, verr, vi, vok, vs},
+        common::{extract_string, verr, vok, vs},
         net::{NetHandle, common::insert_handle},
     },
     values::Value,
@@ -14,10 +14,11 @@ pub fn func(eval: &mut Evaluator, address: Value) -> Value {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("tcp_listen: {} ", e))),
     };
+
     match TcpListener::bind(&addr) {
         Ok(listener) => {
-            let id = insert_handle(eval, NetHandle::TcpListener(listener));
-            vok!(vi!(id))
+            let handle = insert_handle(eval, NetHandle::TcpListener(listener));
+            vok!(handle)
         }
         Err(e) => verr!(vs!(format!("tcp_listen(\"{}\"): {}", addr, e))),
     }

--- a/crates/rl-interpreter/src/stdlib/net/tcp_local_addr.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_local_addr.rs
@@ -1,22 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "tcp_local_addr") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "tcp_local_addr: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("tcp_accept: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_local_addr") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let stream = match eval.net_handles.get(&id) {
         Some(NetHandle::TcpStream(stream)) => stream,
         Some(_) => {

--- a/crates/rl-interpreter/src/stdlib/net/tcp_peer_addr.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_peer_addr.rs
@@ -1,22 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, verr, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "tcp_peer_addr") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "tcp_peer_addr: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("tcp_accept: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_peer_addr") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let stream = match eval.net_handles.get(&id) {
         Some(NetHandle::TcpStream(stream)) => stream,
         Some(_) => {

--- a/crates/rl-interpreter/src/stdlib/net/tcp_read.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_read.rs
@@ -1,20 +1,22 @@
 use std::io::Read;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, extract_number, verr, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, max_bytes: Value) -> Value {
-    let id = match extract_number(id, "tcp_read") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_read: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_accept: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, max_bytes: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_read") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let max_bytes = match extract_number(max_bytes, "tcp_read") {
         Ok(a) => a as usize,
         Err(e) => return verr!(vs!(format!("tcp_read: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/tcp_set_nonblocking.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_set_nonblocking.rs
@@ -1,22 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, flag: bool) -> Value {
-    let id = match extract_number(id, "tcp_set_nonblocking") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "tcp_set_nonblocking: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("tcp_set_nonblocking: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, flag: bool) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_set_nonblocking") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let stream = match eval.net_handles.get(&id) {
         Some(NetHandle::TcpStream(stream)) => stream,
         Some(_) => {
@@ -29,6 +27,7 @@ pub fn func(eval: &mut Evaluator, id: Value, flag: bool) -> Value {
             return verr!(vs!(format!("tcp_set_nonblocking: unknown handle {}", id)));
         }
     };
+
     match stream.set_nonblocking(flag) {
         Ok(()) => vok!(vnl!()),
         Err(e) => verr!(vs!(format!("tcp_set_nonblocking: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/tcp_set_timeout.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_set_timeout.rs
@@ -1,20 +1,22 @@
 use std::time::Duration;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, extract_number, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, millis: Value) -> Value {
-    let id = match extract_number(id, "tcp_set_timeout") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_accept: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_set_timeout: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, millis: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_set_timeout") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let millis = match extract_number(millis, "tcp_set_timeout") {
         Ok(a) => a,
         Err(e) => return verr!(vs!(format!("tcp_set_timeout: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/tcp_shutdown.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_shutdown.rs
@@ -1,20 +1,22 @@
 use std::net::Shutdown;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, extract_string, verr, vnl, vok, vs},
+        common::{extract_handle, extract_string, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, mode: Value) -> Value {
-    let id = match extract_number(id, "tcp_shutdown") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_shutdown: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_shutdown: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, mode: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_local_addr") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let mode = match extract_string(mode, "tcp_shutdown") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("tcp_shutdown: {} ", e))),

--- a/crates/rl-interpreter/src/stdlib/net/tcp_write.rs
+++ b/crates/rl-interpreter/src/stdlib/net/tcp_write.rs
@@ -1,20 +1,22 @@
 use std::io::Write;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, extract_string, verr, vi, vok, vs},
+        common::{extract_handle, extract_string, verr, vi, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, data: Value) -> Value {
-    let id = match extract_number(id, "tcp_write") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("tcp_write: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("tcp_write: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, data: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "tcp_local_addr") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let data = match extract_string(data, "tcp_write") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("tcp_write: {} ", e))),

--- a/crates/rl-interpreter/src/stdlib/net/udp_bind.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_bind.rs
@@ -3,7 +3,7 @@ use std::net::UdpSocket;
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_string, verr, vi, vok, vs},
+        common::{extract_string, verr, vok, vs},
         net::{NetHandle, common::insert_handle},
     },
     values::Value,
@@ -17,7 +17,7 @@ pub fn func(eval: &mut Evaluator, address: Value) -> Value {
     match UdpSocket::bind(&addr) {
         Ok(socket) => {
             let id = insert_handle(eval, NetHandle::UdpSocket(socket));
-            vok!(vi!(id))
+            vok!(id)
         }
         Err(e) => verr!(vs!(format!("udp_bind(\"{}\"): {}", addr, e))),
     }

--- a/crates/rl-interpreter/src/stdlib/net/udp_close.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_close.rs
@@ -1,18 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vnl, vok, vs},
+        common::{extract_handle, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value) -> Value {
-    let id = match extract_number(id, "udp_close") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("udp_close: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("udp_close: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_close") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     match eval.net_handles.get(&id) {
         Some(NetHandle::UdpSocket(_)) => {
             eval.net_handles.remove(&id);

--- a/crates/rl-interpreter/src/stdlib/net/udp_connect.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_connect.rs
@@ -1,18 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, extract_string, verr, vnl, vok, vs},
+        common::{extract_handle, extract_string, verr, vnl, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, address: Value) -> Value {
-    let id = match extract_number(id, "udp_connect") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("udp_connect: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("udp_connect: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, address: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_connect") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let addr = match extract_string(address, "udp_connect") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("udp_connect: {} ", e))),

--- a/crates/rl-interpreter/src/stdlib/net/udp_recv.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_recv.rs
@@ -1,18 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, extract_number, verr, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, max_bytes: Value) -> Value {
-    let id = match extract_number(id, "udp_recv") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("udp_recv: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("udp_recv: {}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, max_bytes: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_recv") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let max_bytes = match extract_number(max_bytes, "udp_recv") {
         Ok(a) => a as usize,
         Err(e) => return verr!(vs!(format!("udp_recv: {}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/udp_recv_from.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_recv_from.rs
@@ -1,22 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, verr, vok, vs},
+        common::{extract_handle, extract_number, verr, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, max_bytes: Value) -> Value {
-    let id = match extract_number(id, "udp_recv_from") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => {
-            return verr!(vs!(
-                "udp_recv_from: id handle cannot be negative".to_string()
-            ));
-        }
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, max_bytes: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_recv_from") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let max_bytes = match extract_number(max_bytes, "udp_recv_from") {
         Ok(a) => a as usize,
         Err(e) => return verr!(vs!(format!("{}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/udp_send.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_send.rs
@@ -1,18 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, extract_string, verr, vi, vok, vs},
+        common::{extract_handle, extract_string, verr, vi, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, data: Value) -> Value {
-    let id = match extract_number(id, "udp_send") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("udp_send: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, data: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_send") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let data = match extract_string(data, "udp_send") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("{}", e))),

--- a/crates/rl-interpreter/src/stdlib/net/udp_send_to.rs
+++ b/crates/rl-interpreter/src/stdlib/net/udp_send_to.rs
@@ -1,18 +1,20 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     evaluator::Evaluator,
     stdlib::{
-        common::{extract_number, extract_string, verr, vi, vok, vs},
+        common::{extract_handle, extract_string, verr, vi, vok, vs},
         net::NetHandle,
     },
     values::Value,
 };
 
-pub fn func(eval: &mut Evaluator, id: Value, data: Value, address: Value) -> Value {
-    let id = match extract_number(id, "udp_send_to") {
-        Ok(a) if a as i64 >= 0 => a as i64,
-        Ok(_) => return verr!(vs!("udp_send_to: id handle cannot be negative".to_string())),
-        Err(e) => return verr!(vs!(format!("{}", e))),
+pub fn func(eval: &mut Evaluator, handle: Value, data: Value, address: Value) -> Value {
+    let id = match extract_handle(handle, HandleKind::Net, "udp_send_to") {
+        Ok(id) => id,
+        Err(e) => return verr!(vs!(e)),
     };
+
     let data = match extract_string(data, "udp_send_to") {
         Ok(s) => s,
         Err(e) => return verr!(vs!(format!("{}", e))),

--- a/crates/rl-interpreter/src/values.rs
+++ b/crates/rl-interpreter/src/values.rs
@@ -1,7 +1,7 @@
 //! Runtime value types for the rl interpreter.
 
 use crate::evaluator::EnvironmentItem;
-use rl_ast::statements::{Param, Statement, TypeAnnotation};
+use rl_ast::statements::{HandleKind, Param, Statement, TypeAnnotation};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -69,6 +69,12 @@ pub enum Value {
         /// The declared element type of this set.
         items_type: TypeAnnotation,
         items: Rc<RefCell<HashSet<MapKey>>>,
+    },
+
+    /// An opaque resource id scoped to one stdlib module (`net`, `c`, `http`, ...).
+    Handle {
+        kind: HandleKind,
+        id: u64,
     },
 }
 
@@ -161,6 +167,12 @@ impl Value {
             Value::Struct { .. } => "record",
             Value::Enum { .. } => "tag",
             Value::Set { .. } => "set",
+            Value::Handle { kind, .. } => match kind {
+                HandleKind::C => "c handle",
+                HandleKind::Net => "net handle",
+                HandleKind::Http => "http handle",
+                HandleKind::Audio => "audio handle",
+            },
         }
     }
 
@@ -234,6 +246,7 @@ impl fmt::Display for Value {
                 }
                 write!(f, "}}")
             }
+            Value::Handle { kind, id } => write!(f, "<{:?} handle #{}>", kind, id),
         }
     }
 }

--- a/crates/rl-tests/tests/commons/mod.rs
+++ b/crates/rl-tests/tests/commons/mod.rs
@@ -1,4 +1,4 @@
-use rl_ast::statements::TypeAnnotation;
+use rl_ast::statements::{HandleKind, TypeAnnotation};
 use rl_commons::{stdlib_signatures::params, *};
 
 #[test]
@@ -236,64 +236,6 @@ fn res_result_unwrap_takes_result_t_returns_t() {
 }
 
 #[test]
-fn http_server_recv_has_two_handle_overloads() {
-    let tree = stdlib_names();
-    let path = vec!["http".to_string(), "http_server_recv".to_string()];
-    let f = tree
-        .resolve(&path)
-        .expect("http_server_recv should resolve");
-    assert_eq!(f.signatures.len(), 2);
-}
-
-#[test]
-fn http_respond_has_four_overloads_across_both_arities() {
-    let tree = stdlib_names();
-    let path = vec!["http".to_string(), "http_respond".to_string()];
-    let f = tree.resolve(&path).expect("http_respond should resolve");
-    assert_eq!(f.signatures.len(), 4);
-}
-
-#[test]
-fn http_request_method_returns_result_string_via_handle_to_string() {
-    let tree = stdlib_names();
-    let path = vec!["http".to_string(), "http_request_method".to_string()];
-    let f = tree
-        .resolve(&path)
-        .expect("http_request_method should resolve");
-    assert_eq!(f.signatures.len(), 2);
-    assert!(
-        f.signatures
-            .iter()
-            .all(|(_, ret)| *ret == TypeAnnotation::Result(Box::new(TypeAnnotation::String)))
-    );
-}
-
-#[test]
-fn net_tcp_read_has_four_overloads_from_two_handle_slots() {
-    let tree = stdlib_names();
-    let path = vec!["net".to_string(), "tcp_read".to_string()];
-    let f = tree.resolve(&path).expect("tcp_read should resolve");
-    assert_eq!(f.signatures.len(), 4);
-}
-
-#[test]
-fn net_tcp_peer_addr_and_local_addr_share_shape_with_http() {
-    let tree = stdlib_names();
-    for name in ["tcp_peer_addr", "tcp_local_addr"] {
-        let path = vec!["net".to_string(), name.to_string()];
-        let f = tree
-            .resolve(&path)
-            .unwrap_or_else(|| panic!("{name} should resolve"));
-        assert_eq!(f.signatures.len(), 2);
-        assert!(
-            f.signatures
-                .iter()
-                .all(|(_, ret)| *ret == TypeAnnotation::Result(Box::new(TypeAnnotation::String)))
-        );
-    }
-}
-
-#[test]
 fn path_extension_and_str_to_lower_share_the_string_to_string_shape() {
     let tree = stdlib_names();
     let expected = vec![(params(vec![TypeAnnotation::String]), TypeAnnotation::String)];
@@ -331,7 +273,7 @@ fn audio_play_file_takes_string_returns_result_null() {
 }
 
 #[test]
-fn audio_play_file_async_returns_result_int_handle() {
+fn audio_play_file_async_returns_result_audio_handle() {
     let tree = stdlib_names();
     let path = vec!["audio".to_string(), "play_file_async".to_string()];
     let f = tree.resolve(&path).expect("play_file_async should resolve");
@@ -339,31 +281,8 @@ fn audio_play_file_async_returns_result_int_handle() {
         f.signatures,
         vec![(
             params(vec![TypeAnnotation::String]),
-            TypeAnnotation::Result(Box::new(TypeAnnotation::Int))
+            TypeAnnotation::Result(Box::new(TypeAnnotation::Handle(HandleKind::Audio)))
         )]
-    );
-}
-
-#[test]
-fn audio_sound_pause_has_int_and_byte_handle_overloads() {
-    let tree = stdlib_names();
-    let path = vec!["audio".to_string(), "sound_pause".to_string()];
-    let f = tree.resolve(&path).expect("sound_pause should resolve");
-    assert_eq!(f.signatures.len(), 2);
-}
-
-#[test]
-fn audio_sound_set_volume_has_handle_times_float_overloads() {
-    let tree = stdlib_names();
-    let path = vec!["audio".to_string(), "sound_set_volume".to_string()];
-    let f = tree
-        .resolve(&path)
-        .expect("sound_set_volume should resolve");
-    assert_eq!(f.signatures.len(), 2);
-    assert!(
-        f.signatures
-            .iter()
-            .all(|(_, ret)| *ret == TypeAnnotation::Result(Box::new(TypeAnnotation::Null)))
     );
 }
 

--- a/crates/rl-vm/src/bytecode.rs
+++ b/crates/rl-vm/src/bytecode.rs
@@ -84,6 +84,7 @@ use std::rc::Rc;
 use crate::chunk::Chunk;
 use crate::native::Module;
 use crate::values::{RecordFields, VmFunction, VmMapKey, VmValue};
+use rl_ast::statements::HandleKind;
 use rl_utils::line_index::LineIndex;
 use rl_utils::span::Span;
 
@@ -322,7 +323,8 @@ fn collect_strings_value(value: &VmValue, pool: &mut StringPoolBuilder) {
         | VmValue::Bool(_)
         | VmValue::Byte(_)
         | VmValue::SByte(_)
-        | VmValue::Char(_) => {}
+        | VmValue::Char(_)
+        | VmValue::Handle { .. } => {}
 
         VmValue::Arr(items) | VmValue::Tuple(items) => {
             for item in items.iter() {
@@ -560,6 +562,12 @@ fn write_value(value: &VmValue, pool: &StringPoolBuilder, out: &mut Vec<u8>) {
             for v in captured.iter() {
                 write_value(v, pool, out);
             }
+        }
+
+        VmValue::Handle { kind, id } => {
+            out.push(26);
+            write_uvarint(*kind as u64, out);
+            write_uvarint(*id, out);
         }
     }
 }
@@ -806,6 +814,22 @@ fn read_value(
         25 => {
             let bits = cursor.take(4)?;
             VmValue::SFloat(f32::from_le_bytes(bits.try_into().unwrap()))
+        }
+        26 => {
+            let kind = match cursor.uvarint()? as u8 {
+                0 => HandleKind::C,
+                1 => HandleKind::Net,
+                2 => HandleKind::Http,
+                3 => HandleKind::Audio,
+                _ => {
+                    return Err(BytecodeError(
+                        "corrupt .rlc: closure template is not a function".into(),
+                    ));
+                }
+            };
+            let id = cursor.uvarint()?;
+
+            VmValue::Handle { kind, id }
         }
         other => {
             return Err(BytecodeError(format!(

--- a/crates/rl-vm/src/stdlib/audio/common.rs
+++ b/crates/rl-vm/src/stdlib/audio/common.rs
@@ -1,15 +1,19 @@
 use cpal::traits::{DeviceTrait, HostTrait};
+use rl_ast::statements::HandleKind;
 
 use crate::Vm;
 use crate::stdlib::audio::AudioHandle;
 use crate::values::VmValue;
 
 /// Registers a new handle and returns its id.
-pub fn insert_handle(vm: &mut Vm, handle: AudioHandle) -> i64 {
+pub fn insert_handle(vm: &mut Vm, handle: AudioHandle) -> VmValue {
     let id = vm.audio_next_handle;
     vm.audio_next_handle += 1;
     vm.audio_handles.insert(id, handle);
-    id
+    VmValue::Handle {
+        kind: HandleKind::Audio,
+        id,
+    }
 }
 
 /// Extracts an `f64` from an `int` or `float` [`VmValue`].

--- a/crates/rl-vm/src/stdlib/audio/play_file_async.rs
+++ b/crates/rl-vm/src/stdlib/audio/play_file_async.rs
@@ -8,7 +8,7 @@ use crate::{
             common::{insert_handle, new_sink},
         },
         common::extract_string,
-        macros::{verr, vi, vok, vs},
+        macros::{verr, vok, vs},
     },
     values::VmValue,
 };
@@ -36,7 +36,7 @@ pub fn func(vm: &mut Vm, path: VmValue) -> VmValue {
 
     sink.append(source);
 
-    let id = insert_handle(
+    let handle = insert_handle(
         vm,
         AudioHandle {
             sink,
@@ -44,5 +44,5 @@ pub fn func(vm: &mut Vm, path: VmValue) -> VmValue {
             base_volume: 1.0,
         },
     );
-    vok!(vi!(id))
+    vok!(handle)
 }

--- a/crates/rl-vm/src/stdlib/audio/sound_get_volume.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_get_volume.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vf, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{verr, vf, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_get_volume") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_get_volume") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_get_volume: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_is_finished.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_is_finished.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{vb, verr, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{vb, verr, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_is_finished") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_is_finished") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_is_finished: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_is_paused.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_is_paused.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{vb, verr, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{vb, verr, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_is_paused") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_is_paused") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_is_paused: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_pause.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_pause.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vnl, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{verr, vnl, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_pause") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_pause") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_pause: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_resume.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_resume.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vnl, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{verr, vnl, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_resume") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_resume") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_resume: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_seek.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_seek.rs
@@ -1,14 +1,19 @@
 use std::time::Duration;
 
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vnl, vok, vs}},
+    stdlib::{
+        common::{extract_handle, extract_number},
+        macros::{verr, vnl, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue, position_ms: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_seek") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_seek") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_seek: {}", e))),
     };
     let position_ms = match extract_number(position_ms, "sound_seek") {

--- a/crates/rl-vm/src/stdlib/audio/sound_set_speed.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_set_speed.rs
@@ -1,16 +1,18 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
     stdlib::{
         audio::common::extract_float,
-        common::extract_number,
+        common::extract_handle,
         macros::{verr, vnl, vok, vs},
     },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue, speed: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_set_speed") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_set_speed") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_set_speed: {}", e))),
     };
     let speed = match extract_float(speed, "sound_set_speed") {

--- a/crates/rl-vm/src/stdlib/audio/sound_set_volume.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_set_volume.rs
@@ -1,16 +1,18 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
     stdlib::{
         audio::common::extract_float,
-        common::extract_number,
+        common::extract_handle,
         macros::{verr, vnl, vok, vs},
     },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue, volume: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_set_volume") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_set_volume") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_set_volume: {}", e))),
     };
     let volume = match extract_float(volume, "sound_set_volume") {

--- a/crates/rl-vm/src/stdlib/audio/sound_stop.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_stop.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vnl, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{verr, vnl, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_stop") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_stop") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_stop: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/audio/sound_wait.rs
+++ b/crates/rl-vm/src/stdlib/audio/sound_wait.rs
@@ -1,12 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
-    stdlib::{common::extract_number, macros::{verr, vnl, vok, vs}},
+    stdlib::{
+        common::extract_handle,
+        macros::{verr, vnl, vok, vs},
+    },
     values::VmValue,
 };
 
 pub fn func(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let id = match extract_number(handle, "sound_wait") {
-        Ok(n) => n as i64,
+    let id = match extract_handle(handle, HandleKind::Audio, "sound_wait") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("sound_wait: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/c/call.rs
+++ b/crates/rl-vm/src/stdlib/c/call.rs
@@ -1,12 +1,13 @@
 use libffi::middle::{Arg, Cif, CodePtr, Type, arg};
 use libloading::Symbol;
+use rl_ast::statements::HandleKind;
 use std::rc::Rc;
 
 use crate::{
     Vm,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string},
+        common::{extract_handle, extract_string},
         macros::{vb, vby, verr, vf, vi, vnl, vok, vs},
     },
     values::VmValue,
@@ -84,8 +85,8 @@ pub fn std_call(
     arg_types: VmValue,
     ret_type: VmValue,
 ) -> VmValue {
-    let handle_id = match extract_number(handle, "call") {
-        Ok(n) => n as i64,
+    let handle_id = match extract_handle(handle, HandleKind::C, "call") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("call: {}", e))),
     };
     let fn_name = match extract_string(fn_name, "call") {

--- a/crates/rl-vm/src/stdlib/c/close.rs
+++ b/crates/rl-vm/src/stdlib/c/close.rs
@@ -1,15 +1,17 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
     stdlib::{
-        common::extract_number,
+        common::extract_handle,
         macros::{verr, vnl, vok, vs},
     },
     values::VmValue,
 };
 
 pub fn std_close(vm: &mut Vm, handle: VmValue) -> VmValue {
-    let handle_id = match extract_number(handle, "close") {
-        Ok(n) => n as i64,
+    let handle_id = match extract_handle(handle, HandleKind::C, "close") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("close: {}", e))),
     };
 

--- a/crates/rl-vm/src/stdlib/c/common.rs
+++ b/crates/rl-vm/src/stdlib/c/common.rs
@@ -1,14 +1,20 @@
 use std::path::PathBuf;
 
+use rl_ast::statements::HandleKind;
+
 use crate::Vm;
 use crate::stdlib::c::CHandle;
+use crate::values::VmValue;
 
 /// Registers a new handle and returns its id.
-pub fn insert_handle(vm: &mut Vm, handle: CHandle) -> i64 {
+pub fn insert_handle(vm: &mut Vm, handle: CHandle) -> VmValue {
     let id = vm.c_next_handle;
     vm.c_next_handle += 1;
     vm.c_handles.insert(id, handle);
-    id
+    VmValue::Handle {
+        kind: HandleKind::C,
+        id,
+    }
 }
 
 /// Where `compile` caches built shared libraries by content hash, and what

--- a/crates/rl-vm/src/stdlib/c/compile.rs
+++ b/crates/rl-vm/src/stdlib/c/compile.rs
@@ -11,7 +11,7 @@ use crate::{
             common::{cache_dir, insert_handle},
         },
         common::extract_string,
-        macros::{verr, vi, vok, vs},
+        macros::{verr, vok, vs},
     },
     values::VmValue,
 };
@@ -112,6 +112,6 @@ pub fn std_compile(vm: &mut Vm, source: VmValue) -> VmValue {
         }
     };
 
-    let id = insert_handle(vm, CHandle::Library(lib));
-    vok!(vi!(id))
+    let handle = insert_handle(vm, CHandle::Library(lib));
+    vok!(handle)
 }

--- a/crates/rl-vm/src/stdlib/c/has_symbol.rs
+++ b/crates/rl-vm/src/stdlib/c/has_symbol.rs
@@ -1,16 +1,18 @@
+use rl_ast::statements::HandleKind;
+
 use crate::{
     Vm,
     stdlib::{
         c::CHandle,
-        common::{extract_number, extract_string},
+        common::{extract_handle, extract_string},
         macros::{vb, verr, vok, vs},
     },
     values::VmValue,
 };
 
 pub fn std_has_symbol(vm: &mut Vm, handle: VmValue, fn_name: VmValue) -> VmValue {
-    let handle_id = match extract_number(handle, "has_symbol") {
-        Ok(n) => n as i64,
+    let handle_id = match extract_handle(handle, HandleKind::C, "has_symbol") {
+        Ok(id) => id,
         Err(e) => return verr!(vs!(format!("has_symbol: {}", e))),
     };
     let fn_name = match extract_string(fn_name, "has_symbol") {

--- a/crates/rl-vm/src/stdlib/c/load.rs
+++ b/crates/rl-vm/src/stdlib/c/load.rs
@@ -3,7 +3,7 @@ use crate::{
     stdlib::{
         c::{CHandle, common::insert_handle},
         common::extract_string,
-        macros::{verr, vi, vok, vs},
+        macros::{verr, vok, vs},
     },
     values::VmValue,
 };
@@ -25,6 +25,6 @@ pub fn std_load(vm: &mut Vm, path: VmValue) -> VmValue {
         }
     };
 
-    let id = insert_handle(vm, CHandle::Library(lib));
-    vok!(vi!(id))
+    let handle = insert_handle(vm, CHandle::Library(lib));
+    vok!(handle)
 }

--- a/crates/rl-vm/src/stdlib/common.rs
+++ b/crates/rl-vm/src/stdlib/common.rs
@@ -1,4 +1,5 @@
 use crate::values::VmValue;
+use rl_ast::statements::HandleKind;
 use rl_utils::{
     errors::{Error, Reason},
     span::Span,
@@ -81,5 +82,24 @@ pub fn extract_number(value: VmValue, name: &str) -> Result<u64, String> {
         _ => {
             unreachable!()
         }
+    }
+}
+
+/// Unwraps a `VmValue::Handle` of the expected kind into its raw id.
+/// This is the runtime half of the checker's static rejection - it catches
+/// a wrong-module handle that reached here anyway (e.g. through an `array[?]`
+/// or anything else the static checker can't fully see through).
+pub fn extract_handle(value: VmValue, expected: HandleKind, name: &str) -> Result<u64, String> {
+    match value {
+        VmValue::Handle { kind, id } if kind == expected => Ok(id),
+        VmValue::Handle { kind, .. } => Err(format!(
+            "{}: expected a {:?} handle, got a {:?} handle",
+            name, expected, kind
+        )),
+        other => Err(format!(
+            "{}: expected a handle, got {}",
+            name,
+            other.type_name()
+        )),
     }
 }

--- a/crates/rl-vm/src/values.rs
+++ b/crates/rl-vm/src/values.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::rc::Rc;
 
+use rl_ast::statements::HandleKind;
+
 use crate::Chunk;
 use crate::native::NativeFn;
 
@@ -45,6 +47,11 @@ pub enum VmValue {
         func: Rc<VmFunction>,
         captured: Rc<Vec<VmValue>>,
         capture_start: u16,
+    },
+    /// An opaque resource id scoped to one stdlib module (`c`, `audio`, ...).
+    Handle {
+        kind: HandleKind,
+        id: u64,
     },
 }
 
@@ -217,6 +224,7 @@ impl fmt::Display for VmValue {
             }
             VmValue::Tag { name, variant } => write!(f, "{}.{}", name, variant),
             VmValue::Closure { func, .. } => write!(f, "<closure {}/{}>", func.name, func.arity),
+            VmValue::Handle { kind, id } => write!(f, "<{:?} handle #{}>", kind, id),
         }
     }
 }
@@ -251,6 +259,12 @@ impl VmValue {
             VmValue::Record { .. } => "record",
             VmValue::Tag { .. } => "tag",
             VmValue::Closure { .. } => "closure",
+            VmValue::Handle { kind, .. } => match kind {
+                HandleKind::C => "c handle",
+                HandleKind::Net => "net handle",
+                HandleKind::Http => "http handle",
+                HandleKind::Audio => "audio handle",
+            },
         }
     }
 

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -105,13 +105,13 @@ pub struct Vm {
     /// id. `pub(crate)` (unlike every field above) because, unlike every
     /// other native function so far, `std::c`'s functions need persistent
     /// state across calls, not just their own arguments - see `stdlib::c`.
-    pub(crate) c_handles: HashMap<i64, crate::stdlib::c::CHandle>,
+    pub(crate) c_handles: HashMap<u64, crate::stdlib::c::CHandle>,
     /// Next handle id to hand out for `std::c` resources; only ever increments.
-    pub(crate) c_next_handle: i64,
+    pub(crate) c_next_handle: u64,
     /// Side-table of native audio-playback resources (`std::audio`), keyed by handle id.
-    pub(crate) audio_handles: HashMap<i64, crate::stdlib::audio::AudioHandle>,
+    pub(crate) audio_handles: HashMap<u64, crate::stdlib::audio::AudioHandle>,
     /// Next handle id to hand out for `std::audio` resources; only ever increments.
-    pub(crate) audio_next_handle: i64,
+    pub(crate) audio_next_handle: u64,
     /// Output device selected via `std::audio::set_output_device`, if any;
     /// `None` means the system default device.
     pub(crate) audio_output_device: Option<String>,


### PR DESCRIPTION
## What does this PR do?
Add new `handle` type for std modules

> [!NOTE]
> Currently to declare such use the following
> `dec your_handle_variable = function_that_returns_handle()` 
> since no keyword (yet) for `handle`

## Checklist
- [X] branched off `dev`
- [X] `cargo test --all-features` passes
- [X] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
