### PR TITLE
fix: register array len with the checker

### DIFF
--- a/crates/rl-std/src/array.rs
+++ b/crates/rl-std/src/array.rs
@@ -277,7 +277,8 @@ pub fn arr_is_empty<R: Runtime>(_cx: &mut R::Cx, array: R::Value) -> R::Value {
 // NOTE: `len` is intentionally NOT defined here. Its return convention diverges
 // between the runtimes (the VM returns `result[int]`, the interpreter a bare
 // `int`) and it needs tuple access, so each runtime registers its own legacy
-// `len` on top of this module's handles.
+// `len` on top of this module's handles. The shared signature tree registers
+// its name as untyped so the checker can still resolve it in both runtimes.
 
 // ---- builders -------------------------------------------------------------
 

--- a/crates/rl-std/src/lib.rs
+++ b/crates/rl-std/src/lib.rs
@@ -53,7 +53,7 @@ pub mod types;
 /// deps), so the checker and LSP stay light.
 pub fn signatures() -> rl_std_core::ModuleNames {
     rl_std_core::ModuleNames::new("std")
-        .with_module(array::signatures())
+        .with_module(array::signatures().with_functions(&["len"]))
         .with_module(audio::signatures())
         .with_module(bitwise::signatures())
         .with_module(c::signatures())

--- a/crates/rl-tests/tests/commons/mod.rs
+++ b/crates/rl-tests/tests/commons/mod.rs
@@ -188,6 +188,14 @@ fn array_arr_push_takes_array_t_and_t_returns_result_array_t() {
 }
 
 #[test]
+fn array_len_resolves_as_an_untyped_legacy_function() {
+    let tree = stdlib_names();
+    let path = vec!["std".to_string(), "array".to_string(), "len".to_string()];
+    let f = tree.resolve(&path).expect("array len should resolve");
+    assert!(f.signatures.is_empty());
+}
+
+#[test]
 fn array_arr_max_has_int_and_float_overloads_only() {
     let tree = stdlib_names();
     let path = vec!["array".to_string(), "arr_max".to_string()];


### PR DESCRIPTION
## What does this PR do?

Registers the runtime-specific `std::array::len` name in the shared checker signature tree as untyped. This lets the checker and LSP resolve the call without assigning one static signature to the VM and tree-walking implementations, whose return conventions differ.

Adds a regression test for resolving the full `std::array::len` path. Runtime behavior is unchanged.

## Related issue
Closes #434

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed

## Validation

- `cargo check --all-targets --all-features`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rl-tests --test tests commons::array_len_resolves_as_an_untyped_legacy_function`
- `rl check` accepts a program that calls `std::array::len([1, 1, 1])`
- the same program executes successfully with both the VM and tree-walking runtimes
