### PR TITLE
Fix/vm/method call

### DIFF
--- a/crates/rl-tests/tests/vm/method_call.rs
+++ b/crates/rl-tests/tests/vm/method_call.rs
@@ -1,0 +1,109 @@
+use crate::common;
+use rl_vm::VmValue;
+
+#[test]
+fn string_method_falls_back_to_stdlib() {
+    let result = common::compile_and_run(
+        r#"
+        get repeat from std::str
+        "ab".repeat(3)
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Str(std::rc::Rc::from("ababab")));
+}
+
+#[test]
+fn chained_stdlib_method_calls() {
+    let result = common::compile_and_run(
+        r#"
+        get repeat from std::str
+        get to_upper from std::str
+        "ab".repeat(3).to_upper()
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Str(std::rc::Rc::from("ABABAB")));
+}
+
+#[test]
+fn user_function_method_fallback() {
+    let result = common::compile_and_run(
+        r#"
+        fn double(int x) -> int {
+            return x * 2
+        }
+
+        dec int x = 21
+        x.double()
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(42));
+}
+
+#[test]
+fn record_impl_method_takes_precedence_over_stdlib_fallback() {
+    let result = common::compile_and_run(
+        r#"
+        get to_upper from std::str
+
+        record Point {
+            int x,
+        }
+
+        impl Point {
+            fn to_upper(self) -> int {
+                return 99
+            }
+        }
+
+        dec Point p = Point { x: 0 }
+        p.to_upper()
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(99));
+}
+
+#[test]
+fn calling_unknown_method_on_a_primitive_is_a_runtime_error() {
+    let err = common::compile_and_run(
+        r#"
+        dec int x = 5
+        x.magnitude()
+        "#,
+    )
+    .expect_err("expected a runtime error for an unknown method on a primitive");
+
+    assert!(
+        err.message().contains("magnitude"),
+        "unexpected error message: {}",
+        err.message()
+    );
+}
+
+#[test]
+fn calling_unknown_method_on_a_record_is_a_runtime_error() {
+    let err = common::compile_and_run(
+        r#"
+        record Point {
+            int x,
+        }
+
+        dec Point p = Point { x: 0 }
+        p.unknown()
+        "#,
+    )
+    .expect_err("expected a runtime error for an unknown record method");
+
+    assert!(
+        err.message().contains("unknown") && err.message().contains("Point"),
+        "unexpected error message: {}",
+        err.message()
+    );
+}

--- a/crates/rl-tests/tests/vm/mod.rs
+++ b/crates/rl-tests/tests/vm/mod.rs
@@ -1,3 +1,4 @@
 mod r#impl;
+mod method_call;
 mod numbers;
 mod stdlib;

--- a/crates/rl-vm/src/chunk.rs
+++ b/crates/rl-vm/src/chunk.rs
@@ -98,16 +98,26 @@ pub enum OpCode {
     /// and pushes the result. Errors on non-numeric sources or values
     /// that don't fit the target type.
     Cast = 44,
+    /// registers an imported stdlib function under its name, so it can be
+    /// used as a free-function fallback for `value.method(...)` on a
+    /// non-record receiver (mirrors the interpreter's `call_path` stdlib
+    /// step). Operands: `key_idx` (method name), `value_idx` (native).
+    RegisterStdlibMethod = 45,
+    /// registers a named user function under its name, so it can be used
+    /// as a free-function fallback for `value.method(...)` (mirrors the
+    /// interpreter's `fn_names`). Operands: `key_idx` (method name),
+    /// `value_idx` (function).
+    RegisterUserMethod = 46,
 }
 
 impl OpCode {
     /// # Safety
-    /// `byte` must be valid discriminant (0..28)
+    /// `byte` must be a valid discriminant (0..=OpCode::RegisterUserMethod)
     /// and that's only true for bytecode emitted by this compiler
     #[inline(always)]
     pub fn from_u8_unchecked(byte: u8) -> Self {
         debug_assert!(
-            byte <= OpCode::Cast as u8,
+            byte <= OpCode::RegisterUserMethod as u8,
             "corrupt bytecode: opcode {byte}"
         );
         unsafe { std::mem::transmute::<u8, OpCode>(byte) }
@@ -162,6 +172,8 @@ impl OpCode {
             42 => OpCode::LookupAssoc,
             43 => OpCode::LookupMethod,
             44 => OpCode::Cast,
+            45 => OpCode::RegisterStdlibMethod,
+            46 => OpCode::RegisterUserMethod,
             other => panic!("corrupt bytecode: unknown opcode byte {other}"),
         }
     }

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -465,9 +465,20 @@ impl<'a> Compiler<'a> {
                 }));
                 let slot = self.next_slot;
                 self.next_slot += 1;
