### PR TITLE
Revert to unified crate versioning to reduce maintenance complexity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "rl-ast"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-lexer",
  "rl-utils",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "rl-benches"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "rl-ast",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "rl-checker"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-commons",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "rl-cli"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "rl-commons"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-std",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "rl-cranelift"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "rl-docs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "rl-interpreter"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "log",
  "rl-ast",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "rl-lexer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "log",
  "rl-utils",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "rl-lsp"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-checker",
  "rl-lexer",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "rl-parser"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "log",
  "rl-ast",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "rl-repl"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "rl-resolver"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-lexer",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "rl-std"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "cpal",
  "crossterm",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "rl-std-core"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-utils",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "rl-std-macros"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "rl-tests"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-checker",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "rl-tooling"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-lexer",
  "serde",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "rl-utils"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "ariadne",
  "log",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rl-vm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "rl-ast",
  "rl-checker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,29 +24,29 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rl-lang/rl-lang"
 
 [workspace.dependencies]
-rl-commons = { path = "crates/rl-commons", version = "1.0.0" }
-rl-std-core = { path = "crates/rl-std-core", version = "1.0.0" }
-rl-std-macros = { path = "crates/rl-std-macros", version = "1.0.0" }
-rl-std = { path = "crates/rl-std", version = "1.0.0" }
-rl-utils = { path = "crates/rl-utils", version = "1.0.0" }
-rl-lexer = { path = "crates/rl-lexer", version = "1.0.0" }
-rl-ast = { path = "crates/rl-ast", version = "1.0.0" }
-rl-parser = { path = "crates/rl-parser", version = "1.0.0" }
-rl-resolver = { path = "crates/rl-resolver", version = "1.0.0" }
-rl-vm = { path = "crates/rl-vm", version = "1.0.0" }
-rl-cranelift = { path = "crates/rl-cranelift", version = "1.0.0" }
-rl-interpreter = { path = "crates/rl-interpreter", version = "1.0.0" }
-rl-checker = { path = "crates/rl-checker", version = "1.0.0" }
-rl-docs = { path = "crates/rl-docs", version = "1.0.0" }
-rl-tooling = { path = "crates/rl-tooling", version = "1.0.0" }
-rl-repl = { path = "crates/rl-repl", version = "1.0.0", default-features = false }
-rl-lsp = { path = "crates/rl-lsp", version = "1.0.0" }
+rl-commons = { path = "crates/rl-commons", version = "1.1.0" }
+rl-std-core = { path = "crates/rl-std-core", version = "1.1.0" }
+rl-std-macros = { path = "crates/rl-std-macros", version = "1.1.0" }
+rl-std = { path = "crates/rl-std", version = "1.1.0" }
+rl-utils = { path = "crates/rl-utils", version = "1.1.0" }
+rl-lexer = { path = "crates/rl-lexer", version = "1.1.0" }
+rl-ast = { path = "crates/rl-ast", version = "1.1.0" }
+rl-parser = { path = "crates/rl-parser", version = "1.1.0" }
+rl-resolver = { path = "crates/rl-resolver", version = "1.1.0" }
+rl-vm = { path = "crates/rl-vm", version = "1.1.0" }
+rl-cranelift = { path = "crates/rl-cranelift", version = "1.1.0" }
+rl-interpreter = { path = "crates/rl-interpreter", version = "1.1.0" }
+rl-checker = { path = "crates/rl-checker", version = "1.1.0" }
+rl-docs = { path = "crates/rl-docs", version = "1.1.0" }
+rl-tooling = { path = "crates/rl-tooling", version = "1.1.0" }
+rl-repl = { path = "crates/rl-repl", version = "1.1.0", default-features = false }
+rl-lsp = { path = "crates/rl-lsp", version = "1.1.0" }
 
 criterion = { version = "0.5", features = ["html_reports"] }
 syn = { version = "2", features = ["full"] }

--- a/crates/rl-ast/Cargo.toml
+++ b/crates/rl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-ast"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-checker/Cargo.toml
+++ b/crates/rl-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-checker"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-cli/Cargo.toml
+++ b/crates/rl-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-cli"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-commons/Cargo.toml
+++ b/crates/rl-commons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-commons"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-cranelift/Cargo.toml
+++ b/crates/rl-cranelift/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-cranelift"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-interpreter/Cargo.toml
+++ b/crates/rl-interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-interpreter"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-lexer/Cargo.toml
+++ b/crates/rl-lexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-lexer"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-lsp/Cargo.toml
+++ b/crates/rl-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-lsp"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-parser/Cargo.toml
+++ b/crates/rl-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-parser"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-repl/Cargo.toml
+++ b/crates/rl-repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-repl"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-resolver/Cargo.toml
+++ b/crates/rl-resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-resolver"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-std-core/Cargo.toml
+++ b/crates/rl-std-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-std-core"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-std-macros/Cargo.toml
+++ b/crates/rl-std-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-std-macros"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-std/Cargo.toml
+++ b/crates/rl-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-std"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-tooling/Cargo.toml
+++ b/crates/rl-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-tooling"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-utils/Cargo.toml
+++ b/crates/rl-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-utils"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true

--- a/crates/rl-vm/Cargo.toml
+++ b/crates/rl-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rl-vm"
-version = "1.0.0"
+version.workspace = true
 readme = "readme.md"
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## What does this PR do?

Replace per-crate literal version fields with the workspace-level version, and bump the workspace version to 1.1.0. This gives a single source of truth for the crate version and simplifies future releases.

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
