### PR TITLE
add tests to catch future regressions for `and` and `or` in `rl-vm`

### DIFF
--- a/crates/rl-tests/tests/vm/logical.rs
+++ b/crates/rl-tests/tests/vm/logical.rs
@@ -1,0 +1,68 @@
+use crate::common;
+use rl_vm::VmValue;
+
+#[test]
+fn logical_and_truth_table() {
+    let result = common::compile_and_run(
+        r#"
+        dec bool a = true and true
+        dec bool b = true and false
+        dec bool c = false and true
+        dec bool d = false and false
+        a == true and b == false and c == false and d == false
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn logical_or_truth_table() {
+    let result = common::compile_and_run(
+        r#"
+        dec bool a = true or true
+        dec bool b = true or false
+        dec bool c = false or true
+        dec bool d = false or false
+        a == true and b == true and c == true and d == false
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn logical_and_evaluates_right_side_when_left_is_true() {
+    let err = common::compile_and_run(
+        r#"
+        dec bool x = true and (1 / 0 == 1)
+        x
+        "#,
+    )
+    .expect_err("right side of `and` should run and divide by zero");
+
+    assert!(
+        err.message().contains("division by zero"),
+        "unexpected error message: {}",
+        err.message()
+    );
+}
+
+#[test]
+fn logical_or_evaluates_right_side_when_left_is_false() {
+    let err = common::compile_and_run(
+        r#"
+        dec bool x = false or (1 / 0 == 1)
+        x
+        "#,
+    )
+    .expect_err("right side of `or` should run and divide by zero");
+
+    assert!(
+        err.message().contains("division by zero"),
+        "unexpected error message: {}",
+        err.message()
+    );
+}

--- a/crates/rl-tests/tests/vm/mod.rs
+++ b/crates/rl-tests/tests/vm/mod.rs
@@ -1,4 +1,5 @@
 mod r#impl;
+mod logical;
 mod method_call;
 mod numbers;
 mod stdlib;

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -708,6 +708,8 @@ impl<'a> Compiler<'a> {
                     TokenType::LessEqual => OpCode::LessEq,
                     TokenType::Greater => OpCode::Greater,
                     TokenType::GreaterEqual => OpCode::GreaterEq,
+                    TokenType::And => return self.compile_logical(*left, *right, span, true),
+                    TokenType::Or => return self.compile_logical(*left, *right, span, false),
                     other => {
                         return Err(self.err(
                             format!("unsupported binary operator in vm compiler: {other:?}"),
@@ -1202,6 +1204,37 @@ impl<'a> Compiler<'a> {
         self.chunk.write_op(OpCode::Index, span);
         self.emit_define_slot(base, span);
 
+        Ok(())
+    }
+
+    fn compile_logical(
+        &mut self,
+        left: ExprId,
+        right: ExprId,
+        span: Span,
+        is_and: bool,
+    ) -> Result<(), CompileError> {
+        self.compile_expr(left)?;
+        let branch = self.emit_jump(OpCode::JumpIfFalse, span);
+
+        if is_and {
+            self.compile_expr(right)?;
+            self.emit_const(VmValue::Bool(true), span);
+            self.chunk.write_op(OpCode::Eq, span);
+        } else {
+            self.emit_const(VmValue::Bool(true), span);
+        }
+        let end = self.emit_jump(OpCode::Jump, span);
+
+        self.patch_jump(branch);
+        if is_and {
+            self.emit_const(VmValue::Bool(false), span);
+        } else {
+            self.compile_expr(right)?;
+            self.emit_const(VmValue::Bool(true), span);
+            self.chunk.write_op(OpCode::Eq, span);
+        }
+        self.patch_jump(end);
         Ok(())
     }
 


### PR DESCRIPTION
## What does this PR do?

add `and` and `or` to vm

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
