### PR TITLE
Move tempfile dependency to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ cpal = "0.17"
 symphonia = { version = "0.5", features = ["all"] }
 eframe = "0.35"
 shell-words = "1.1"
+tempfile = "3.27.0"
 
 [profile.release]
 opt-level = 3

--- a/crates/rl-tests/Cargo.toml
+++ b/crates/rl-tests/Cargo.toml
@@ -14,4 +14,4 @@ rl-utils.workspace = true
 rl-vm.workspace = true
 rl-commons.workspace = true
 rl-tooling.workspace = true
-tempfile = "3.27.0"
+tempfile.workspace = true


### PR DESCRIPTION
## What does this PR do?
Moves tempfile dependency to workspace to avoid duplicate dep declarations.

## Related issue
Closes #

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
