### PR TITLE
Tooling tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3882,8 +3882,10 @@ dependencies = [
  "rl-interpreter",
  "rl-lexer",
  "rl-parser",
+ "rl-tooling",
  "rl-utils",
  "rl-vm",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/rl-tests/Cargo.toml
+++ b/crates/rl-tests/Cargo.toml
@@ -13,3 +13,5 @@ rl-interpreter.workspace = true
 rl-utils.workspace = true
 rl-vm.workspace = true
 rl-commons.workspace = true
+rl-tooling.workspace = true
+tempfile = "3.27.0"

--- a/crates/rl-tests/tests/tests.rs
+++ b/crates/rl-tests/tests/tests.rs
@@ -4,3 +4,4 @@ mod interpreter;
 mod lexer;
 mod parser;
 mod vm;
+mod tooling;

--- a/crates/rl-tests/tests/tooling/common.rs
+++ b/crates/rl-tests/tests/tooling/common.rs
@@ -1,0 +1,11 @@
+use rl_tooling::new::try_create_project;
+use std::path::PathBuf;
+
+pub fn create_test_project(name: &str, no_git: bool) -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let project = temp.path().join(name);
+
+    try_create_project(project.to_str().unwrap(), no_git).unwrap();
+
+    (temp, project)
+}

--- a/crates/rl-tests/tests/tooling/dev.rs
+++ b/crates/rl-tests/tests/tooling/dev.rs
@@ -1,0 +1,96 @@
+use rl_tooling::dev::try_read_rl_toml;
+
+#[test]
+fn reads_valid_rl_toml() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let file = temp.path().join("rl.toml");
+
+    std::fs::write(
+        &file, 
+        r#"
+[project]
+name = "hello"
+version = "0.0.1"
+entry = "src/main.rl"
+        "#
+    )
+    .unwrap();
+
+    let manifest = try_read_rl_toml(&file).unwrap();
+
+    assert_eq!(manifest.project.name, "hello");
+    assert_eq!(manifest.project.version, "0.0.1");
+    assert_eq!(manifest.project.entry, "src/main.rl");
+}
+
+#[test]
+fn fails_when_rl_toml_does_not_exist() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("missing.toml");
+
+    let result = try_read_rl_toml(&file);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn fails_when_rl_toml_is_invalid() {
+    let temp = tempfile::tempdir().unwrap();
+    let file = temp.path().join("rl.toml");
+
+    std::fs::write(
+        &file, 
+        r#"
+[project]
+name = "hello"
+        "#
+    )
+    .unwrap();
+
+    let result = try_read_rl_toml(&file);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn fails_without_project_section() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let file = temp.path().join("rl.toml");
+
+    std::fs::write(
+        &file, 
+        r#"
+name = "hello"
+version = "0.0.1"
+entry = "src/main.rl"
+        "#
+    )
+    .unwrap();
+
+    let result = try_read_rl_toml(&file);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn fails_when_project_entry_is_missing() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let file = temp.path().join("rl.toml");
+
+    std::fs::write(
+        &file, 
+        r#"
+[project]
+name = "hello"
+version = "0.0.1"
+        "#
+    )
+    .unwrap();
+
+    let result = try_read_rl_toml(&file);
+    
+    assert!(result.is_err());
+}

