### PR TITLE
feat(docs): website generation for language docs

### DIFF
--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -150,6 +150,10 @@ enum Commands {
         #[arg(long)]
         tui: bool,
 
+        /// Browse docs in an interactive terminal UI instead of printing them
+        #[arg(long)]
+        website: bool,
+
         /// Print output as JSON instead of Markdown
         #[arg(long)]
         json: bool,
@@ -478,6 +482,7 @@ fn main() {
             no_highlight,
             out_dir,
             tui,
+            website,
         } => {
             if generate {
                 {
@@ -730,6 +735,15 @@ fn main() {
                     );
                     std::process::exit(1);
                 }
+            }
+
+            if website {
+                rl_docs::website::build_and_open_website(
+                    &matched_std,
+                    &matched_concepts,
+                    &matched_tutorial,
+                );
+                std::process::exit(1);
             }
 
             let rendered = if json {

--- a/crates/rl-docs/assets/style.css
+++ b/crates/rl-docs/assets/style.css
@@ -1,0 +1,376 @@
+:root {
+    --bg: #0d1420;
+    --bg-alt: #0a1018;
+    --panel: #0a121f;
+    --border: #1e2d42;
+    --text: #dbe4ee;
+    --text-dim: #8ea0b8;
+    --heading: #f2f6fb;
+    --accent: #6cb0f5;
+    --accent-strong: #3d8be0;
+    --active-bg: #17395e;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family:
+        "Inter",
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        sans-serif;
+    line-height: 1.65;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+}
+
+/* ---------- top bar (mobile only) ---------- */
+
+.topbar {
+    display: none;
+    align-items: center;
+    gap: 0.9rem;
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    background: var(--bg-alt);
+    border-bottom: 1px solid var(--border);
+    padding: 0.7rem 1rem;
+}
+
+.topbar-brand {
+    font-weight: 700;
+    color: var(--accent);
+    text-decoration: none;
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+}
+
+.menu-toggle {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.menu-toggle span {
+    display: block;
+    width: 18px;
+    height: 2px;
+    margin: 0 auto;
+    background: var(--text);
+    border-radius: 2px;
+}
+
+.sidebar-backdrop {
+    display: none;
+}
+
+/* ---------- layout ---------- */
+
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 270px;
+    flex-shrink: 0;
+    background: var(--bg-alt);
+    border-right: 1px solid var(--border);
+    padding: 1.4rem 1.1rem 2rem;
+    overflow-y: auto;
+    height: 100vh;
+    position: sticky;
+    top: 0;
+}
+
+.sidebar h2 {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+    margin: 1.5rem 0 0.5rem 0;
+    border-bottom: none;
+}
+
+.sidebar h2:first-of-type {
+    margin-top: 1.2rem;
+}
+
+.sidebar ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0 0 0.5rem 0;
+}
+
+.sidebar li {
+    margin: 0.1rem 0;
+}
+
+.sidebar a {
+    display: block;
+    padding: 0.35rem 0.6rem;
+    border-radius: 6px;
+    color: #a9c3de;
+    font-size: 0.92rem;
+    text-decoration: none;
+    transition:
+        background 0.12s ease,
+        color 0.12s ease;
+}
+
+.sidebar a:hover {
+    background: #16253a;
+    color: var(--heading);
+}
+
+.sidebar a.active {
+    background: var(--active-bg);
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.sidebar .home-link {
+    display: block;
+    font-weight: 700;
+    color: var(--accent);
+    margin-bottom: 1.2rem;
+    font-size: 1.1rem;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+}
+
+/* ---------- main content ---------- */
+
+main {
+    flex: 1;
+    min-width: 0;
+    padding: 3rem 3.2rem 5rem;
+    max-width: 880px;
+}
+
+h1,
+h2,
+h3,
+h4 {
+    line-height: 1.3;
+    color: var(--heading);
+    font-weight: 700;
+}
+
+h1 {
+    font-size: 2rem;
+    border-bottom: 2px solid var(--border);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.2rem;
+}
+
+h2 {
+    font-size: 1.35rem;
+    margin-top: 2.4rem;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 0.3rem;
+}
+
+h3 {
+    font-size: 1.1rem;
+    margin-top: 1.8rem;
+}
+
+p {
+    margin: 0.9rem 0;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.2rem 0;
+}
+
+code {
+    background: #16253a;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    font-family: "SF Mono", Consolas, Monaco, "Courier New", monospace;
+    font-size: 0.88em;
+    color: #cfe0f2;
+}
+
+pre {
+    background: var(--panel);
+    color: #d4dbe6;
+    padding: 1rem 1.15rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    font-family: "SF Mono", Consolas, Monaco, "Courier New", monospace;
+    font-size: 0.88em;
+    border: 1px solid var(--border);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02) inset;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+}
+
+ul {
+    padding-left: 1.4rem;
+}
+
+li {
+    margin: 0.25rem 0;
+}
+
+em {
+    color: var(--text-dim);
+}
+
+strong {
+    color: var(--heading);
+}
+
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1.2rem 0;
+    display: block;
+    overflow-x: auto;
+}
+
+th,
+td {
+    border: 1px solid var(--border);
+    padding: 0.5rem 0.7rem;
+    text-align: left;
+}
+
+th {
+    background: var(--panel);
+    color: var(--heading);
+}
+
+/* ---------- syntax highlighting ---------- */
+
+.rl-kw {
+    color: #c896e8;
+}
+.rl-type {
+    color: #5fd0c0;
+}
+.rl-lit {
+    color: #6cb0f5;
+}
+.rl-ident {
+    color: #d4dbe6;
+}
+.rl-string {
+    color: #e0a97a;
+}
+.rl-char {
+    color: #e0a97a;
+}
+.rl-number {
+    color: #a8d18f;
+}
+.rl-comment {
+    color: #7fa06a;
+    font-style: italic;
+}
+.rl-op {
+    color: #d4dbe6;
+}
+
+/* ---------- responsive ---------- */
+
+@media (max-width: 860px) {
+    .topbar {
+        display: flex;
+    }
+
+    .layout {
+        min-height: calc(100vh - 53px);
+    }
+
+    .sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100vh;
+        transform: translateX(-100%);
+        transition: transform 0.2s ease;
+        z-index: 50;
+        box-shadow: 2px 0 16px rgba(0, 0, 0, 0.4);
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .sidebar .home-link {
+        display: none;
+    }
+
+    .sidebar-backdrop {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 40;
+    }
+
+    .sidebar-backdrop.open {
+        display: block;
+    }
+
+    main {
+        padding: 1.6rem 1.2rem 3.5rem;
+        max-width: 100%;
+    }
+
+    h1 {
+        font-size: 1.6rem;
+    }
+
+    h2 {
+        font-size: 1.2rem;
+    }
+}
+
+@media (max-width: 480px) {
+    main {
+        padding: 1.2rem 1rem 3rem;
+    }
+
+    pre {
+        padding: 0.8rem 0.9rem;
+        font-size: 0.82em;
+    }
+}

--- a/crates/rl-docs/src/entry.rs
+++ b/crates/rl-docs/src/entry.rs
@@ -6,7 +6,7 @@
 use serde::Serialize;
 
 /// A single stdlib function's documentation.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct FnEntry {
     /// The function signature as it appears in rl (e.g. `"arr_push(arr, value)"`).
     pub signature: &'static str,
@@ -32,7 +32,7 @@ pub struct FnEntry {
 }
 
 /// A stdlib module's documentation, grouping related [`FnEntry`]s together.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct StdEntry {
     /// The module name as used in imports (e.g. `"io"`, `"math::consts"`).
     pub name: &'static str,
@@ -49,7 +49,7 @@ pub struct StdEntry {
 }
 
 /// Coarse grouping used to organize the concept index / nav.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum ConceptCategory {
     /// Basic language syntax (comments, literals, general structure).
     Syntax,
@@ -67,9 +67,25 @@ pub enum ConceptCategory {
     ErrorHandling,
 }
 
+impl std::fmt::Display for ConceptCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            ConceptCategory::Syntax => "Syntax",
+            ConceptCategory::Types => "Types",
+            ConceptCategory::ControlFlow => "Control Flow",
+            ConceptCategory::Functions => "Functions",
+            ConceptCategory::Modules => "Modules",
+            ConceptCategory::Tooling => "Tooling",
+            ConceptCategory::ErrorHandling => "Error Handling",
+        };
+
+        write!(f, "{}", name)
+    }
+}
+
 /// What role a [`DescriptionEntry`] plays, so the renderer can style it
 /// differently (e.g. a pitfall as a warning callout).
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum DescriptionKind {
     /// Ordinary prose explaining how or why something works.
     Explanation,
@@ -81,8 +97,24 @@ pub enum DescriptionKind {
     Note,
 }
 
+impl std::fmt::Display for DescriptionKind {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>
+    ) -> std::fmt::Result {
+        let name = match self {
+            DescriptionKind::Explanation => "Explanation",
+            DescriptionKind::Syntax => "Syntax",
+            DescriptionKind::Pitfall => "Pitfall",
+            DescriptionKind::Note => "Note",
+        };
+
+        write!(f, "{}", name)
+    }
+}
+
 /// Documentation for a language concept (variables, loops, types, etc.).
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct ConceptEntry {
     /// The concept name shown as a section header (e.g. `"arrays"`, `"for loops"`).
     pub name: &'static str,
@@ -109,7 +141,7 @@ pub struct ConceptEntry {
 }
 
 /// A single description with one or more accompanying rl code examples.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct DescriptionEntry {
     /// What role this block plays (explanation, syntax, pitfall, note).
     pub kind: DescriptionKind,

--- a/crates/rl-docs/src/lib.rs
+++ b/crates/rl-docs/src/lib.rs
@@ -14,6 +14,7 @@ pub mod entries;
 pub mod entry;
 #[cfg(feature = "tui")]
 pub mod tui;
+pub mod website;
 use serde::Serialize;
 use serde_json::to_string_pretty;
 

--- a/crates/rl-docs/src/website/builder.rs
+++ b/crates/rl-docs/src/website/builder.rs
@@ -1,0 +1,306 @@
+use std::{collections::HashMap, fs, path::PathBuf};
+
+use crate::{entry::{ConceptEntry, StdEntry}, website::helpers::{html_escape, page, render_description_entry, render_fn_entry, render_related, slugify}};
+
+const STYLE_CSS: &str = include_str!("../../assets/style.css");
+const RL_HIGHLIGHT_JS: &str = include_str!("../../../rl-tooling/assets/rl-highlight.js");
+
+pub struct SiteBuilder<'a> {
+    out_dir: PathBuf,
+    stdlib: &'a [&'a StdEntry],
+    std_files: HashMap<String, String>,
+    concepts: &'a [&'a ConceptEntry],
+    concept_files: HashMap<String, String>,
+    tutorials: &'a [&'a ConceptEntry],
+    tutorial_files: HashMap<String, String>,
+    fn_files: HashMap<String, String>
+}
+
+impl<'a> SiteBuilder<'a> {
+    pub fn new(out_dir: PathBuf, stdlib: &'a [&'a StdEntry], concepts: &'a [&'a ConceptEntry], tutorials: &'a [&'a ConceptEntry]) -> Self {
+        // filename maps, so cross-references (see_also / related / related_stdlib)
+        // can become real links between pages
+        let mut concept_files = HashMap::new();
+        for e in concepts {
+            let filename = format!("concept_{}.html", slugify(e.name));
+            concept_files.insert(e.name.into(), filename);
+        }
+
+        let mut tutorial_files = HashMap::new();
+        for e in tutorials {
+            let filename = format!("tutorial_{}.html", slugify(e.name));
+            tutorial_files.insert(e.name.into(), filename);
+        }
+
+        let mut std_files = HashMap::new();
+
+        // flat map of every function's bare name -> its module page, for "see also" links
+        let mut fn_files = HashMap::new();
+
+        for e in stdlib {
+            let filename = format!("std_{}.html", slugify(e.name));
+            std_files.insert(e.name.into(), filename.clone());
+
+            for func in e.functions {
+                let bare = func
+                    .signature
+                    .split('(')
+                    .next()
+                    .unwrap_or("");
+
+                fn_files.insert(bare.to_string(), filename.clone());
+            }
+        }
+
+        Self { 
+            out_dir, 
+            stdlib, 
+            std_files, 
+            concepts, 
+            concept_files, 
+            tutorials, 
+            tutorial_files,
+            fn_files
+        }
+    }
+
+    pub fn build(self) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.out_dir)?;
+
+        self.create_asset_file("style.css", STYLE_CSS)?;
+        self.create_asset_file("rl-highlight.js", RL_HIGHLIGHT_JS)?;
+
+        self.build_index()?;
+
+        for entry in self.stdlib {
+            self.build_std_page(entry)?;
+        }
+
+        for entry in self.concepts {
+            self.build_concept_or_tutorial_page(entry, &self.concept_files)?;
+        }
+
+        for entry in self.tutorials {
+            self.build_concept_or_tutorial_page(entry, &self.tutorial_files)?;
+        }
+
+        Ok(())
+    }
+
+    /// Writes a static asset (css/js) into the output directory.
+    ///
+    /// The asset contents are provided at compile time and written
+    /// to the generated website directory.
+    fn create_asset_file(&self, filename: &str, contents: &str) -> std::io::Result<()> {
+        let path = self.out_dir.join(filename);
+        std::fs::write(path, contents)?;
+        Ok(())
+    }
+
+    fn write(&self, filename: &str, title: &str, body: &str) -> std::io::Result<()> {
+        let contents = page(title, &self.sidebar_html(Some(filename)), body);
+        std::fs::write(
+            self.out_dir.join(filename), 
+            contents
+        )?;
+        Ok(())
+    }
+
+    fn build_index(&self) -> std::io::Result<()> {
+        let mut body = String::from("<h1>rl docs</h1>\n");
+
+        if !self.stdlib.is_empty() || !self.concepts.is_empty() || !self.tutorials.is_empty() {
+            body.push_str("<p>Pick an item from the sidebar to get started.</p>\n");
+        } else {
+            body.push_str("<p>No documentation entries found.</p>\n");
+        }
+
+        fs::write(
+            self.out_dir.join("index.html"), 
+            page("rl docs", &self.sidebar_html(Some("index.html")), &body)
+        )?;
+    
+        Ok(())
+    }
+
+    /// Builds the full sidebar shown on every page: a Home link plus
+    /// one section per category (stdlib/concepts/tutorial), each listing
+    /// every entry. The current page's link gets the 'active' class.
+    fn sidebar_html(&self, active_filename: Option<&str>) -> String {
+        let mut out = String::new();
+
+        let link = |filename: &str, label: &str| {
+            let class = if Some(filename) == active_filename {
+                " class=\"active\""
+            } else {
+                ""
+            };
+
+            format!(
+                "<li><a href=\"{}\"{}>{}</a></li>\n",
+                html_escape(filename),
+                class,
+                html_escape(label)
+            )
+        };
+
+        out.push_str("<a class=\"home-link\" href=\"index.html\">rl docs</a>\n");
+
+        if !self.stdlib.is_empty() {
+            out.push_str("<h2>stdlib</h2>\n<ul>\n");
+            
+            for entry in self.stdlib {
+                let name = entry.name;
+
+                out.push_str(&link(
+                    &self.std_files[name],
+                    &format!("std::{}", name)
+                ));
+            }
+
+            out.push_str("</ul>\n");
+        }
+
+        if !self.concepts.is_empty() {
+            out.push_str("<h2>concepts</h2>\n<ul>\n");
+            
+            for entry in self.concepts {
+                let name = entry.name;
+
+                out.push_str(&link(
+                    &self.concept_files[name],
+                    name
+                ));
+            }
+
+            out.push_str("</ul>\n");
+        }
+
+        if !self.tutorials.is_empty() {
+            out.push_str("<h2>tutorial</h2>\n<ul>\n");
+            
+            for entry in self.tutorials {
+                let name = entry.name;
+
+                out.push_str(&link(
+                    &self.tutorial_files[name],
+                    name
+                ));
+            }
+
+            out.push_str("</ul>\n");
+        }
+
+        out
+    }
+
+    fn build_std_page(&self, entry: &StdEntry) -> std::io::Result<()> {
+        let name = entry.name;
+        let mut body = String::new();
+
+        body.push_str(&format!(
+            "<h1>std::{}</h1>\n",
+            html_escape(name)
+        ));
+
+        let mut meta_bits = Vec::new();
+
+        if let Some(since) = entry.since {
+            meta_bits.push(
+                format!(
+                    "since {}",
+                    html_escape(since)
+                )
+            );
+        };
+
+        if entry.unstable {
+            meta_bits.push("unstable".to_string());
+        };
+
+        if !meta_bits.is_empty() {
+            body.push_str(
+                &format!(
+                    "<p><em>{}</em></p>\n",
+                    meta_bits.join(" | ")
+                )
+            );
+        };
+
+        body.push_str(
+            &format!(
+                "<p>{}</p>\n",
+                html_escape(entry.description)
+            )
+        );
+
+        for func in entry.functions {
+            body.push_str(&render_fn_entry(func, &self.fn_files));
+        }
+
+        self.write(&self.std_files[name], &format!("std::{}", name), &body)
+    }
+
+    fn build_concept_or_tutorial_page(&self, entry: &ConceptEntry, file_map: &HashMap<String, String>) -> std::io::Result<()> {
+        let name = entry.name;
+        let mut body = format!("<h1>{}</h1>\n", html_escape(name));
+
+        let mut meta_bits = vec![entry.category.to_string()];
+
+        if let Some(since) = entry.since {
+            meta_bits.push(
+                format!("since {}", html_escape(since))
+            );
+            body.push_str(
+                &format!("<p><em>{}</em></p>\n", meta_bits.join(" | "))
+            );
+        }
+
+        body.push_str(
+            &format!("<p>{}</p>\n", entry.summary)
+        );
+
+        body.push_str(
+            &render_related(
+                "Prerequisites",
+                entry.prerequisites.to_vec(),
+                &self.concept_files,
+                ""
+            )
+        );
+
+        for desc in entry.descriptions {
+            body.push_str(&render_description_entry(desc));
+        }
+
+        if !entry.pitfalls.is_empty() {
+            body.push_str("<p><strong>Pitfalls:</strong></p>\n<ul>\n");
+            for p in entry.pitfalls {
+                body.push_str(&format!("<li>{}</li>\n", p));
+            }
+            body.push_str("</ul>\n");
+        }
+
+        body.push_str(
+            &render_related(
+                "Related concepts", 
+                entry.related.to_vec(), 
+                &self.concept_files, 
+                ""
+            )
+        );
+
+        body.push_str(
+            &render_related(
+                "Related stdlib", 
+                entry.related_stdlib.to_vec(), 
+                &self.std_files, 
+                "std::"
+            )
+        );
+
+        self.write(&file_map[name], name, &body)
+    }
+
+    
+}

