### PR TITLE
Fix/cli/treewalker flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,29 +24,29 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rl-lang/rl-lang"
 
 [workspace.dependencies]
-rl-commons = { path = "crates/rl-commons", version = "1.2.0" }
-rl-std-core = { path = "crates/rl-std-core", version = "1.2.0" }
-rl-std-macros = { path = "crates/rl-std-macros", version = "1.2.0" }
-rl-std = { path = "crates/rl-std", version = "1.2.0" }
-rl-utils = { path = "crates/rl-utils", version = "1.2.0" }
-rl-lexer = { path = "crates/rl-lexer", version = "1.2.0" }
-rl-ast = { path = "crates/rl-ast", version = "1.2.0" }
-rl-parser = { path = "crates/rl-parser", version = "1.2.0" }
-rl-resolver = { path = "crates/rl-resolver", version = "1.2.0" }
-rl-vm = { path = "crates/rl-vm", version = "1.2.0" }
-rl-cranelift = { path = "crates/rl-cranelift", version = "1.2.0" }
-rl-interpreter = { path = "crates/rl-interpreter", version = "1.2.0" }
-rl-checker = { path = "crates/rl-checker", version = "1.2.0" }
-rl-docs = { path = "crates/rl-docs", version = "1.2.0" }
-rl-tooling = { path = "crates/rl-tooling", version = "1.2.0" }
-rl-repl = { path = "crates/rl-repl", default-features = false, version = "1.2.0" }
-rl-lsp = { path = "crates/rl-lsp", version = "1.2.0" }
+rl-commons = { path = "crates/rl-commons", version = "1.2.1" }
+rl-std-core = { path = "crates/rl-std-core", version = "1.2.1" }
+rl-std-macros = { path = "crates/rl-std-macros", version = "1.2.1" }
+rl-std = { path = "crates/rl-std", version = "1.2.1" }
+rl-utils = { path = "crates/rl-utils", version = "1.2.1" }
+rl-lexer = { path = "crates/rl-lexer", version = "1.2.1" }
+rl-ast = { path = "crates/rl-ast", version = "1.2.1" }
+rl-parser = { path = "crates/rl-parser", version = "1.2.1" }
+rl-resolver = { path = "crates/rl-resolver", version = "1.2.1" }
+rl-vm = { path = "crates/rl-vm", version = "1.2.1" }
+rl-cranelift = { path = "crates/rl-cranelift", version = "1.2.1" }
+rl-interpreter = { path = "crates/rl-interpreter", version = "1.2.1" }
+rl-checker = { path = "crates/rl-checker", version = "1.2.1" }
+rl-docs = { path = "crates/rl-docs", version = "1.2.1" }
+rl-tooling = { path = "crates/rl-tooling", version = "1.2.1" }
+rl-repl = { path = "crates/rl-repl", default-features = false, version = "1.2.1" }
+rl-lsp = { path = "crates/rl-lsp", version = "1.2.1" }
 
 criterion = { version = "0.5", features = ["html_reports"] }
 syn = { version = "2", features = ["full"] }

--- a/crates/rl-cli/readme.md
+++ b/crates/rl-cli/readme.md
@@ -8,7 +8,7 @@ Part of the [rl-lang](https://github.com/rl-lang/rl-lang) workspace. This is the
 
 | Subcommand | Action |
 |---|---|
-| `rl run <file>` | Lex, parse, and evaluate a single `.rl` file (`--vm` / `--cranelift` to pick an alternate backend) |
+| `rl run <file>` | Lex, parse, and evaluate a single `.rl` file (`--treewalker` / `--vm` / `--cranelift` to pick a backend) |
 | `rl dev` | Read `rl.toml`, lex, parse, and evaluate the project entry point |
 | `rl check <file>` | Lex, parse, and type-check a file, reporting errors without running it |
 | `rl new <name>` | Scaffold a new project directory |

--- a/crates/rl-cli/readme.md
+++ b/crates/rl-cli/readme.md
@@ -9,7 +9,7 @@ Part of the [rl-lang](https://github.com/rl-lang/rl-lang) workspace. This is the
 | Subcommand | Action |
 |---|---|
 | `rl run <file>` | Lex, parse, and evaluate a single `.rl` file (`--treewalker` / `--vm` / `--cranelift` to pick a backend) |
-| `rl dev` | Read `rl.toml`, lex, parse, and evaluate the project entry point |
+| `rl dev` | Read `rl.toml`, lex, parse, and evaluate the project entry point (`--treewalker` / `--vm` / `--cranelift` to pick a backend) |
 | `rl check <file>` | Lex, parse, and type-check a file, reporting errors without running it |
 | `rl new <name>` | Scaffold a new project directory |
 | `rl docs [topic]` | Print stdlib / concept / tutorial reference (Markdown, JSON, or an interactive TUI) |

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -88,9 +88,28 @@ enum Commands {
     #[command(
         long_about = "Read `rl.toml` in the current directory and run the project's \
                        configured entry file.\n\n\
-                       Use `rl new` first if you don't have an rl.toml yet."
+                       Use `rl new` first if you don't have an rl.toml yet.",
+        after_help = "EXAMPLES:\n    \
+                       rl dev\n    \
+                       rl dev --treewalker\n    \
+                       rl dev --vm\n    \
+                       rl dev --cranelift"
     )]
-    Dev,
+    Dev {
+        /// Run through the tree-walking evaluator instead of the bytecode VM
+        #[arg(long)]
+        treewalker: bool,
+
+        /// Run thought the bytecode VM instead of the tree-walking evaluator
+        /// (this is highly experimental)
+        #[arg(long)]
+        vm: bool,
+
+        /// JIT compile via cranelift instead
+        /// (this is very very highly experimental)
+        #[arg(long)]
+        cranelift: bool,
+    },
 
     /// Scaffold a new project directory
     #[command(after_help = "EXAMPLES:\n    rl new my_project\n    rl new my_project --no-git")]
@@ -404,7 +423,11 @@ fn main() {
             }
         }
 