--- a/crates/rl-tests/tests/tooling/format/format_tokens.rs
+++ b/crates/rl-tests/tests/tooling/format/format_tokens.rs
@@ -1,0 +1,161 @@
+use rl_tooling::format::format_tokens;
+
+use crate::common;
+
+#[test]
+fn format_simple_expression() {
+    let tokens = common::lex(" dec  int x =  1000");
+    let out = format_tokens(&tokens);
+    assert_eq!(out, "dec int x = 1000");
+}
+
+#[test]
+fn format_function_call() {
+    let tokens = common::lex("println    (\"hello\")");
+    let out = format_tokens(&tokens);
+    assert_eq!(out, "println(\"hello\")");
+}
+
+#[test]
+fn format_indentation_with_braces() {
+    let tokens = common::lex(r#"fn main(){
+println("hello")
+}"#
+    );
+
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        r#"fn main() {
+    println("hello")
+}"#
+    )
+}
+
+#[test]
+fn format_nested_blocks() {
+    let tokens = common::lex(r#"if x {
+if y {
+hello()
+}
+}"#
+    );
+
+    let out = format_tokens(&tokens);
+    assert_eq!(
+        out,
+        r#"if x {
+    if y {
+        hello()
+    }
+}"#
+    );
+}
+
+#[test]
+fn format_line_comments() {
+    let tokens = common::lex(r#"//hello
+dec int x = 1"#
+    );
+    
+    let out = format_tokens(&tokens);
+    assert_eq!(
+        out,
+        r#"
+// hello
+dec int x = 1"#
+    );
+}
+
+#[test]
+fn format_doc_comments() {
+    let tokens = common::lex(r#"/// docs
+fn main()"#);
+
+    let out = format_tokens(&tokens);
+    assert_eq!(
+        out,
+        r#"
+/// docs
+fn main()"#
+    );
+}
+
+#[test]
+fn format_blank_lines() {
+    let tokens = common::lex(r#"
+    
+    
+    
+dec int x = 1"#);
+
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        r#"
+
+dec int x = 1"#
+    );
+}
+
+#[test]
+fn format_unary_minus() {
+    let tokens = common::lex("x = - 10");
+    
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        "x = -10"
+    );
+}
+
+#[test]
+fn format_binary_minus() {
+    let tokens = common::lex("x = 10-5");
+    
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        "x = 10 - 5"
+    );
+}
+
+#[test]
+fn format_array_indexing() {
+    let tokens = common::lex("arr [0]");
+
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        "arr[0]"
+    );
+}
+
+#[test]
+fn format_generic_type_brackets() {
+    let tokens = common::lex("arr [int]");
+
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        "arr[int]"
+    );
+}
+
+#[test]
+fn format_function_call_with_arguments() {
+    let tokens = common::lex("foo(1,2)");
+
+    let out = format_tokens(&tokens);
+
+    assert_eq!(
+        out,
+        "foo(1, 2)"
+    );
+}

--- a/crates/rl-tests/tests/tooling/format/is_value_token.rs
+++ b/crates/rl-tests/tests/tooling/format/is_value_token.rs
@@ -1,0 +1,25 @@
+use rl_tooling::format::format_tokens;
+
+use crate::common;
+
+
+#[test]
+fn identifier_before_minus_is_binary_operator() {
+    let tokens = common::lex("x-10");
+
+    assert_eq!(format_tokens(&tokens), "x - 10");
+}
+
+#[test]
+fn literal_before_minus_is_binary_operator() {
+    let tokens = common::lex("10-5");
+    
+    assert_eq!(format_tokens(&tokens), "10 - 5");
+}
+
+#[test]
+fn operator_before_minus_is_unary_operator() {
+    let tokens = common::lex("10+-5");
+
+    assert_eq!(format_tokens(&tokens), "10 + -5");
+}

--- a/crates/rl-tests/tests/tooling/format/mod.rs
+++ b/crates/rl-tests/tests/tooling/format/mod.rs
@@ -1,0 +1,3 @@
+mod format_tokens;
+mod need_space;
+mod is_value_token;

--- a/crates/rl-tests/tests/tooling/format/need_space.rs
+++ b/crates/rl-tests/tests/tooling/format/need_space.rs
@@ -1,0 +1,32 @@
+use rl_tooling::format::format_tokens;
+
+use crate::common;
+
+
+#[test]
+fn no_space_after_opening_tokens() {
+    let tokens = common::lex("( x )");
+
+    assert_eq!(format_tokens(&tokens), "(x)");
+}
+
+#[test]
+fn no_space_before_closing_tokens() {
+    let tokens = common::lex("foo( x )");
+
+    assert_eq!(format_tokens(&tokens), "foo(x)");
+}
+
+#[test]
+fn no_space_before_comma() {
+    let tokens = common::lex("foo(a , b)");
+    
+    assert_eq!(format_tokens(&tokens), "foo(a, b)");
+}
+
+#[test]
+fn index_access_has_no_space() {
+    let tokens = common::lex("arr [0]");
+
+    assert_eq!(format_tokens(&tokens), "arr[0]");
+}

