### PR TITLE
Feat/std/process/with exec

### DIFF
--- a/crates/rl-commons/src/keywords.rs
+++ b/crates/rl-commons/src/keywords.rs
@@ -170,8 +170,14 @@ pub mod net {
 }
 
 pub mod c {
-    pub const KEYWORDS: &[&str] =
-        &["compile", "load", "call", "has_symbol", "close", "clear_cache"];
+    pub const KEYWORDS: &[&str] = &[
+        "compile",
+        "load",
+        "call",
+        "has_symbol",
+        "close",
+        "clear_cache",
+    ];
 }
 
 pub mod path {
@@ -200,8 +206,11 @@ pub mod process {
         "pid",
         "sleep",
         "exec",
+        "with_exec",
         "exec_code",
+        "with_exec_code",
         "exec_lines",
+        "with_exec_lines",
     ];
 }
 

--- a/crates/rl-commons/src/stdlib_signatures/process.rs
+++ b/crates/rl-commons/src/stdlib_signatures/process.rs
@@ -14,8 +14,11 @@ pub fn module() -> ModuleNames {
         .with_typed_function(pid())
         .with_typed_function(sleep())
         .with_typed_function(exec())
+        .with_typed_function(with_exec())
         .with_typed_function(exec_code())
+        .with_typed_function(with_exec_code())
         .with_typed_function(exec_lines())
+        .with_typed_function(with_exec_lines())
 }
 
 fn args() -> StdFn {
@@ -49,8 +52,22 @@ fn exec() -> StdFn {
     StdFn::typed("exec", vec![(params(vec![T::String]), result(T::String))])
 }
 
+fn with_exec() -> StdFn {
+    StdFn::typed(
+        "with_exec",
+        vec![(params(vec![T::String, T::String]), result(T::String))],
+    )
+}
+
 fn exec_code() -> StdFn {
     StdFn::typed("exec_code", vec![(params(vec![T::String]), result(T::Int))])
+}
+
+fn with_exec_code() -> StdFn {
+    StdFn::typed(
+        "with_exec_code",
+        vec![(params(vec![T::String, T::String]), result(T::Int))],
+    )
 }
 
 fn exec_lines() -> StdFn {
@@ -58,6 +75,16 @@ fn exec_lines() -> StdFn {
         "exec_lines",
         vec![(
             params(vec![T::String]),
+            result(T::Array(Box::new(T::String))),
+        )],
+    )
+}
+
+fn with_exec_lines() -> StdFn {
+    StdFn::typed(
+        "with_exec_lines",
+        vec![(
+            params(vec![T::String, T::String]),
             result(T::Array(Box::new(T::String))),
         )],
     )

--- a/crates/rl-interpreter/src/stdlib/process/exec.rs
+++ b/crates/rl-interpreter/src/stdlib/process/exec.rs
@@ -20,6 +20,21 @@ fn shell_command(cmd: &str) -> Command {
     c
 }
 
+fn with_command(e: &str, cmd: &str) -> Command {
+    let mut c = Command::new(e);
+    c.args(["-c", cmd]);
+    c
+}
+
+pub fn std_with_exec(_: &mut Evaluator, e: String, cmd: String) -> Value {
+    let output = match with_command(&e, &cmd).output() {
+        Ok(o) => o,
+        Err(e) => return verr!(vs!(format!("with_exec: failed to run \"{}\": {}", cmd, e))),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    vok!(vs!(stdout.trim_end_matches('\n').to_string()))
+}
+
 pub fn std_exec(_: &mut Evaluator, cmd: String) -> Value {
     let output = match shell_command(&cmd).output() {
         Ok(o) => o,
@@ -39,11 +54,47 @@ pub fn std_exec_code(_: &mut Evaluator, cmd: String) -> Value {
     vok!(vi!(status.code().unwrap_or(-1) as i64))
 }
 
+pub fn std_with_exec_code(_: &mut Evaluator, e: String, cmd: String) -> Value {
+    let status = match with_command(&e, &cmd).status() {
+        Ok(s) => s,
+        Err(e) => {
+            return verr!(vs!(format!(
+                "with_exec_code: failed to run \"{}\": {}",
+                cmd, e
+            )));
+        }
+    };
+    vok!(vi!(status.code().unwrap_or(-1) as i64))
+}
+
 pub fn std_exec_lines(_: &mut Evaluator, cmd: String) -> Value {
     let output = match shell_command(&cmd).output() {
         Ok(o) => o,
         Err(e) => {
             return verr!(vs!(format!("exec_lines: failed to run \"{}\": {}", cmd, e)));
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let lines: Vec<Value> = stdout
+        .lines()
+        .map(|l| Value::String(l.to_string()))
+        .collect();
+
+    vok!(Value::Values {
+        items_type: TypeAnnotation::String,
+        items: lines,
+    })
+}
+
+pub fn std_with_exec_lines(_: &mut Evaluator, e: String, cmd: String) -> Value {
+    let output = match with_command(&e, &cmd).output() {
+        Ok(o) => o,
+        Err(e) => {
+            return verr!(vs!(format!(
+                "with_exec_lines: failed to run \"{}\": {}",
+                cmd, e
+            )));
         }
     };
 

--- a/crates/rl-interpreter/src/stdlib/process/exec.rs
+++ b/crates/rl-interpreter/src/stdlib/process/exec.rs
@@ -22,7 +22,7 @@ fn shell_command(cmd: &str) -> Command {
 
 fn with_command(e: &str, cmd: &str) -> Command {
     let mut c = Command::new(e);
-    c.args(["-c", cmd]);
+    c.args([cmd]);
     c
 }
 

--- a/crates/rl-interpreter/src/stdlib/process/mod.rs
+++ b/crates/rl-interpreter/src/stdlib/process/mod.rs
@@ -28,6 +28,9 @@ pub fn module() -> Module {
         .with_function("pid", pid::std_pid)
         .with_function("sleep", sleep::std_sleep)
         .with_function("exec", exec::std_exec)
+        .with_function("with_exec", exec::std_with_exec)
         .with_function("exec_code", exec::std_exec_code)
+        .with_function("with_exec_code", exec::std_with_exec_code)
         .with_function("exec_lines", exec::std_exec_lines)
+        .with_function("with_exec_lines", exec::std_with_exec_lines)
 }


### PR DESCRIPTION
## What does this PR do?
Add three functions for running executables without `sh` being present

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
