### PR TITLE
add some test units for `vm` for catching future `match` regressions

### DIFF
--- a/crates/rl-tests/tests/vm/match.rs
+++ b/crates/rl-tests/tests/vm/match.rs
@@ -1,0 +1,152 @@
+use crate::common;
+use rl_vm::VmValue;
+
+#[test]
+fn match_matching_literal_arm_runs_its_body() {
+    let result = common::compile_and_run(
+        r#"
+        dec int x = 2
+        dec int res = 0
+        match x {
+            1 => { res = 100 }
+            2 => { res = 200 }
+            _ => { res = 300 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(200));
+}
+
+#[test]
+fn match_first_arm_skips_remaining_arms() {
+    let result = common::compile_and_run(
+        r#"
+        dec int x = 1
+        dec int res = 0
+        match x {
+            1 => { res= 1 }
+            1 => { res= 2 }
+            _ => { res= 3 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(1));
+}
+
+#[test]
+fn match_wildcard_is_fallback_for_unmatched_value() {
+    let result = common::compile_and_run(
+        r#"
+        dec int x = 99
+        dec int res = 0
+        match x {
+            1 => { res = 100 }
+            2 => { res = 200 }
+            _ => { res = 300 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(300));
+}
+
+#[test]
+fn match_no_arm_matches_leaves_state_unchanged() {
+    let result = common::compile_and_run(
+        r#"
+        dec int x = 99
+        dec int res = 42
+        match x {
+            1 => { res = 100 }
+            2 => { res = 200 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(42));
+}
+
+#[test]
+fn match_arm_body_reads_outer_local() {
+    let result = common::compile_and_run(
+        r#"
+        dec int factor = 10
+        dec int x = 2
+        dec int res = 0
+        match x {
+            1 => { res = factor }
+            2 => { res = factor * 2 }
+            _ => { res = factor }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(20));
+}
+
+#[test]
+fn match_arm_body_reads_global() {
+    let result = common::compile_and_run(
+        r#"
+        dec int factor = 7
+        dec int x = 2
+        dec int res = 0
+        match x {
+            2 => { res = factor }
+            _ => { res = 0 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(7));
+}
+
+#[test]
+fn match_arms_assign_to_outer_scope() {
+    let result = common::compile_and_run(
+        r#"
+        dec int res = 0
+        match 5 {
+            5 => { res = res + 1 }
+            _ => { res = 999 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(1));
+}
+
+#[test]
+fn match_on_string_value() {
+    let result = common::compile_and_run(
+        r#"
+        dec string s = "hi"
+        dec int res = 0
+        match s {
+            "hi" => { res = 1 }
+            "bye" => { res = 2 }
+            _ => { res = 3 }
+        }
+        res
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(1));
+}

--- a/crates/rl-tests/tests/vm/mod.rs
+++ b/crates/rl-tests/tests/vm/mod.rs
@@ -1,4 +1,5 @@
 mod r#impl;
+mod r#match;
 mod method_call;
 mod numbers;
 mod stdlib;

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -1090,14 +1090,13 @@ impl<'a> Compiler<'a> {
         arms: &[(MatchPattern, Vec<Statement>)],
         span: Span,
     ) -> Result<(), CompileError> {
-        self.chunk.write_op(OpCode::PushScope, span);
-        self.scope_bases.push(self.next_slot);
+        let slot = self.next_slot;
+        self.next_slot += 1;
+        let vslot = slot;
+        let is_global = self.scope_bases.is_empty();
 
         self.compile_expr(value)?;
-        let _slot = self.next_slot;
-        self.next_slot += 1;
-        self.chunk.write_op(OpCode::DefineLocal, span);
-        self.chunk.write_u16(_slot, span);
+        self.emit_define_slot(vslot, span);
 
         let mut end_jumps = Vec::new();
         for (pattern, body) in arms {
@@ -1105,8 +1104,7 @@ impl<'a> Compiler<'a> {
                 MatchPattern::Wildcard => None,
                 MatchPattern::Literal(expr) => {
                     self.compile_expr(*expr)?;
-                    self.chunk.write_op(OpCode::GetLocal, span);
-                    self.chunk.write_u16(_slot, span);
+                    self.emit_get_slot(vslot, is_global, span);
                     self.chunk.write_op(OpCode::Eq, span);
                     Some(self.emit_jump(OpCode::JumpIfFalse, span))
                 }
@@ -1124,8 +1122,7 @@ impl<'a> Compiler<'a> {
             self.patch_jump(j);
         }
 
-        self.chunk.write_op(OpCode::PopScope, span);
-        self.next_slot = self.scope_bases.pop().unwrap();
+        self.next_slot = slot;
         Ok(())
     }
 


### PR DESCRIPTION
## What does this PR do?

fixes `match` logic

## Related issue
Closes #438

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