--- a/crates/rl-tests/tests/tooling/generate_docs.rs
+++ b/crates/rl-tests/tests/tooling/generate_docs.rs
@@ -1,0 +1,197 @@
+use std::fs;
+
+use rl_tooling::generate_docs::{DocItem, extract_doc_items, write_doc_site, write_doc_site_html};
+
+use crate::common;
+
+#[test]
+fn extracts_function_documentation() {
+    let tokens = common::lex(
+        r#"/// prints hello
+fn hello() {
+}"#
+    );
+
+    let items = extract_doc_items(&tokens, "main.rl");
+
+    assert_eq!(items.len(), 1);
+
+    let item = &items[0];
+
+    assert_eq!(item.kind, "fn");
+    assert_eq!(item.name, "hello");
+    assert_eq!(item.doc, "prints hello");
+    assert_eq!(item.file, "main.rl");
+}
+
+#[test]
+fn ignores_regular_comments() {
+    let tokens = common::lex(
+        r#"// not docs
+fn hello() {
+}
+"#
+    );
+
+    let items = extract_doc_items(&tokens, "main.rl");
+    assert!(items.is_empty())
+}
+
+#[test]
+fn extracts_multiple_documented_items() {
+    let tokens = common::lex(
+        r#"/// first
+fn one() {
+}
+
+/// second
+record User {
+}
+        "#
+    );
+
+    let items = extract_doc_items(&tokens, "main.rl");
+
+    assert_eq!(items.len(), 2);
+
+    assert_eq!(items[0].name, "one");
+    assert_eq!(items[1].name, "User");
+}
+
+#[test]
+fn write_markdown_docs() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let items = vec![
+        DocItem {
+            kind: "fn",
+            name: "hello".into(),
+            signature: "fn hello()".into(),
+            doc: "prints hello".into(),
+            file: "main.rl".into(),
+            line: 1
+        }
+    ];
+
+    write_doc_site(
+        &items, 
+        temp.path(), 
+        "my-project"
+    )
+    .unwrap();
+
+    assert!(temp.path().join("index.md").exists());
+    assert!(temp.path().join("main.md").exists());
+
+    let content = std::fs::read_to_string(temp.path().join("main.md")).unwrap();
+
+    assert!(content.contains("hello"));
+    assert!(content.contains("prints hello"));
+}
+
+#[test]
+fn groups_docs_by_file() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let items = vec![
+        DocItem {
+            kind: "fn",
+            name: "foo".into(),
+            signature: "fn foo()".into(),
+            doc: "prints foo".into(),
+            file: "foo.rl".into(),
+            line: 1,
+        },
+        DocItem {
+            kind: "fn",
+            name: "bar".into(),
+            signature: "fn bar()".into(),
+            doc: "prints bar".into(),
+            file: "bar.rl".into(),
+            line: 1,
+        }
+    ];
+
+    write_doc_site(
+        &items, 
+        temp.path(), 
+        "test"
+    ).unwrap();
+
+    assert!(temp.path().join("foo.md").exists());
+    assert!(temp.path().join("bar.md").exists());
+}
+
+#[test]
+fn writes_html_docs() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let items = vec![
+        DocItem {
+            kind: "fn",
+            name: "foo".into(),
+            signature: "fn foo()".into(),
+            doc: "prints foo".into(),
+            file: "main.rl".into(),
+            line: 1
+        }
+    ];
+
+    write_doc_site_html(
+        &items, 
+        temp.path(), 
+        "test", 
+        None, 
+        true
+    )
+    .unwrap();
+
+    assert!(temp.path().join("index.html").exists());
+    assert!(temp.path().join("main.html").exists());
+}
+
+#[test]
+fn html_output_escapes_special_chars() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let items = vec![
+        DocItem {
+            kind: "fn",
+            name: "test".into(),
+            signature: "<bad>".into(),
+            doc: "a < b".into(),
+            file: "main.rl".into(),
+            line: 1
+        }
+    ];
+
+    write_doc_site_html(
+        &items, 
+        temp.path(), 
+        "test", 
+        None, 
+        true
+    )
+    .unwrap();
+
+    let html = fs::read_to_string(temp.path().join("main.html")).unwrap();
+
+    assert!(html.contains("&lt;bad&gt;"));
+    assert!(html.contains("a &lt; b"));
+}
+
+#[test]
+fn html_without_highlight_does_not_write_script() {
+    let temp = tempfile::tempdir().unwrap();
+
+    write_doc_site_html(
+        &[], 
+        temp.path(), 
+        "test", 
+        None, 
+        true
+    )
+    .unwrap();
+
+    assert!(!temp.path().join("rl-highlight.js").exists())
+}

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -3,3 +3,4 @@ mod new;
 mod dev;
 mod format;
 mod workflows;
