### PR TITLE
Add missing readme files for the shared stdlib crates

### DIFF
--- a/crates/rl-std-core/readme.md
+++ b/crates/rl-std-core/readme.md
@@ -1,0 +1,49 @@
+# rl-std-core
+
+> Runtime-agnostic core for the rl-lang standard library: the `Runtime` abstraction, native-function descriptors, value conversions, and stdlib signatures
+
+Part of the [rl-lang](https://github.com/rl-lang/rl-lang) workspace.
+
+## Overview
+
+Holds what the shared stdlib (`rl-std`) and both runtimes (`rl-vm`, `rl-interpreter`) need in common, without referencing either runtime's value type, so it can sit below both in the dependency graph:
+
+- The `Runtime` trait each runtime implements, plus the shared `HandleStore` for opaque resource handles
+- The thin-`fn`-pointer native descriptor (`NativeHandle` / `Arity`)
+- Value <-> Rust type conversions (`ValueType` / `FromValueR` / `IntoValueR`)
+- The checker signature types (`StdFn` / `ModuleNames`)
+- `Xoshiro256`, the shared PRNG
+
+## Modules
+
+| Module | Contents |
+|---|---|
+| `runtime` | `Runtime` trait, `HandleStore`, and `R::Cx` runtime context |
+| `handle` | `NativeHandle`, `Arity`, `NativeThunk` - thin-pointer native descriptors |
+| `convert` | `ValueType`, `FromValueR`, `IntoValueR` value <-> Rust type conversions |
+| `module` | Module builders that aggregate per-function handles and signatures |
+| `rng` | `Xoshiro256` - the shared PRNG |
+| `signatures` | `StdFn`, `ModuleNames` - checker signature types |
+
+## Dependencies
+
+Depends only on `rl-ast` and `rl-utils`.
+
+## Usage
+
+```toml
+[dependencies]
+rl-std-core = { workspace = true }
+```
+
+```rust
+use rl_std_core::Runtime;
+
+fn process<R: Runtime>(_cx: &mut R::Cx, value: R::Value) -> R::Value {
+    value
+}
+```
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your option - see [LICENSE.md](../../LICENSE.md) for the full text and why both are offered.

--- a/crates/rl-std-macros/readme.md
+++ b/crates/rl-std-macros/readme.md
@@ -1,0 +1,52 @@
+# rl-std-macros
+
+> Procedural macros for the rl-lang standard library: `#[native_fn]` lowers a Rust function into a thin-pointer native descriptor plus its checker signature
+
+Part of the [rl-lang](https://github.com/rl-lang/rl-lang) workspace.
+
+## Overview
+
+`#[native_fn(...)]` lowers an annotated stdlib function into:
+
+- a generic thin-`fn`-pointer wrapper (`wrapper::<R>`) that arity-checks, extracts each argument, calls the body, and converts the result
+- a `signature()` builder producing the checker's `StdFn`
+- a `handle::<R>()` builder producing a `NativeHandle`
+
+The three are placed in a `mod <fn-name>` beside the (unchanged) function, so `mod::handle::<R>()` / `mod::signature()` can be aggregated by the module builders in `rl-std`.
+
+Each Rust parameter is classified structurally:
+
+- a leading `&mut R::Cx` -> the runtime context (forwarded, not an rl arg)
+- `R::Value` -> a raw value argument (identity extraction)
+- `Vec<R::Value>` -> variadic (the whole argument vector)
+- `R::Span` -> the call span
+- anything else -> a typed argument extracted via `FromValueR`
+
+Return values are classified as:
+
+- `Result<T, Error>` -> fallible; the error propagates, sig return is `T`
+- `Result<T, String>` -> a language `result[T]` value (Ok/Err)
+- `R::Value` -> a raw value (requires an explicit `sig`)
+- anything else -> converted via `IntoValueR`, sig derived from the type
+
+## Modules
+
+| Module | Contents |
+|---|---|
+| `attr` | Parsing of the `#[native_fn]` attribute arguments |
+| `codegen` | Expansion of the annotated function into wrapper / signature / handle |
+
+## Usage
+
+Used by `rl-std` to annotate its function implementations:
+
+```rust
+#[native_fn(module = "math", sig(int -> result[int]), sig(float -> result[float]))]
+pub fn abs<R: Runtime>(_cx: &mut R::Cx, a: R::Value) -> R::Value {
+    // ...
+}
+```
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your option - see [LICENSE.md](../../LICENSE.md) for the full text and why both are offered.

--- a/crates/rl-std/readme.md
+++ b/crates/rl-std/readme.md
@@ -1,0 +1,58 @@
+# rl-std
+
+> The single, runtime-agnostic implementation of the rl-lang standard library, shared by the VM and the interpreter
+
+Part of the [rl-lang](https://github.com/rl-lang/rl-lang) workspace.
+
+## Overview
+
+Each standard-library function is written once, generic over `rl_std_core::Runtime`, and annotated with `#[native_fn]` so it is available to both the VM and the interpreter as a thin function pointer, and to the checker as a signature.
+
+The crate is split into two features:
+
+- `signatures` (default) - only the pure `signature()`/`KEYWORDS` data is compiled, with no runtime and no OS-facing dependencies. This is what the type checker and language server use.
+- `impls` - the actual function bodies plus `handles::<R>()` builders, pulling in the OS-facing crates. The VM and interpreter enable this.
+
+`#[native_fn]` gates the body/wrapper/handle behind `impls` per function, so every module's `signature()` data is available in a signatures-only build without compiling eframe/rodio/libffi.
+
+## Modules
+
+| Module | Contents |
+|---|---|
+| `array` | `std::array` - array builders, slicing, and reductions |
+| `audio` | `std::audio` - audio playback and volume (via `rodio`/`cpal`/`symphonia`) |
+| `bitwise` | `std::bitwise` - bit-level operations on integers |
+| `c` | `std::c` - call C library functions via `libffi` |
+| `collections` | `std::collections` - map and set operations |
+| `debug` | `std::debug` - runtime debugging helpers |
+| `fs` | `std::fs` - filesystem access |
+| `gui` | `std::gui` - windowed UI toolkit (via `eframe`) |
+| `http` | `std::http` - HTTP requests (via `tiny_http`/`ureq`) |
+| `io` | `std::io` - printing and stdin |
+| `math` | `std::math` - math functions and `std::math::consts` |
+| `net` | `std::net` - networking helpers |
+| `path` | `std::path` - path manipulation |
+| `process` | `std::process` - process execution |
+| `random` | `std::random` - PRNG-backed generation |
+| `result` | `std::result` - `result[T]` helpers |
+| `string` | `std::str` - string manipulation |
+| `terminal` | `std::terminal` - terminal / key input |
+| `time` | `std::time` - time and timing helpers |
+| `types` | `std::types` - type introspection |
+
+## Dependencies
+
+Depends on `rl-std-core`, `rl-std-macros`, `rl-ast`, and `rl-utils`. The OS-facing modules bring in `crossterm`, `tiny_http`, `ureq`, `libloading`, `libffi`, `rodio`, `cpal`, `symphonia`, `eframe`, and `shell-words` (only when the `impls` feature is enabled).
+
+## Usage
+
+```toml
+[dependencies]
+rl-std = { workspace = true, features = ["impls"] }
+```
+
+The checker and language server use the default `signatures` feature; the VM and interpreter depend on `rl-std` with the `impls` feature enabled.
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your option - see [LICENSE.md](../../LICENSE.md) for the full text and why both are offered.


### PR DESCRIPTION
## What does this PR do?

rl-std, rl-std-core, and rl-std-macros declared readme = "readme.md" but the files were never created, which made cargo package and publish fail.

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