--- a/crates/rl-docs/src/website/helpers.rs
+++ b/crates/rl-docs/src/website/helpers.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+
+use crate::entry::{DescriptionEntry, FnEntry};
+
+pub fn page(title: &str, sidebar_html: &str, body: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<link rel="stylesheet" href="style.css">
+<script src="rl-highlight.js" defer></script>
+</head>
+
+<body>
+<header class="topbar">
+<button class="menu-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false">
+<span></span><span></span><span></span>
+</button>
+<a class="topbar-brand" href="index.html">rl docs</a>
+</header>
+
+<div class="layout">
+<div class="sidebar-backdrop"></div>
+
+<nav class="sidebar">
+{sidebar_html}
+</nav>
+
+<main>
+{body}
+</main>
+
+</div>
+
+<script>
+(function(){{
+    var btn = document.querySelector(".menu-toggle");
+    var sidebar = document.querySelector(".sidebar");
+    var backdrop = document.querySelector(".sidebar-backdrop");
+
+    function close(){{
+        sidebar.classList.remove("open");
+        backdrop.classList.remove("open");
+        btn.setAttribute("aria-expanded", "false");
+    }}
+
+    function toggle(){{
+        var open = sidebar.classList.toggle("open");
+        backdrop.classList.toggle("open", open);
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+    }}
+
+    btn.addEventListener("click", toggle);
+    backdrop.addEventListener("click", close);
+
+    sidebar.addEventListener("click", function(e){{
+        if (e.target.tagName === "A") close();
+    }});
+}})();
+</script>
+
+</body>
+</html>
+"#,
+        title = title,
+        sidebar_html = sidebar_html,
+        body = body,
+    )
+}
+
+/// Escapes the five characters that are meaningful in HTML text content.
+pub fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+///Turn a name into a safe filename/id (letters, digits, hyphens).
+pub fn slugify(text: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_dash = false;
+
+    for ch in text.to_lowercase().chars() {
+        if ch.is_alphanumeric() {
+            slug.push(ch);
+            last_was_dash = false
+        } else if !last_was_dash {
+            slug.push('-');
+            last_was_dash = true
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+
+    if slug.is_empty() {
+        "entry".into()
+    } else {
+        slug.to_string()
+    }
+}
+
+pub fn render_fn_entry(func: &FnEntry, fn_link_map: &HashMap<String, String>) -> String {
+    let mut out = format!(
+        "<h3><code>{}</code></h3>\n",
+        html_escape(func.signature)
+    );
+
+    if let Some(since) = func.since {
+        out.push_str(&format!(
+            "<p><em>since {}</em></p>\n",
+            html_escape(since)
+        ));
+    }
+    
+    out.push_str(&format!(
+        "<p>{}</p>\n<p><strong>Returns:</strong> {}</p>\n",
+        html_escape(func.description),
+        html_escape(func.returns)
+    ));
+
+    if let Some(errors) = func.errors {
+        out.push_str(&format!(
+            "<p><strong>Errors:</strong> {}</p>\n",
+            html_escape(errors)
+        ));
+    }
+
+    out.push_str(&render_example_block(func.example, func.expected_output));
+
+    out.push_str(&render_related(
+        "See also", 
+        func.see_also.to_vec(), 
+        fn_link_map, 
+        ""
+    ));
+
+    out 
+}
+
+/// Render a labeled list of related names.
+/// link_map is {name: filename} so related items become links
+/// to their own page instead of plain text.
+pub fn render_related(label: &str, names: Vec<&str>, link_map: &HashMap<String, String>, prefix: &str) -> String {
+    if names.is_empty() {
+        return "".into()
+    }
+
+    let mut items = Vec::new();
+
+    for n in names {
+        let display = html_escape(&format!("{prefix}{n}"));
+        if let Some(link) = link_map.get(n) {
+            items.push(format!("<a href=\"{}\"><code>{display}</code></a>", html_escape(link)));
+        } else {
+            items.push(format!("<code>{display}</code>"));
+        }
+    }
+
+    format!("<p><strong>{}:</strong> {}</p>\n", html_escape(label), items.join(", "))
+}
+pub fn render_description_entry(desc: &DescriptionEntry) -> String {
+    let mut out = String::new();
+
+    if let Some(title) = desc.title {
+        out.push_str(&format!(
+            "<h4>{}</h4>\n",
+            html_escape(title)
+        ));
+    }
+
+    out.push_str(&format!(
+        "<p><strong>{}:</strong> {}</p>\n",
+        desc.kind,
+        desc.description
+    ));
+
+    for (i, example) in desc.examples.iter().enumerate() {
+        let expected = desc.expected_output.get(i).copied();
+        out.push_str(&render_example_block(example, expected));
+    }
+
+    out
+}
+
+fn render_example_block(example: &str, expected_output: Option<&str>) -> String {
+    let mut out = format!(
+        "<pre class=\"rl-code\">{}</pre>\n", 
+        html_escape(example),
+    );
+
+    if let Some(expected) = expected_output {
+        out.push_str(&format!(
+            "<p><em>output:</em></p>\n<pre>{}</pre>\n",
+            html_escape(expected)
+        ));
+    }
+
+    out
+}

--- a/crates/rl-docs/src/website/mod.rs
+++ b/crates/rl-docs/src/website/mod.rs
@@ -1,0 +1,36 @@
+use crate::{
+    entry::{ConceptEntry, StdEntry}, website::{builder::SiteBuilder, platform::{docs_dir, open_browser}},
+};
+
+mod builder;
+mod helpers;
+mod platform;
+
+/// Builds the documentation website if it has not already been generated,
+/// then opens the generated index page in the user's default browser.
+///
+/// The website is stored in the platform-specific docs directory. Existing
+/// generated documentation is reused instead of being rebuilt.
+pub fn build_and_open_website(
+    std_entries: &[&StdEntry],
+    concept_entries: &[&ConceptEntry],
+    tutorial_entries: &[&ConceptEntry]
+) {
+    let docs_dir = docs_dir();
+    let index_path = docs_dir.join("index.html");
+    if !index_path.exists() {
+        let site_builder = SiteBuilder::new(
+            docs_dir, 
+            std_entries, 
+            concept_entries,
+            tutorial_entries
+        );
+        if let Err(e) = site_builder.build() {
+            eprintln!("error: building website {}", e);
+            return
+        };
+    } 
+    if let Err(e) = open_browser(&index_path) {
+        eprintln!("error: opening browser {}", e);
+    }
+}

--- a/crates/rl-docs/src/website/platform.rs
+++ b/crates/rl-docs/src/website/platform.rs
@@ -1,0 +1,52 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(windows)]
+pub fn docs_dir() -> PathBuf {
+    PathBuf::from(std::env::var_os("APPDATA").unwrap())
+        .join("rl")
+        .join("docs")
+}
+
+#[cfg(unix)]
+pub fn docs_dir() -> PathBuf {
+    PathBuf::from(std::env::var_os("HOME").unwrap())
+        .join(".rl")
+        .join("docs")
+}
+
+pub fn open_browser(path: &Path) -> std::io::Result<()> {
+    open(path)
+}
+
+#[cfg(target_os = "windows")]
+fn open(path: &Path) -> std::io::Result<()> {
+    Command::new("cmd")
+        .args([
+            "/C",
+            "start",
+            "",
+            path.to_str().unwrap(),
+        ])
+        .spawn()?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn open(path: &Path) -> std::io::Result<()> {
+    Command::new("xdg-open")
+        .arg(path)
+        .spawn()?;
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn open(path: &Path) -> std::io::Result<()> {
+    Command::new("open")
+        .arg(path)
+        .spawn()?;
+
+    Ok(())
+}


### PR DESCRIPTION
## What does this PR do?
Adds offline HTML documentation website generation for rl docs.

## Related issue
Closes #329 

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