+mod generate_docs;

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -1,3 +1,4 @@
 mod common;
 mod new;
 mod dev;
+mod format;

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -4,3 +4,4 @@ mod dev;
 mod format;
 mod workflows;
 mod generate_docs;
+mod package;

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -1,2 +1,3 @@
 mod common;
 mod new;
+mod dev;

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -2,3 +2,4 @@ mod common;
 mod new;
 mod dev;
 mod format;
+mod workflows;

--- a/crates/rl-tests/tests/tooling/mod.rs
+++ b/crates/rl-tests/tests/tooling/mod.rs
@@ -1,0 +1,2 @@
+mod common;
+mod new;

--- a/crates/rl-tests/tests/tooling/new.rs
+++ b/crates/rl-tests/tests/tooling/new.rs
@@ -1,0 +1,40 @@
+use crate::tooling::common::create_test_project;
+
+#[test]
+fn create_project_creates_directory() {
+    let (_temp, project) = create_test_project("my-project", true);
+    assert!(project.exists());
+}
+
+#[test]
+fn create_project_creates_rl_toml() {
+    let (_temp, project) = create_test_project("my-project", true);
+    assert!(project.join("rl.toml").exists());
+}
+
+#[test]
+fn create_project_creates_main_file() {
+    let (_temp, project) = create_test_project("test", true);
+    assert!(project.join("src/main.rl").exists());
+}
+
+#[test]
+fn create_project_generates_correct_manifest() {
+    let (_temp, project) = create_test_project("test", true);
+    let content = std::fs::read_to_string(project.join("rl.toml")).unwrap();
+
+    assert!(content.contains(&format!("name = \"{}\"", project.to_str().unwrap())));
+    assert!(content.contains("entry = \"src/main.rl\""));
+}
+
+#[test]
+fn create_project_without_git_does_not_create_git_directory() {
+    let (_temp, project) = create_test_project("hello", true);
+    assert!(!project.join(".git").exists());
+}
+
+#[test]
+fn create_project_with_git_creates_git_directory() {
+    let (_temp, project) = create_test_project("hello", false);
+    assert!(project.join(".git").exists());
+}

