### PR TITLE
fix workflows to enable sccache for release and nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,7 +57,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_CACHE_TAG: rl-v1-${{ matrix.target }}
+      SCCACHE_GHA_CACHE_TAG: rl-v1-${{ matrix.target }}-${{ matrix.group }}
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -120,7 +121,7 @@ jobs:
         run: choco install zip -y
 
       - name: Start sccache
-        uses: mozilla/sccache-action@v0.0.10
+        uses: mozilla/sccache-action@v0.0.11
 
       - name: Build variants (${{ matrix.group }})
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_CACHE_TAG: rl-v1-${{ matrix.target }}
+      SCCACHE_GHA_CACHE_TAG: rl-v1-${{ matrix.target }}-${{ matrix.group }}
+      RUSTC_WRAPPER: "sccache"
     steps:
       - name: Install build deps (linux)
         if: matrix.os == 'ubuntu-latest' && matrix.platform != 'android'
@@ -132,7 +133,7 @@ jobs:
         run: choco install zip -y
 
       - name: Start sccache
-        uses: mozilla/sccache-action@v0.0.10
+        uses: mozilla/sccache-action@v0.0.11
 
       - name: Build variants (${{ matrix.group }})
         shell: bash


### PR DESCRIPTION
## What does this PR do?

Set RUSTC_WRAPPER so cargo routes rustc invocations through sccache, and scope the GHA cache tag per matrix group so concurrent jobs don't collide
on a single cache key. Bump sccache-action to v0.0.11.

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
