### PR TITLE
add regression test for namespaced method calls to `vm`

### DIFF
--- a/crates/rl-tests/tests/vm/method_call.rs
+++ b/crates/rl-tests/tests/vm/method_call.rs
@@ -107,3 +107,16 @@ fn calling_unknown_method_on_a_record_is_a_runtime_error() {
         err.message()
     );
 }
+
+#[test]
+fn namespaced_stdlib_method_call() {
+    // `x.std::module::fn()` resolves the stdlib path without an `import`
+    let result = common::compile_and_run(
+        r#"
+        dec string s = "Hello"
+        s.std::str::to_lower()
+        "#,
+    )
+    .expect("vm run failed");
+    assert_eq!(result, VmValue::Str(std::rc::Rc::from("hello")));
+}

--- a/crates/rl-vm/src/compiler.rs
+++ b/crates/rl-vm/src/compiler.rs
@@ -787,12 +787,18 @@ impl<'a> Compiler<'a> {
                 method,
                 args,
             } => {
-                if method.len() != 1 {
-                    return Err(self.err(
-                        "namespaced method calls (`value.module::method(...)`) are not yet \
-                         supported by the vm compiler",
-                        span,
-                    ));
+                if method.len() > 1 {
+                    let native = self.stdlib.resolve(method).ok_or_else(|| {
+                        self.err(format!("undefined function {}", method.join("::")), span)
+                    })?;
+                    self.emit_const(VmValue::Native(native), span); // callee
+                    self.compile_expr(*caller)?; // receiver = arg 1
+                    for arg in args {
+                        self.compile_expr(*arg)?;
+                    }
+                    self.chunk.write_op(OpCode::Call, span);
+                    self.chunk.write_u16((args.len() + 1) as u16, span);
+                    return Ok(());
                 }
                 // Instance method dispatch, e.g. `point.magnitude()`. The
                 // record type is only known at runtime, so the caller is


### PR DESCRIPTION
## What does this PR do?

Allow using full path of std function as method call in vm

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