--- a/crates/rl-tests/tests/tooling/package.rs
+++ b/crates/rl-tests/tests/tooling/package.rs
@@ -1,0 +1,90 @@
+use rl_tooling::package::bundle;
+
+#[test]
+fn bundle_simple_source_file() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let file = temp.path().join("main.rl");
+
+    std::fs::write(
+        &file, 
+        "fn main() {\n}\n"
+    )
+    .unwrap();
+
+    let output = bundle(file.to_str().unwrap()).unwrap();
+
+    assert!(output.contains("fn main()"));
+}
+
+#[test]
+fn bundles_local_imports() {
+    let temp = tempfile::tempdir().unwrap();
+
+    std::fs::write(
+        temp.path().join("utils.rl"), 
+        "fn helper() {}\n"
+    )
+    .unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rl"), 
+        "get utils\nfn main() {}\n"
+    )
+    .unwrap();
+
+    let output = bundle(
+        temp.path()
+                        .join("main.rl")
+                        .to_str()
+                        .unwrap()
+    )
+    .unwrap();
+
+    assert!(output.contains("fn helper()"));
+    assert!(output.contains("fn main()"));
+}
+
+#[test]
+fn does_not_bundle_std_imports() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let main = temp.path().join("main.rl");
+
+    std::fs::write(
+        &main, 
+        "get println from std::io"
+    )
+    .unwrap();
+
+    let output = bundle(main.to_str().unwrap()).unwrap();
+
+    assert!(output.contains("get println from std::io"));
+}
+
+#[test]
+fn does_not_duplicate_imports() {
+    let temp = tempfile::tempdir().unwrap();
+
+    std::fs::write(
+        temp.path().join("utils.rl"), 
+        "fn helper() {}\n"
+    )
+    .unwrap();
+
+    std::fs::write(
+        temp.path().join("main.rl"), 
+        "get utils\nget utils\n"
+    )
+    .unwrap();
+
+    let output = bundle(
+        temp.path().join("main.rl").to_str().unwrap()
+    )
+    .unwrap();
+
+    assert_eq!(
+        output.matches("fn helper").count(),
+        1
+    );
+}

--- a/crates/rl-tests/tests/tooling/workflows.rs
+++ b/crates/rl-tests/tests/tooling/workflows.rs
@@ -1,0 +1,64 @@
+use rl_tooling::workflows::try_generate;
+
+#[test]
+fn generate_check_workflow() {
+    let temp = tempfile::tempdir().unwrap();
+
+    try_generate(temp.path(), true, false).unwrap();
+
+    let file = temp.path().join("check.yml");
+
+    assert!(file.exists());
+
+    let content = std::fs::read_to_string(file).unwrap();
+
+    assert!(content.contains("name: RL Check"));
+    assert!(content.contains("rl-check"));
+}
+
+#[test]
+fn generate_package_workflow() {
+    let temp = tempfile::tempdir().unwrap();
+
+    try_generate(temp.path(), false, true).unwrap();
+
+    let file = temp.path().join("release.yml");
+
+    assert!(file.exists());
+
+    let content = std::fs::read_to_string(file).unwrap();
+
+    assert!(content.contains("name: Release"));
+    assert!(content.contains("rl-package"));
+}
+
+#[test]
+fn generate_all_workflows() {
+    let temp = tempfile::tempdir().unwrap();
+
+    try_generate(temp.path(), true, true).unwrap();
+
+    assert!(temp.path().join("check.yml").exists());
+    assert!(temp.path().join("release.yml").exists());
+}
+
+#[test]
+fn does_not_override_existing_workflow() {
+    let temp = tempfile::tempdir().unwrap();
+
+    std::fs::create_dir_all(temp.path()).unwrap();
+
+    std::fs::write(
+        temp.path().join("check.yml"),
+        "existing" 
+    )
+    .unwrap();
+
+    let result = try_generate(temp.path(), true, false);
+
+    assert!(result.is_err());
+
+    let content = std::fs::read_to_string(temp.path().join("check.yml")).unwrap();
+
+    assert_eq!(content, "existing");
+}

--- a/crates/rl-tooling/src/dev.rs
+++ b/crates/rl-tooling/src/dev.rs
@@ -23,13 +23,24 @@ pub struct Project {
 /// - `rl.toml` is not found in the current directory
 /// - the file content is not valid TOML or doesn't match [`RlToml`]
 pub fn read_rl_toml() -> RlToml {
-    let content = std::fs::read_to_string("rl.toml").unwrap_or_else(|_| {
-        eprintln!("error: no rl.toml found in current directory");
-        std::process::exit(1);
-    });
+    try_read_rl_toml(std::path::Path::new("rl.toml"))
+        .unwrap_or_else(|e| {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        })
+}
 
-    toml::from_str(&content).unwrap_or_else(|e| {
-        eprintln!("error: invalid rl.toml - {}", e);
-        std::process::exit(1);
-    })
+/// Inner fallible implementation of [`read_rl_toml`].
+///
+/// Returns an error if reading the file or parsing TOML fails.
+pub fn try_read_rl_toml(path: &std::path::Path) -> Result<RlToml, Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string(path).map_err(|_| {
+        "error: no rl.toml found in current directory".to_string()
+    })?;
+
+    let manifest =  toml::from_str(&content).map_err(|e| {
+        format!("error: invalid rl.toml - {}", e)
+    })?;
+
+    Ok(manifest)
 }

