### PR TITLE
Fix/stderr printing

### DIFF
--- a/crates/rl-docs/src/entries/stdlib/io/eprint.rs
+++ b/crates/rl-docs/src/entries/stdlib/io/eprint.rs
@@ -1,7 +1,7 @@
 use crate::entry::FnEntry;
 
 pub static EPRINT: FnEntry = FnEntry {
-    signature: "eprint(message)",
+    signature: "eprint(message, ..)",
     description: "prints any value to stderr without trailing newline",
     example: "get std::io::eprint\n\neprint(\"something went wrong\")",
     expected_output: Some("something went wrong"),

--- a/crates/rl-docs/src/entries/stdlib/io/eprint.rs
+++ b/crates/rl-docs/src/entries/stdlib/io/eprint.rs
@@ -2,13 +2,11 @@ use crate::entry::FnEntry;
 
 pub static EPRINT: FnEntry = FnEntry {
     signature: "eprint(message)",
-    description: "halts evaluation, raising message as a runtime error",
-    example: "get std::io::eprint\n\neprint(\"something went wrong\") // error: something went wrong",
-    expected_output: None,
-    returns: "never returns",
-    errors: Some(
-        "Always raises `message` as an interpreter-level runtime error - this is\nnot a catchable `result[..]` err, and cannot be caught with `?`. Program\nevaluation stops here.",
-    ),
-    see_also: &[],
-    since: Some("v0.1.5"),
+    description: "prints any value to stderr without trailing newline",
+    example: "get std::io::eprint\n\neprint(\"something went wrong\")",
+    expected_output: Some("something went wrong"),
+    returns: "null",
+    errors: None,
+    see_also: &["eprintln", "print", "println"],
+    since: Some("v1.1.0"),
 };

--- a/crates/rl-docs/src/entries/stdlib/io/eprintln.rs
+++ b/crates/rl-docs/src/entries/stdlib/io/eprintln.rs
@@ -1,0 +1,12 @@
+use crate::entry::FnEntry;
+
+pub static EPRINTLN: FnEntry = FnEntry {
+    signature: "eprintln(message)",
+    description: "prints any value to stderr with trailing newline",
+    example: "get std::io::eprintln\n\neprintln(\"something went wrong\")",
+    expected_output: Some("something went wrong"),
+    returns: "null",
+    errors: None,
+    see_also: &["eprint", "print", "println"],
+    since: Some("v1.1.0"),
+};

--- a/crates/rl-docs/src/entries/stdlib/io/eprintln.rs
+++ b/crates/rl-docs/src/entries/stdlib/io/eprintln.rs
@@ -1,7 +1,7 @@
 use crate::entry::FnEntry;
 
 pub static EPRINTLN: FnEntry = FnEntry {
-    signature: "eprintln(message)",
+    signature: "eprintln(message, ..)",
     description: "prints any value to stderr with trailing newline",
     example: "get std::io::eprintln\n\neprintln(\"something went wrong\")",
     expected_output: Some("something went wrong"),

--- a/crates/rl-docs/src/entries/stdlib/io/mod.rs
+++ b/crates/rl-docs/src/entries/stdlib/io/mod.rs
@@ -3,6 +3,7 @@ use crate::entry::{FnEntry, StdEntry};
 mod append_file;
 mod delete_file;
 mod eprint;
+mod eprintln;
 mod print;
 mod println;
 mod read;
@@ -22,19 +23,20 @@ pub static IO: StdEntry = StdEntry {
 };
 
 static FUNCTIONS: &[&FnEntry] = &[
-    &read::READ,
-    &read::READ_PROMPT,
-    &read_int::READ_INT,
-    &read_int::READ_INT_PROMPT,
-    &read_float::READ_FLOAT,
-    &read_float::READ_FLOAT_PROMPT,
     &append_file::APPEND_FILE,
     &delete_file::DELETE_FILE,
-    &read_file::READ_FILE,
-    &read_lines::READ_LINES,
-    &read_bytes::READ_BYTES,
-    &write_file::WRITE_FILE,
+    &eprint::EPRINT,
+    &eprintln::EPRINTLN,
     &print::PRINT,
     &println::PRINTLN,
-    &eprint::EPRINT,
+    &read::READ,
+    &read::READ_PROMPT,
+    &read_bytes::READ_BYTES,
+    &read_file::READ_FILE,
+    &read_float::READ_FLOAT,
+    &read_float::READ_FLOAT_PROMPT,
+    &read_int::READ_INT,
+    &read_int::READ_INT_PROMPT,
+    &read_lines::READ_LINES,
+    &write_file::WRITE_FILE,
 ];

--- a/crates/rl-std/src/io.rs
+++ b/crates/rl-std/src/io.rs
@@ -21,7 +21,6 @@
 
 use rl_std_core::Runtime;
 use rl_std_macros::native_fn;
-use rl_utils::errors::Error;
 
 // ---- printing (variadic, untyped) -----------------------------------------
 
@@ -247,9 +246,18 @@ pub fn delete_file(file: String) -> Result<(), String> {
 
 // ---- stderr (propagating runtime error) -----------------------------------
 
-#[native_fn(module = "io")]
-pub fn eprint<R: Runtime>(cx: &mut R::Cx, string: String, span: R::Span) -> Result<(), Error> {
-    Err(R::error(cx, string, span))
+#[native_fn(module = "io", untyped)]
+pub fn eprint<R: Runtime>(_cx: &mut R::Cx, args: Vec<R::Value>) -> R::Value {
+    let text = args.iter().map(|v| R::display(v)).collect::<String>();
+    eprint!("{}", text);
+    R::null()
+}
+
+#[native_fn(module = "io", untyped)]
+pub fn eprintln<R: Runtime>(_cx: &mut R::Cx, args: Vec<R::Value>) -> R::Value {
+    let text = args.iter().map(|v| R::display(v)).collect::<String>();
+    eprintln!("{}", text);
+    R::null()
 }
 
 rl_std_core::native_module!("io";
@@ -258,6 +266,6 @@ rl_std_core::native_module!("io";
         read, read_int, read_float,
         read_file, read_lines, read_bytes,
         write_file, append_file, delete_file,
-        eprint,
+        eprint, eprintln
     ],
 );

--- a/crates/rl-tests/tests/vm/stdlib/io.rs
+++ b/crates/rl-tests/tests/vm/stdlib/io.rs
@@ -182,17 +182,6 @@ x
 }
 
 #[test]
-fn eprint_raises_runtime_error() {
-    let result = compile_and_run(
-        r#"
-get eprint from std::io
-dec string x = eprint("boom")
-"#,
-    );
-    assert!(result.is_err());
-}
-
-#[test]
 fn read_rejects_too_many_args() {
     let result = compile_and_run(
         r#"


### PR DESCRIPTION
## What does this PR do?

Refactor `eprint` function to instead write to `stderr` (for runtime errors use `panic`)
Add new variant `eprintln` with trailing newline

## Related issue
Closes #428

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
