### PR TITLE
Refactor/vm

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -2,19 +2,6 @@ name: Benchmarks
 
 on:
   workflow_dispatch:
-    inputs:
-      bench:
-        description: Benchmark target(s) to run
-        type: choice
-        required: true
-        default: all
-        options:
-          - all
-          - lexer
-          - parser
-          - pipeline
-          - vm
-          - compare
   push:
     branches: [main]
 
@@ -37,21 +24,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      # `workflow_dispatch` selects a target; a push to main always runs all.
-      - name: Select benchmark targets
-        id: select
-        run: |
-          target="${{ github.event.inputs.bench || 'all' }}"
-          if [ "$target" = "all" ]; then
-            echo "args=" >> "$GITHUB_OUTPUT"
-          else
-            echo "args=--bench $target" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run benchmarks
         run: |
-          cargo bench -p rl-benches ${{ steps.select.outputs.args }} -- \
-            --warm-up-time 0.5 --measurement-time 2 --noplot
+          cargo bench -p rl-benches --benches -- \
+            --warm-up-time 0.2 --measurement-time 2 --noplot
 
       - name: Upload criterion report
         uses: actions/upload-artifact@v4

--- a/crates/rl-vm/src/chunk.rs
+++ b/crates/rl-vm/src/chunk.rs
@@ -224,4 +224,19 @@ impl Chunk {
     pub fn read_u16(&self, offset: usize) -> u16 {
         u16::from_le_bytes([self.code[offset], self.code[offset + 1]])
     }
+
+    /// Inverse function of write_u16, without bounds checks.
+    ///
+    /// # Safety
+    /// `offset` and `offset + 1` must be valid indices into `code`. That's
+    /// only true for bytecode emitted by this compiler (`write_u16` always
+    /// appends exactly two bytes), mirroring [`OpCode::from_u8_unchecked`].
+    #[inline(always)]
+    pub unsafe fn read_u16_unchecked(&self, offset: usize) -> u16 {
+        debug_assert!(offset + 1 < self.code.len(), "operand read past end of code");
+        unsafe {
+            let p = self.code.as_ptr().add(offset);
+            u16::from_le_bytes([*p, *p.add(1)])
+        }
+    }
 }

--- a/crates/rl-vm/src/stdlib/array/arr_all.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_all.rs
@@ -26,7 +26,7 @@ pub fn std_arr_all(eval: &mut Vm, array: VmValue, function: VmValue) -> Result<V
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Bool(false) = mapped_item {
             return Ok(vok!(VmValue::Bool(false)));
         }

--- a/crates/rl-vm/src/stdlib/array/arr_any.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_any.rs
@@ -26,7 +26,7 @@ pub fn std_arr_any(eval: &mut Vm, array: VmValue, function: VmValue) -> Result<V
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Bool(true) = mapped_item {
             return Ok(vok!(VmValue::Bool(true)));
         }

