### PR TITLE
add tests to catch regressions

### DIFF
--- a/crates/rl-tests/tests/vm/logical.rs
+++ b/crates/rl-tests/tests/vm/logical.rs
@@ -66,3 +66,43 @@ fn logical_or_evaluates_right_side_when_left_is_false() {
         err.message()
     );
 }
+
+#[test]
+fn logical_and_short_circuits_when_left_is_false() {
+    let result = common::compile_and_run(
+        r#"
+        dec bool x = false and (1 / 0 == 1)
+        x
+        "#,
+    )
+    .expect("left `false` should short-circuit `and` without dividing by zero");
+
+    assert_eq!(result, VmValue::Bool(false));
+}
+
+#[test]
+fn logical_or_short_circuits_when_left_is_true() {
+    let result = common::compile_and_run(
+        r#"
+        dec bool x = true or (1 / 0 == 1)
+        x
+        "#,
+    )
+    .expect("left `true` should short-circuit `or` without dividing by zero");
+
+    assert_eq!(result, VmValue::Bool(true));
+}
+
+#[test]
+fn logical_and_keeps_stack_balanced_around_dec() {
+    let result = common::compile_and_run(
+        r#"
+        dec bool x = true and false
+        dec int y = 42
+        y
+        "#,
+    )
+    .expect("vm run failed");
+
+    assert_eq!(result, VmValue::Int(42));
+}

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -695,6 +695,11 @@ impl<'a> Compiler<'a> {
                 operator,
                 right,
             } => {
+                match operator {
+                    TokenType::And => return self.compile_logical(*left, *right, span, true),
+                    TokenType::Or => return self.compile_logical(*left, *right, span, false),
+                    _ => {}
+                }
                 self.compile_expr(*left)?;
                 self.compile_expr(*right)?;
                 let op = match operator {
@@ -708,8 +713,6 @@ impl<'a> Compiler<'a> {
                     TokenType::LessEqual => OpCode::LessEq,
                     TokenType::Greater => OpCode::Greater,
                     TokenType::GreaterEqual => OpCode::GreaterEq,
-                    TokenType::And => return self.compile_logical(*left, *right, span, true),
-                    TokenType::Or => return self.compile_logical(*left, *right, span, false),
                     other => {
                         return Err(self.err(
                             format!("unsupported binary operator in vm compiler: {other:?}"),


### PR DESCRIPTION
## What does this PR do?

fixes `and` and `or` not short circuiting correctly

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