--- a/crates/rl-tooling/src/new.rs
+++ b/crates/rl-tooling/src/new.rs
@@ -27,7 +27,7 @@ pub fn create_project(name: &str, no_git: bool) {
 /// Inner fallible implementation of [`create_project`].
 ///
 /// Returns [`io::Error`] if any filesystem operation or `git init` fails.
-fn try_create_project(name: &str, no_git: bool) -> io::Result<()> {
+pub fn try_create_project(name: &str, no_git: bool) -> io::Result<()> {
     let toml = format!(
         r#"[project]
 name = "{}"

--- a/crates/rl-tooling/src/package.rs
+++ b/crates/rl-tooling/src/package.rs
@@ -134,7 +134,7 @@ fn try_package_payload(payload: &[u8], magic: &[u8], output_path: &str) -> std::
     Ok(())
 }
 
-fn bundle(entry_path: &str) -> std::io::Result<String> {
+pub fn bundle(entry_path: &str) -> std::io::Result<String> {
     let mut visited = HashSet::new();
     bundle_inner(Path::new(entry_path), &mut visited)
 }

--- a/crates/rl-tooling/src/workflows.rs
+++ b/crates/rl-tooling/src/workflows.rs
@@ -74,27 +74,39 @@ jobs:
 /// Exits with code 1 if a target file already exists or any IO error occurs.
 pub fn generate(check: bool, package: bool) {
     let dir = Path::new("workflows");
-    if let Err(e) = fs::create_dir_all(dir) {
-        eprintln!("error: could not create workflows: {}", e);
-        std::process::exit(1);
-    }
-
-    if check {
-        write_file(dir.join("check.yml").as_path(), CHECK_YML);
-    }
-    if package {
-        write_file(dir.join("release.yml").as_path(), PACKAGE_YML);
-    }
+    try_generate(dir, check, package)
+      .unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        std::process::exit(1)
+      });
+    
 }
 
-fn write_file(path: &Path, content: &str) {
+/// Inner fallible implementation of [`generate`].
+///
+/// Returns an error if writing the directory or file fails.
+pub fn try_generate(dir: &Path, check: bool, package: bool) -> Result<(), Box<dyn std::error::Error>> {
+  fs::create_dir_all(dir).map_err(|e| format!("error: could not create workflows: {}", e))?;
+
+  if check {
+    write_file(dir.join("check.yml").as_path(), CHECK_YML)?;
+  }
+
+  if package {
+    write_file(dir.join("release.yml").as_path(), PACKAGE_YML)?;
+  }
+
+  Ok(())
+}
+
+fn write_file(path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>> {
     if path.exists() {
-        eprintln!("error: '{}' already exists", path.display());
-        std::process::exit(1);
+        return Err(format!("error: '{}' already exists", path.display()).into());
     }
-    if let Err(e) = fs::write(path, content) {
-        eprintln!("error: failed to write '{}': {}", path.display(), e);
-        std::process::exit(1);
-    }
+
+    fs::write(path, content).map_err(|e| format!("error: failed to write '{}': {}", path.display(), e))?;
+
     println!("created '{}'", path.display());
+    Ok(())
 }
+


### PR DESCRIPTION
## What does this PR do?

Adds tests for `rl-tooling` modules.

## Additional changes
Exposed fallible/internal functions to make tooling behavior testable from `rl-tests`:
- `try_read_rl_toml` in `dev`
- `try_create_project` in `new`
- `try_generate` in `workflows`
- `bundle` in `package`

## Related issue
Closes #346

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