--- a/crates/rl-vm/src/stdlib/array/arr_filter.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_filter.rs
@@ -33,7 +33,7 @@ pub fn std_arr_filter(
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Bool(true) = mapped_item {
             result.push((*item).clone());
         }

--- a/crates/rl-vm/src/stdlib/array/arr_find.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_find.rs
@@ -26,7 +26,7 @@ pub fn std_arr_find(eval: &mut Vm, array: VmValue, function: VmValue) -> Result<
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Bool(true) = mapped_item {
             return Ok(vok!((*item).clone()));
         }

--- a/crates/rl-vm/src/stdlib/array/arr_find_index.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_find_index.rs
@@ -30,7 +30,7 @@ pub fn std_arr_find_index(
 
     for (i, item) in items.iter().enumerate() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Bool(true) = mapped_item {
             return Ok(vok!(VmValue::Int(i as i64)));
         }

--- a/crates/rl-vm/src/stdlib/array/arr_flat_map.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_flat_map.rs
@@ -33,7 +33,7 @@ pub fn std_arr_flat_map(
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         if let VmValue::Arr(inner) = mapped_item {
             result.extend((*inner).clone());
         }

--- a/crates/rl-vm/src/stdlib/array/arr_for_each.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_for_each.rs
@@ -29,7 +29,7 @@ pub fn std_arr_for_each(
     }
 
     for item in items.iter() {
-        eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+        eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
     }
 
     Ok(vok!(VmValue::Null))

--- a/crates/rl-vm/src/stdlib/array/arr_map.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_map.rs
@@ -29,7 +29,7 @@ pub fn std_arr_map(eval: &mut Vm, array: VmValue, function: VmValue) -> Result<V
 
     for item in items.iter() {
         let mapped_item =
-            eval.call_value(function.clone(), vec![(*item).clone()], eval.current_span())?;
+            eval.call_value(&function, std::slice::from_ref(item), eval.current_span())?;
         result.push(mapped_item);
     }
 

--- a/crates/rl-vm/src/stdlib/array/arr_reduce.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_reduce.rs
@@ -33,8 +33,8 @@ pub fn std_arr_reduce(
 
     for item in items.iter() {
         result = eval.call_value(
-            function.clone(),
-            vec![result, (*item).clone()],
+            &function,
+            &[result, (*item).clone()],
             eval.current_span(),
         )?;
     }

--- a/crates/rl-vm/src/stdlib/array/arr_sort_by.rs
+++ b/crates/rl-vm/src/stdlib/array/arr_sort_by.rs
@@ -34,8 +34,8 @@ pub fn std_arr_sort_by(
         let mut j = i;
         while j > 0 {
             let result = eval.call_value(
-                function.clone(),
-                vec![items[j - 1].clone(), items[j].clone()],
+                &function,
+                &[items[j - 1].clone(), items[j].clone()],
                 eval.current_span(),
             )?;
 

--- a/crates/rl-vm/src/stdlib/debug/bench.rs
+++ b/crates/rl-vm/src/stdlib/debug/bench.rs
@@ -27,7 +27,7 @@ pub fn func(eval: &mut Vm, function: VmValue, iterations_val: VmValue) -> VmValu
 
     let start = std::time::Instant::now();
     for _ in 0..iterations {
-        if let Err(e) = eval.call_value(function.clone(), vec![], eval.current_span()) {
+        if let Err(e) = eval.call_value(&function, &[], eval.current_span()) {
             return verr!(vs!(format!(
                 "bench: error executing the function: {}",
                 e.message()

--- a/crates/rl-vm/src/stdlib/gui/common.rs
+++ b/crates/rl-vm/src/stdlib/gui/common.rs
@@ -46,7 +46,7 @@ pub fn close_window(eval: &mut Vm, id: u64) {
         eval.gui_handles.remove(child);
     }
     if let Some(cb) = w.on_close {
-        report_callback_err(eval.call_value(cb, vec![], Span::dummy()));
+        report_callback_err(eval.call_value(&cb, &[], Span::dummy()));
     }
 }
 

--- a/crates/rl-vm/src/stdlib/gui/gui_run.rs
+++ b/crates/rl-vm/src/stdlib/gui/gui_run.rs
@@ -482,8 +482,8 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
         };
         if let Some(cb) = callback {
             report_callback_err(eval.call_value(
-                cb,
-                vec![VmValue::Str(text.into())],
+                &cb,
+                &[VmValue::Str(text.into())],
                 Span::dummy(),
             ));
         }
@@ -496,8 +496,8 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
         };
         if let Some(cb) = callback {
             report_callback_err(eval.call_value(
-                cb,
-                vec![VmValue::Str(text.into())],
+                &cb,
+                &[VmValue::Str(text.into())],
                 Span::dummy(),
             ));
         }
@@ -512,7 +512,7 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
             _ => None,
         };
         if let Some(cb) = callback {
-            report_callback_err(eval.call_value(cb, vec![VmValue::Bool(checked)], Span::dummy()));
+            report_callback_err(eval.call_value(&cb, &[VmValue::Bool(checked)], Span::dummy()));
         }
     }
 
@@ -525,7 +525,7 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
             _ => None,
         };
         if let Some(cb) = callback {
-            report_callback_err(eval.call_value(cb, vec![VmValue::Int(sel as i64)], Span::dummy()));
+            report_callback_err(eval.call_value(&cb, &[VmValue::Int(sel as i64)], Span::dummy()));
         }
     }
 
@@ -538,7 +538,7 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
             _ => None,
         };
         if let Some(cb) = callback {
-            report_callback_err(eval.call_value(cb, vec![VmValue::Float(v)], Span::dummy()));
+            report_callback_err(eval.call_value(&cb, &[VmValue::Float(v)], Span::dummy()));
         }
     }
 
@@ -548,7 +548,7 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
             _ => None,
         };
         if let Some(cb) = callback {
-            report_callback_err(eval.call_value(cb, vec![], Span::dummy()));
+            report_callback_err(eval.call_value(&cb, &[], Span::dummy()));
         }
     }
 
@@ -575,8 +575,8 @@ fn render_window(eval: &mut Vm, ctx: &egui::Context, window_id: u64) {
         if let Some(cb) = on_key {
             for key_name in key_names {
                 report_callback_err(eval.call_value(
-                    cb.clone(),
-                    vec![VmValue::Str(key_name.into())],
+                    &cb,
+                    &[VmValue::Str(key_name.into())],
                     Span::dummy(),
                 ));
             }

--- a/crates/rl-vm/src/stdlib/result/result_map.rs
+++ b/crates/rl-vm/src/stdlib/result/result_map.rs
@@ -7,7 +7,7 @@ use crate::{
 pub fn std_result_map(eval: &mut Vm, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
     match a {
         VmValue::Ok(inner) => {
-            let mapped = match eval.call_value(b, vec![*inner], eval.current_span()) {
+            let mapped = match eval.call_value(&b, &[*inner], eval.current_span()) {
                 Ok(mapped) => mapped,
                 Err(e) => return Ok(verr!(vs!(e.message().to_string()))),
             };
@@ -25,7 +25,7 @@ pub fn std_result_map(eval: &mut Vm, a: VmValue, b: VmValue) -> Result<VmValue, 
 pub fn std_result_map_err(eval: &mut Vm, a: VmValue, b: VmValue) -> Result<VmValue, VmError> {
     match a {
         VmValue::Err(inner) => {
-            let mapped = match eval.call_value(b, vec![*inner], eval.current_span()) {
+            let mapped = match eval.call_value(&b, &[*inner], eval.current_span()) {
                 Ok(mapped) => mapped,
                 Err(e) => return Ok(verr!(vs!(e.message().to_string()))),
             };

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -78,6 +78,11 @@ struct CallFrame<'a> {
     source: FrameSource<'a>,
     ip: usize,
     scope_base: usize,
+    /// `scope_starts[scope_base]`, the locals base of this frame. Cached here
+    /// (instead of re-indexing the scope table at every frame switch) so
+    /// `Return`/`Propagate` can restore the caller's base from a plain struct
+    /// field read.
+    frame_base: usize,
 }
 
 pub struct Vm {
@@ -85,10 +90,16 @@ pub struct Vm {
     globals: Vec<VmValue>,
     locals: Vec<VmValue>,
     scope_starts: Vec<usize>,
-    /// [`Span`] of the instruction currently executing, refreshed once per
-    /// dispatch loop iteration in [`Vm::run`]. Every runtime error is
-    /// anchored here.
-    current_span: Span,
+    /// Byte offset of the instruction currently executing, written once per
+    /// dispatch loop iteration. The [`Span`] is *not* materialized eagerly -
+    /// it's recovered from the chunk on demand via [`Vm::cur_span`] only when
+    /// an error is built or a native function asks for it, which avoids a
+    /// per-instruction copy in the hot loop.
+    current_ip: usize,
+    /// The chunk the currently-executing instruction belongs to, kept in sync
+    /// with the dispatch loop's `cur_chunk` local so [`Vm::cur_span`] can
+    /// resolve `current_ip`. `null` when no chunk is running.
+    current_chunk: *const Chunk,
     /// Original source text, so runtime errors can render ariadne snippets.
     source: Option<SourceFile>,
     /// Byte-offset -> line/col table, used when `source` is `None` (e.g.
@@ -149,7 +160,8 @@ impl Vm {
             globals: Vec::new(),
             locals: Vec::new(),
             scope_starts: Vec::new(),
-            current_span: Span::dummy(),
+            current_ip: 0,
+            current_chunk: std::ptr::null(),
             source: None,
             line_index: None,
             impl_methods: HashMap::new(),
@@ -191,7 +203,7 @@ impl Vm {
     /// executing instruction, with source (or a line-index location)
     /// attached when known.
     pub fn err(&self, message: impl Into<String>) -> VmError {
-        let err = Error::at(Reason::Runtime, message, self.current_span);
+        let err = Error::at(Reason::Runtime, message, self.cur_span());
         self.attach_location(err)
     }
 
@@ -199,7 +211,18 @@ impl Vm {
     /// (which don't receive a `Span` argument) can use this to anchor errors
     /// or re-enter the interpreter via [`Vm::call_value`] at the right spot.
     pub fn current_span(&self) -> Span {
-        self.current_span
+        self.cur_span()
+    }
+
+    /// Resolves the span of the currently-executing instruction from the
+    /// lazily-tracked `current_ip`/`current_chunk`, without copying it on
+    /// every instruction. Falls back to a dummy span when no chunk is
+    /// running (e.g. a native function invoked before `Vm::run`).
+    fn cur_span(&self) -> Span {
+        if self.current_chunk.is_null() {
+            return Span::dummy();
+        }
+        unsafe { (*self.current_chunk).span_at(self.current_ip) }
     }
 
     /// Original source attached via [`Vm::with_source_file`], if any.
@@ -214,7 +237,7 @@ impl Vm {
     /// loop, so every native-function error still gets a correct source
     /// snippet without threading a `Span` through `FromValue`/`IntoNativeFn`.
     pub fn annotate(&self, e: VmError) -> VmError {
-        let e = e.with_span(self.current_span);
+        let e = e.with_span(self.cur_span());
         self.attach_location(e)
     }
 
@@ -332,6 +355,7 @@ impl Vm {
             source,
             ip: 0,
             scope_base,
+            frame_base: self.scope_starts.get(scope_base).copied().unwrap_or(0),
         }];
         self.run_frames(frames)?;
         Ok(self.stack.pop().unwrap_or(VmValue::Null))
@@ -343,6 +367,7 @@ impl Vm {
             source: FrameSource::Top(chunk),
             ip: 0,
             scope_base: self.scope_starts.len(),
+            frame_base: 0,
         }];
         self.run_frames(frames)
     }
@@ -355,13 +380,27 @@ impl Vm {
     /// higher-order callback call.
     fn run_frames(&mut self, mut frames: Vec<CallFrame>) -> Result<(), VmError> {
         let mut cur_chunk: *const Chunk = frames[0].source.chunk();
+        self.current_chunk = cur_chunk;
         let mut ip: usize = 0;
         let mut scope_base: usize = frames[0].scope_base;
+        // `self.scope_starts[scope_base]` - the locals base of the current
+        // call frame. Constant for the frame's lifetime (only ever written by
+        // the frame's first `PushScope`), so cache it instead of re-indexing
+        // the scope table on every local access.
+        let mut frame_base: usize = frames[0].frame_base;
 
         macro_rules! chunk {
             () => {
                 unsafe { &*cur_chunk }
             };
+        }
+        macro_rules! read_u16 {
+            () => {{
+                // SAFETY: `ip` and `ip + 1` index the current chunk's operand
+                // bytes, which the compiler always writes in full pairs (see
+                // `Chunk::write_u16`), so both are in bounds here.
+                unsafe { (&*cur_chunk).read_u16_unchecked(ip) }
+            }};
         }
 
         loop {
@@ -373,20 +412,27 @@ impl Vm {
                 }
                 let top = frames.last().unwrap();
                 cur_chunk = top.source.chunk();
+                self.current_chunk = cur_chunk;
                 ip = top.ip;
                 scope_base = top.scope_base;
+                frame_base = top.frame_base;
                 continue;
             }
 
-            let op = OpCode::from_u8_unchecked(chunk!().code[ip]);
+            // SAFETY: `ip < code.len()` was checked above and the bytecode is
+            // compiler-emitted, so the byte is a valid opcode (see
+            // `OpCode::from_u8_unchecked`).
+            let op = unsafe { OpCode::from_u8_unchecked(*(&*cur_chunk).code.as_ptr().add(ip)) };
             ip += 1;
-            self.current_span = chunk!().span_at(ip - 1);
+            self.current_ip = ip - 1;
 
             match op {
                 OpCode::Const => {
-                    let idx = chunk!().read_u16(ip) as usize;
+                    let idx = read_u16!() as usize;
                     ip += 2;
-                    let val = chunk!().constants[idx].clone();
+                    // SAFETY: `idx` was emitted by the compiler and always
+                    // points at a valid constant slot.
+                    let val = unsafe { (&*cur_chunk).constants.get_unchecked(idx).clone() };
                     self.stack.push(val);
                 }
 
@@ -417,11 +463,11 @@ impl Vm {
                     self.stack.push(out);
                 }
                 OpCode::Eq => {
-                    let (a, b) = self.pop_two()?;
+                    let (a, b) = self.pop_two_unchecked();
                     self.stack.push(VmValue::Bool(a == b));
                 }
                 OpCode::NotEq => {
-                    let (a, b) = self.pop_two()?;
+                    let (a, b) = self.pop_two_unchecked();
                     self.stack.push(VmValue::Bool(a != b));
                 }
                 OpCode::Less => self.binary_cmp(|o| o.is_lt())?,
@@ -430,25 +476,23 @@ impl Vm {
                 OpCode::GreaterEq => self.binary_cmp(|o| o.is_ge())?,
 
                 OpCode::GetLocal => {
-                    let flat = chunk!().read_u16(ip) as usize;
+                    let flat = read_u16!() as usize;
                     ip += 2;
-                    let frame_base = self.scope_starts[scope_base];
                     let val = self.locals[frame_base + flat].clone();
                     self.stack.push(val);
                 }
                 OpCode::SetLocal => {
-                    let flat = chunk!().read_u16(ip) as usize;
+                    let flat = read_u16!() as usize;
                     ip += 2;
                     let val = self
                         .stack
                         .last()
                         .cloned()
                         .ok_or_else(|| self.err("stack underflow on assignment"))?;
-                    let frame_base = self.scope_starts[scope_base];
                     self.locals[frame_base + flat] = val;
                 }
                 OpCode::GetGlobal => {
-                    let slot = chunk!().read_u16(ip) as usize;
+                    let slot = read_u16!() as usize;
                     ip += 2;
                     let val =
                         self.globals.get(slot).cloned().ok_or_else(|| {
@@ -457,7 +501,7 @@ impl Vm {
                     self.stack.push(val);
                 }
                 OpCode::SetGlobal => {
-                    let slot = chunk!().read_u16(ip) as usize;
+                    let slot = read_u16!() as usize;
                     ip += 2;
                     let val = self
                         .stack
@@ -470,7 +514,7 @@ impl Vm {
                     self.globals[slot] = val;
                 }
                 OpCode::DefineLocal => {
-                    let slot = chunk!().read_u16(ip) as usize;
+                    let slot = read_u16!() as usize;
                     ip += 2;
                     let val = self.pop()?;
 
@@ -480,11 +524,10 @@ impl Vm {
                         }
                         self.globals[slot] = val;
                     } else {
-                        let base = self.scope_starts[scope_base];
-                        if base + slot >= self.locals.len() {
-                            self.locals.resize(base + slot + 1, VmValue::Null);
+                        if frame_base + slot >= self.locals.len() {
+                            self.locals.resize(frame_base + slot + 1, VmValue::Null);
                         }
-                        self.locals[base + slot] = val;
+                        self.locals[frame_base + slot] = val;
                     }
                 }
                 OpCode::Pop => {
@@ -500,11 +543,19 @@ impl Vm {
                     }
                     let top = frames.last().unwrap();
                     cur_chunk = top.source.chunk();
+                    self.current_chunk = cur_chunk;
                     ip = top.ip;
                     scope_base = top.scope_base;
+                    frame_base = top.frame_base;
                 }
 
-                OpCode::PushScope => self.scope_starts.push(self.locals.len()),
+                OpCode::PushScope => {
+                    let base = self.locals.len();
+                    self.scope_starts.push(base);
+                    if self.scope_starts.len() - 1 == scope_base {
+                        frame_base = base;
+                    }
+                }
                 OpCode::PopScope => {
                     let num_active = self.scope_starts.len() - scope_base;
                     let min_active = if frames.len() > 1 { 1 } else { 0 };
@@ -516,12 +567,12 @@ impl Vm {
                 }
 
                 OpCode::Jump => {
-                    let offset = chunk!().read_u16(ip) as usize;
+                    let offset = read_u16!() as usize;
                     ip += 2;
                     ip += offset;
                 }
                 OpCode::JumpIfFalse => {
-                    let offset = chunk!().read_u16(ip) as usize;
+                    let offset = read_u16!() as usize;
                     ip += 2;
                     match self.pop()? {
                         VmValue::Bool(false) => ip += offset,
@@ -534,13 +585,13 @@ impl Vm {
                     }
                 }
                 OpCode::Loop => {
-                    let offset = chunk!().read_u16(ip) as usize;
+                    let offset = read_u16!() as usize;
                     ip += 2;
                     ip -= offset;
                 }
 
                 OpCode::Call => {
-                    let arg_count = chunk!().read_u16(ip) as usize;
+                    let arg_count = read_u16!() as usize;
                     ip += 2;
 
                     let callee_idx = self.stack.len() - 1 - arg_count;
@@ -565,13 +616,16 @@ impl Vm {
 
                             frames.last_mut().unwrap().ip = ip;
                             cur_chunk = &func.chunk as *const Chunk;
+                            self.current_chunk = cur_chunk;
                             frames.push(CallFrame {
                                 source: FrameSource::Func(func),
                                 ip: 0,
                                 scope_base: new_scope_base,
+                                frame_base: base,
                             });
                             ip = 0;
                             scope_base = new_scope_base;
+                            frame_base = base;
                         }
 
                         VmValue::Native(native) => {
@@ -614,13 +668,16 @@ impl Vm {
 
                             frames.last_mut().unwrap().ip = ip;
                             cur_chunk = &func.chunk as *const Chunk;
+                            self.current_chunk = cur_chunk;
                             frames.push(CallFrame {
                                 source: FrameSource::Func(func),
                                 ip: 0,
                                 scope_base: new_scope_base,
+                                frame_base: base,
                             });
                             ip = 0;
                             scope_base = new_scope_base;
+                            frame_base = base;
                         }
 
                         other => return Err(self.err(format!("cannot call {other:?}"))),
@@ -649,8 +706,10 @@ impl Vm {
                             }
                             let top = frames.last().unwrap();
                             cur_chunk = top.source.chunk();
+                            self.current_chunk = cur_chunk;
                             ip = top.ip;
                             scope_base = top.scope_base;
+                            frame_base = top.frame_base;
                         }
                         other => self.stack.push(other),
                     }
@@ -662,7 +721,7 @@ impl Vm {
                 }
 
                 OpCode::BuildArr => {
-                    let count = chunk!().read_u16(ip) as usize;
+                    let count = read_u16!() as usize;
                     ip += 2;
                     if self.stack.len() < count {
                         return Err(self.err("stack underflow building array"));
@@ -672,7 +731,7 @@ impl Vm {
                 }
 
                 OpCode::BuildTuple => {
-                    let count = chunk!().read_u16(ip) as usize;
+                    let count = read_u16!() as usize;
                     ip += 2;
                     if self.stack.len() < count {
                         return Err(self.err("stack underflow building tuple"));
@@ -709,7 +768,7 @@ impl Vm {
                 }
 
                 OpCode::BuildSet => {
-                    let count = chunk!().read_u16(ip) as usize;
+                    let count = read_u16!() as usize;
                     ip += 2;
                     if self.stack.len() < count {
                         return Err(self.err("stack underflow building set"));
@@ -726,7 +785,7 @@ impl Vm {
                 }
 
                 OpCode::BuildMap => {
-                    let count = chunk!().read_u16(ip) as usize; // number of entries
+                    let count = read_u16!() as usize; // number of entries
                     ip += 2;
                     if self.stack.len() < count * 2 {
                         return Err(self.err("stack underflow building map"));
@@ -746,11 +805,11 @@ impl Vm {
                 }
 
                 OpCode::BuildRecord => {
-                    let name_idx = chunk!().read_u16(ip) as usize;
+                    let name_idx = read_u16!() as usize;
                     ip += 2;
-                    let fields_idx = chunk!().read_u16(ip) as usize;
+                    let fields_idx = read_u16!() as usize;
                     ip += 2;
-                    let count = chunk!().read_u16(ip) as usize;
+                    let count = read_u16!() as usize;
                     ip += 2;
 
                     let VmValue::Str(name) = chunk!().constants[name_idx].clone() else {
@@ -780,7 +839,7 @@ impl Vm {
                 }
 
                 OpCode::FieldGet => {
-                    let field_idx = chunk!().read_u16(ip) as usize;
+                    let field_idx = read_u16!() as usize;
                     ip += 2;
                     let VmValue::Str(field) = chunk!().constants[field_idx].clone() else {
                         return Err(self.err("corrupt bytecode: field name is not a string"));
@@ -800,7 +859,7 @@ impl Vm {
                 }
 
                 OpCode::FieldSet => {
-                    let field_idx = chunk!().read_u16(ip) as usize;
+                    let field_idx = read_u16!() as usize;
                     ip += 2;
                     let VmValue::Str(field) = chunk!().constants[field_idx].clone() else {
                         return Err(self.err("corrupt bytecode: field name is not a string"));
@@ -821,9 +880,9 @@ impl Vm {
                     self.stack.push(value);
                 }
                 OpCode::BuildClosure => {
-                    let const_idx = chunk!().read_u16(ip) as usize;
+                    let const_idx = read_u16!() as usize;
                     ip += 2;
-                    let capture_start = chunk!().read_u16(ip);
+                    let capture_start = read_u16!();
                     ip += 2;
                     let VmValue::Function(func) = chunk!().constants[const_idx].clone() else {
                         return Err(
@@ -853,9 +912,9 @@ impl Vm {
                 }
 
                 OpCode::RegisterMethod => {
-                    let key_idx = chunk!().read_u16(ip) as usize;
+                    let key_idx = read_u16!() as usize;
                     ip += 2;
-                    let func_idx = chunk!().read_u16(ip) as usize;
+                    let func_idx = read_u16!() as usize;
                     ip += 2;
 
                     let VmValue::Str(key) = chunk!().constants[key_idx].clone() else {
@@ -868,7 +927,7 @@ impl Vm {
                 }
 
                 OpCode::LookupAssoc => {
-                    let key_idx = chunk!().read_u16(ip) as usize;
+                    let key_idx = read_u16!() as usize;
                     ip += 2;
 
                     let VmValue::Str(key) = chunk!().constants[key_idx].clone() else {
@@ -883,7 +942,7 @@ impl Vm {
                 }
 
                 OpCode::LookupMethod => {
-                    let name_idx = chunk!().read_u16(ip) as usize;
+                    let name_idx = read_u16!() as usize;
                     ip += 2;
 
                     let VmValue::Str(method) = chunk!().constants[name_idx].clone() else {
@@ -908,7 +967,7 @@ impl Vm {
                 }
 
                 OpCode::Cast => {
-                    let code = chunk!().read_u16(ip) as usize;
+                    let code = read_u16!() as usize;
                     ip += 2;
                     let value = self.pop()?;
                     let cast = self.cast(value, code)?;
@@ -1102,11 +1161,6 @@ impl Vm {
     /// Helper functions that wraps the Vec::pop to return valid VmError or VmValue
     fn pop(&mut self) -> Result<VmValue, VmError> {
         self.stack.pop().ok_or_else(|| self.err("stack underflow"))
-    }
-    fn pop_two(&mut self) -> Result<(VmValue, VmValue), VmError> {
-        let b = self.pop()?;
-        let a = self.pop()?;
-        Ok((a, b))
     }
 
     /// Helper function for arth operations

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -242,48 +242,118 @@ impl Vm {
     ///
     /// Used by native stdlib modules (e.g. `std::gui`) that need to invoke
     /// an rl-lang callback value from Rust - outside the normal `Call`
-    /// opcode dispatch path, e.g. from an egui event callback. Builds a
-    /// tiny synthetic `Chunk` (`Const` callee, `Const` per arg, `Call`,
-    /// `Return`) and runs it via `Vm::run_and_return`; `self.stack`,
-    /// `self.locals`, and `self.scope_starts` are ordinary fields, so this
-    /// is safe to call reentrantly from inside an already-running
-    /// dispatch loop (e.g. from within a native function's own body).
+    /// opcode dispatch path, e.g. from an egui event callback. Dispatches
+    /// directly on the callee instead of building a synthetic chunk:
+    /// native functions are invoked synchronously, and user functions /
+    /// closures get their own call frame executed to completion via the
+    /// shared [`Vm::run_frames`] loop. `self.stack`, `self.locals`, and
+    /// `self.scope_starts` are ordinary fields, so this is safe to call
+    /// reentrantly from inside an already-running dispatch loop (e.g. from
+    /// within a native function's own body).
     pub fn call_value(
         &mut self,
-        callee: VmValue,
-        args: Vec<VmValue>,
-        span: Span,
+        callee: &VmValue,
+        args: &[VmValue],
+        _span: Span,
     ) -> Result<VmValue, VmError> {
-        let mut chunk = Chunk::new();
-        let arg_count = args.len() as u16;
+        self.invoke_callable(callee, args)
+    }
 
-        let callee_idx = chunk.add_constant(callee);
-        chunk.write_op(OpCode::Const, span);
-        chunk.write_u16(callee_idx, span);
-
-        for arg in args {
-            let idx = chunk.add_constant(arg);
-            chunk.write_op(OpCode::Const, span);
-            chunk.write_u16(idx, span);
+    /// Direct callable dispatch backing [`Vm::call_value`] (synchronous
+    /// invocation). Binds the arguments into a fresh scope and pushes a
+    /// single call frame for user functions and closures; runs native
+    /// functions inline.
+    fn invoke_callable(
+        &mut self,
+        callee: &VmValue,
+        args: &[VmValue],
+    ) -> Result<VmValue, VmError> {
+        match callee {
+            VmValue::Native(native) => {
+                (native.func)(self, args.to_vec()).map_err(|e| self.annotate(e))
+            }
+            VmValue::Function(func) => {
+                if args.len() != func.arity {
+                    return Err(self.err(format!(
+                        "{} expects {} args, got {}",
+                        func.name,
+                        func.arity,
+                        args.len()
+                    )));
+                }
+                let base = self.locals.len();
+                self.locals.resize(base + args.len(), VmValue::Null);
+                for (i, arg) in args.iter().enumerate() {
+                    self.locals[base + i] = arg.clone();
+                }
+                self.scope_starts.push(base);
+                let scope_base = self.scope_starts.len() - 1;
+                self.run_call_frame(FrameSource::Func(func.clone()), scope_base)
+            }
+            VmValue::Closure {
+                func,
+                captured,
+                capture_start,
+            } => {
+                if args.len() != func.arity {
+                    return Err(self.err(format!(
+                        "closure expects {} args, got {}",
+                        func.arity,
+                        args.len()
+                    )));
+                }
+                let base = self.locals.len();
+                self.locals
+                    .resize(base + (*capture_start) as usize, VmValue::Null);
+                self.locals.extend_from_slice(captured);
+                let params_start = base + (*capture_start) as usize + captured.len();
+                self.locals.resize(params_start + args.len(), VmValue::Null);
+                for (i, arg) in args.iter().enumerate() {
+                    self.locals[params_start + i] = arg.clone();
+                }
+                self.scope_starts.push(base);
+                let scope_base = self.scope_starts.len() - 1;
+                self.run_call_frame(FrameSource::Func(func.clone()), scope_base)
+            }
+            other => Err(self.err(format!("cannot call {other:?}"))),
         }
+    }
 
-        chunk.write_op(OpCode::Call, span);
-        chunk.write_u16(arg_count, span);
-
-        chunk.write_op(OpCode::Return, span);
-
-        self.run_and_return(&chunk)
+    /// Executes a single fresh call frame to completion, returning the value
+    /// its `Return` left on the stack. Used by [`Vm::invoke_callable`] to
+    /// run a user function / closure synchronously without routing through
+    /// the `Call` opcode.
+    fn run_call_frame(
+        &mut self,
+        source: FrameSource<'_>,
+        scope_base: usize,
+    ) -> Result<VmValue, VmError> {
+        let frames = vec![CallFrame {
+            source,
+            ip: 0,
+            scope_base,
+        }];
+        self.run_frames(frames)?;
+        Ok(self.stack.pop().unwrap_or(VmValue::Null))
     }
 
     /// Vm entry function
     pub fn run(&mut self, chunk: &Chunk) -> Result<(), VmError> {
-        let mut frames: Vec<CallFrame> = vec![CallFrame {
+        let frames = vec![CallFrame {
             source: FrameSource::Top(chunk),
             ip: 0,
             scope_base: self.scope_starts.len(),
         }];
+        self.run_frames(frames)
+    }
 
-        // caching method
+    /// Runs a stack of call frames to completion.
+    ///
+    /// The dispatch loop lives here so it can be reused both for whole
+    /// programs (`run`) and for synchronous callable invocations
+    /// (`call_value`), which avoids constructing a synthetic chunk on every
+    /// higher-order callback call.
+    fn run_frames(&mut self, mut frames: Vec<CallFrame>) -> Result<(), VmError> {
         let mut cur_chunk: *const Chunk = frames[0].source.chunk();
         let mut ip: usize = 0;
         let mut scope_base: usize = frames[0].scope_base;


### PR DESCRIPTION
## What does this PR do?
Some optimizations related to `vm`
- refactor `call_value`
- lazy-fy `span`
- allow more unchecked
- better frame base caching

Remove the input select from bench workflow