-        Commands::Dev => {
+        Commands::Dev {
+            treewalker,
+            vm,
+            cranelift,
+        } => {
             let config = read_rl_toml();
             let path = std::path::PathBuf::from(&config.project.entry);
             let source_text = std::fs::read_to_string(&path).unwrap_or_else(|_| {
@@ -418,17 +441,45 @@ fn main() {
             let source = SourceFile::new(&*config.project.entry, source_text);
             let tokens = lexing_loop(source.clone());
             let (ast, statements) = parsing_loop(source.clone(), tokens);
-            #[cfg(feature = "treewalker")]
-            eval_loop(source, ast, statements, 3);
-            #[cfg(all(not(feature = "treewalker"), feature = "vm"))]
-            crate::logic_loops::vm_loop(source, ast, statements);
-            #[cfg(all(not(feature = "treewalker"), not(feature = "vm")))]
-            {
-                let _ = (&ast, &statements);
-                eprintln!(
-                    "error: this build of rl has no execution backend (missing the `treewalker` or `vm` feature)"
-                );
-                std::process::exit(1);
+            if vm {
+                #[cfg(feature = "vm")]
+                crate::logic_loops::vm_loop(source, ast, statements);
+                #[cfg(not(feature = "vm"))]
+                {
+                    eprintln!("error: --vm requires the `vm` feature");
+                    std::process::exit(1)
+                }
+            } else if cranelift {
+                #[cfg(feature = "cranelift")]
+                crate::logic_loops::cranelift_loop(source, ast, statements);
+                #[cfg(not(feature = "cranelift"))]
+                {
+                    eprintln!(
+                        "error: --cranelift requires the `cranelift` feature (which implies `vm`)"
+                    );
+                    std::process::exit(1)
+                }
+            } else if treewalker {
+                #[cfg(feature = "treewalker")]
+                eval_loop(source, ast, statements, 3);
+                #[cfg(not(feature = "treewalker"))]
+                {
+                    eprintln!("error: --treewalker requires the `treewalker` feature");
+                    std::process::exit(1)
+                }
+            } else {
+                #[cfg(feature = "treewalker")]
+                eval_loop(source, ast, statements, 3);
+                #[cfg(all(not(feature = "treewalker"), feature = "vm"))]
+                crate::logic_loops::vm_loop(source, ast, statements);
+                #[cfg(all(not(feature = "treewalker"), not(feature = "vm")))]
+                {
+                    let _ = (&ast, &statements);
+                    eprintln!(
+                        "error: this build of rl has no execution backend (missing the `treewalker` or `vm` feature)"
+                    );
+                    std::process::exit(1);
+                }
             }
         }
 

--- a/crates/rl-cli/src/main.rs
+++ b/crates/rl-cli/src/main.rs
@@ -64,6 +64,10 @@ enum Commands {
         #[arg(long)]
         vm: bool,
 
+        /// Run through the tree-walking evaluator instead of the bytecode VM
+        #[arg(long)]
+        treewalker: bool,
+
         /// JIT compile via cranelift instead
         /// (this is very very highly experimental)
         #[arg(long)]
@@ -304,6 +308,7 @@ fn main() {
         Commands::Run {
             file,
             vm,
+            treewalker,
             cranelift,
             ..
         } => {
@@ -373,6 +378,14 @@ fn main() {
                     eprintln!(
                         "error: --cranelift requires the `cranelift` feature (which implies `vm`)"
                     );
+                    std::process::exit(1)
+                }
+            } else if treewalker {
+                #[cfg(feature = "treewalker")]
+                eval_loop(source, ast, statements, 3);
+                #[cfg(not(feature = "treewalker"))]
+                {
+                    eprintln!("error: --treewalker requires the `treewalker` feature");
                     std::process::exit(1)
                 }
             } else {


### PR DESCRIPTION
## What does this PR do?

Fix missing flag for tree walker backend
add new flags to `dev` command

## Checklist
- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] docs updated if needed