-                self.emit_const(func, span);
+                let func_idx = self.chunk.add_constant(func);
+                self.chunk.write_op(OpCode::Const, span);
+                self.chunk.write_u16(func_idx, span);
                 self.chunk.write_op(OpCode::DefineLocal, span);
                 self.chunk.write_u16(slot, span);
+                // Register the function as a method-call fallback so
+                // `value.name(...)` calls it with the receiver as its first
+                // argument (mirrors the interpreter's `fn_names`).
+                let key_idx = self
+                    .chunk
+                    .add_constant(VmValue::Str(Rc::from(name.as_str())));
+                self.chunk.write_op(OpCode::RegisterUserMethod, span);
+                self.chunk.write_u16(key_idx, span);
+                self.chunk.write_u16(func_idx, span);
                 Ok(())
             }
 
@@ -501,7 +512,18 @@ impl<'a> Compiler<'a> {
                     .collect::<Result<_, CompileError>>()?;
 
                 for (name, f) in names.iter().zip(fns) {
-                    self.stdlib.functions.insert(name.clone(), f);
+                    self.stdlib.functions.insert(name.clone(), f.clone());
+                    // Register the import as a method-call fallback so
+                    // `value.name(...)` calls it with the receiver as its
+                    // first argument (mirrors the interpreter's `call_path`
+                    // stdlib step).
+                    let key_idx = self
+                        .chunk
+                        .add_constant(VmValue::Str(Rc::from(name.as_str())));
+                    let value_idx = self.chunk.add_constant(VmValue::Native(f));
+                    self.chunk.write_op(OpCode::RegisterStdlibMethod, span);
+                    self.chunk.write_u16(key_idx, span);
+                    self.chunk.write_u16(value_idx, span);
                 }
 
                 Ok(())

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -1017,19 +1017,55 @@ impl Vm {
                     let caller = self
                         .stack
                         .last()
-                        .ok_or_else(|| self.err("stack underflow on method call"))?;
-                    let VmValue::Record { name, .. } = caller else {
-                        return Err(self.err(format!(
-                            "cannot call method `{method}` on {}",
-                            caller.type_name()
-                        )));
-                    };
-                    let key = format!("{name}::{method}");
-                    let func = self.impl_methods.get(&key).cloned().ok_or_else(|| {
-                        self.err(format!("record `{name}` has no method `{method}`"))
-                    })?;
+                        .ok_or_else(|| self.err("stack underflow on method call"))?
+                        .clone();
                     let insert_pos = self.stack.len() - 1;
-                    self.stack.insert(insert_pos, VmValue::Function(func));
+
+                    // Dispatch order mirrors the interpreter's `MethodCall`
+                    // handler (`evaluator.rs`): a record's `impl` method wins,
+                    // then the method name is resolved as a free function with
+                    // the receiver as its first argument - imported stdlib
+                    // functions first, then named user functions.
+                    let resolved: Option<VmValue> = match &caller {
+                        VmValue::Record { name, .. } => {
+                            if let Some(func) = self.impl_methods.get(&format!("{name}::{method}"))
+                            {
+                                Some(VmValue::Function(func.clone()))
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    }
+                    .or_else(|| {
+                        self.stdlib_methods
+                            .get(&*method)
+                            .map(|n| VmValue::Native(n.clone()))
+                            .or_else(|| {
+                                self.user_methods
+                                    .get(&*method)
+                                    .map(|f| VmValue::Function(f.clone()))
+                            })
+                    });
+
+                    match resolved {
+                        Some(callee) => {
+                            self.stack.insert(insert_pos, callee);
+                        }
+                        None => match &caller {
+                            VmValue::Record { name, .. } => {
+                                return Err(
+                                    self.err(format!("record `{name}` has no method `{method}`"))
+                                );
+                            }
+                            other => {
+                                return Err(self.err(format!(
+                                    "cannot call method `{method}` on {}",
+                                    other.type_name()
+                                )));
+                            }
+                        },
+                    }
                 }
 
                 OpCode::Cast => {

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use crate::chunk::{Chunk, OpCode};
 use crate::stdlib::gui::GuiHandle;
-use crate::values::{RecordFields, VmFunction, VmMapKey, VmValue};
+use crate::values::{RecordFields, VmFunction, VmMapKey, VmNativeFn, VmValue};
 use rl_utils::errors::{Error, Reason};
 use rl_utils::line_index::LineIndex;
 use rl_utils::source::SourceFile;
@@ -113,6 +113,17 @@ pub struct Vm {
     /// functions, `Record::method(...)`) and `OpCode::LookupMethod`
     /// (instance methods, `value.method(...)`).
     impl_methods: HashMap<String, Rc<VmFunction>>,
+    /// stdlib functions imported via `get x from std::module`, keyed by
+    /// name. Populated by `OpCode::RegisterStdlibMethod` (emitted per
+    /// import) and consulted by `OpCode::LookupMethod` as the
+    /// free-function fallback for `value.method(...)` on non-record
+    /// receivers - mirroring the interpreter's `call_path` stdlib step.
+    stdlib_methods: HashMap<String, Rc<VmNativeFn>>,
+    /// named user functions, keyed by name. Populated by
+    /// `OpCode::RegisterUserMethod` (emitted per function declaration) and
+    /// consulted by `OpCode::LookupMethod` after the stdlib fallback -
+    /// mirroring the interpreter's `fn_names`.
+    user_methods: HashMap<String, Rc<VmFunction>>,
     /// Side-table of native C-interop resources (`std::c`), keyed by handle
     /// id. `pub(crate)` (unlike every field above) because, unlike every
     /// other native function so far, `std::c`'s functions need persistent
@@ -169,6 +180,8 @@ impl Vm {
             source: None,
             line_index: None,
             impl_methods: HashMap::new(),
+            stdlib_methods: HashMap::new(),
+            user_methods: HashMap::new(),
             c_handles: HashMap::new(),
             c_next_handle: 1,
             audio_handles: HashMap::new(),

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -960,6 +960,38 @@ impl Vm {
                     self.impl_methods.insert(key.to_string(), func);
                 }
 
+                OpCode::RegisterStdlibMethod => {
+                    let key_idx = read_u16!() as usize;
+                    ip += 2;
+                    let value_idx = read_u16!() as usize;
+                    ip += 2;
+
+                    let VmValue::Str(key) = chunk!().constants[key_idx].clone() else {
+                        return Err(self.err("corrupt bytecode: method key is not a string"));
+                    };
+                    let VmValue::Native(native) = chunk!().constants[value_idx].clone() else {
+                        return Err(self.err("corrupt bytecode: stdlib fallback is not a native"));
+                    };
+                    self.stdlib_methods.insert(key.to_string(), native);
+                }
+
+                OpCode::RegisterUserMethod => {
+                    let key_idx = read_u16!() as usize;
+                    ip += 2;
+                    let func_idx = read_u16!() as usize;
+                    ip += 2;
+
+                    let VmValue::Str(key) = chunk!().constants[key_idx].clone() else {
+                        return Err(self.err("corrupt bytecode: method key is not a string"));
+                    };
+                    let VmValue::Function(func) = chunk!().constants[func_idx].clone() else {
+                        return Err(
+                            self.err("corrupt bytecode: user method body is not a function")
+                        );
+                    };
+                    self.user_methods.insert(key.to_string(), func);
+                }
+
                 OpCode::LookupAssoc => {
                     let key_idx = read_u16!() as usize;
                     ip += 2;

--- a/crates/rl-vm/src/vm_logic.rs
+++ b/crates/rl-vm/src/vm_logic.rs
@@ -1028,12 +1028,7 @@ impl Vm {
                     // functions first, then named user functions.
                     let resolved: Option<VmValue> = match &caller {
                         VmValue::Record { name, .. } => {
-                            if let Some(func) = self.impl_methods.get(&format!("{name}::{method}"))
-                            {
-                                Some(VmValue::Function(func.clone()))
-                            } else {
-                                None
-                            }
+                            self.impl_methods.get(&format!("{name}::{method}")).map(|func| VmValue::Function(func.clone()))
                         }
                         _ => None,
                     }


### PR DESCRIPTION
## What does this PR do

Fix method calls being strictly only to `record`s

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
