### PR TITLE
Feat/escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the rl-lang toolchain are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/), and the project follows [Semantic Versioning](https://semver.org/) (see [VERSIONING.md](VERSIONING.md)). Full per-commit history is available on the [GitHub Releases](https://github.com/rl-lang/rl-lang/releases) page.
 
+## [Unreleased]
+
+### Added
+
+- **Escape sequences** - string and character literals now support the full set of escape sequences: `\n`, `\t`, `\r`, `\0`, `\\`, `\"`, `\'`, `\a`, `\b`, `\f`, `\v`, `\e`, plus `\xHH` hex byte escapes (1–2 hex digits, e.g. `\x41`, `\xff`) and `\uHHHH` / `\u{HHHH...}` unicode codepoint escapes (e.g. `\u0041`, `\u{1F600}`).
+
 ## [2.0.0] - 2026-08-13
 
 The bytecode VM is now the sole execution backend; the tree-walking interpreter has been removed.

--- a/crates/rl-docs/src/entries/concepts/types/mod.rs
+++ b/crates/rl-docs/src/entries/concepts/types/mod.rs
@@ -55,6 +55,15 @@ pub static TYPES: ConceptEntry = ConceptEntry {
             expected_output: &["'a'"],
         },
         DescriptionEntry {
+            kind: DescriptionKind::Syntax,
+            title: Some("escape sequences"),
+            description: "both string and character literals support escape sequences introduced with `\\\\`",
+            examples: &[
+                "// common escapes\ndec string s = \"line1\\nline2\"\nprintln(s)\n\n// control characters\ndec string bell = \"\\a\"\ndec string tab = \"\\t\"\nprintln(bell)\nprintln(tab)\n\n// hex byte (1-2 digits)\ndec char a = '\\x41'\nprintln(a)  // A\n\n// unicode (4 digits)\ndec string u = \"\\u0041\"\nprintln(u)  // A\n\n// unicode (braced, 1-6 digits)\ndec string emoji = \"\\u{1F600}\"\nprintln(emoji)",
+            ],
+            expected_output: &["line1", "line2", "\x07", "\t", "A", "A", "\u{1F600}"],
+        },
+        DescriptionEntry {
             kind: DescriptionKind::Explanation,
             title: Some("byte"),
             description: "`byte` is an unsigned 8-bit integer (0-255); unlike the other primitives, a bare integer literal is always typed `int`, never `byte` - get a byte value with `<literal> as byte` (see the `byte` concept for the full casting rules)",

--- a/crates/rl-lexer/src/types/character_literal.rs
+++ b/crates/rl-lexer/src/types/character_literal.rs
@@ -67,6 +67,88 @@ impl Tokenizer {
                     })?;
                     byte as char
                 }
+                'u' => {
+                    if self.is_at_end() {
+                        return Err(self.err(
+                            "unterminated unicode escape",
+                            self.current_span(),
+                        ));
+                    }
+                    if self.peek() == '{' {
+                        self.advance();
+                        let mut hex = String::new();
+                        while !self.is_at_end() && self.peek() != '}' {
+                            if self.peek().is_ascii_hexdigit() {
+                                hex.push(self.advance());
+                            } else {
+                                let invalid_ch = self.peek();
+                                return Err(self.err(
+                                    format!(
+                                        "invalid character in unicode escape: '{}'",
+                                        invalid_ch
+                                    ),
+                                    self.current_span(),
+                                ));
+                            }
+                        }
+                        if self.is_at_end() {
+                            return Err(self.err(
+                                "unterminated unicode escape",
+                                self.current_span(),
+                            ));
+                        }
+                        self.advance();
+                        if hex.is_empty() {
+                            return Err(self.err(
+                                "expected hex digits in unicode escape",
+                                self.current_span(),
+                            ));
+                        }
+                        let codepoint = u32::from_str_radix(&hex, 16).map_err(|_| {
+                            self.err(
+                                format!("invalid unicode escape '\\u{{{}}}'", hex),
+                                self.current_span(),
+                            )
+                        })?;
+                        char::from_u32(codepoint).ok_or_else(|| {
+                            self.err(
+                                format!(
+                                    "invalid unicode codepoint '\\u{{{}}}'",
+                                    hex
+                                ),
+                                self.current_span(),
+                            )
+                        })?
+                    } else {
+                        let hex = self.read_hex_digits(4).map_err(|_| {
+                            self.err(
+                                "expected 4 hex digits after '\\u'",
+                                self.current_span(),
+                            )
+                        })?;
+                        if hex.len() != 4 {
+                            return Err(self.err(
+                                format!(
+                                    "expected 4 hex digits after '\\u', found {}",
+                                    hex.len()
+                                ),
+                                self.current_span(),
+                            ));
+                        }
+                        let codepoint = u32::from_str_radix(&hex, 16).map_err(|_| {
+                            self.err(
+                                format!("invalid unicode escape '\\u{}'", hex),
+                                self.current_span(),
+                            )
+                        })?;
+                        char::from_u32(codepoint).ok_or_else(|| {
+                            self.err(
+                                format!("invalid unicode codepoint '\\u{}'", hex),
+                                self.current_span(),
+                            )
+                        })?
+                    }
+                }
                 _ => {
                     return Err(self.err(
                         format!("unknown escape sequence `\\{}`", escaped),

--- a/crates/rl-lexer/src/types/character_literal.rs
+++ b/crates/rl-lexer/src/types/character_literal.rs
@@ -52,6 +52,21 @@ impl Tokenizer {
                 'f' => '\x0C',
                 'v' => '\x0B',
                 'e' => '\x1B',
+                'x' => {
+                    let hex = self.read_hex_digits(2).map_err(|_| {
+                        self.err(
+                            "expected hex digits after '\\x'",
+                            self.current_span(),
+                        )
+                    })?;
+                    let byte = u8::from_str_radix(&hex, 16).map_err(|_| {
+                        self.err(
+                            format!("invalid hex escape '\\x{}'", hex),
+                            self.current_span(),
+                        )
+                    })?;
+                    byte as char
+                }
                 _ => {
                     return Err(self.err(
                         format!("unknown escape sequence `\\{}`", escaped),

--- a/crates/rl-lexer/src/types/character_literal.rs
+++ b/crates/rl-lexer/src/types/character_literal.rs
@@ -47,6 +47,11 @@ impl Tokenizer {
                 '\"' => '\"',
                 '\'' => '\'',
                 '0' => '\0',
+                'a' => '\x07',
+                'b' => '\x08',
+                'f' => '\x0C',
+                'v' => '\x0B',
+                'e' => '\x1B',
                 _ => {
                     return Err(self.err(
                         format!("unknown escape sequence `\\{}`", escaped),

--- a/crates/rl-lexer/src/types/character_literal.rs
+++ b/crates/rl-lexer/src/types/character_literal.rs
@@ -10,15 +10,23 @@ impl Tokenizer {
     /// Only a single character is allowed between the quotes.
     /// Supports the following escape sequences:
     ///
-    /// | Sequence | Meaning         |
-    /// |----------|-----------------|
-    /// | `\n`     | newline         |
-    /// | `\t`     | tab             |
-    /// | `\r`     | carriage return |
-    /// | `\0`     | null            |
-    /// | `\\`     | backslash       |
-    /// | '\"'     | double quote    |
-    /// | `\'`     | single quote    |
+    /// | Sequence   | Meaning              |
+    /// |------------|----------------------|
+    /// | `\n`       | newline              |
+    /// | `\t`       | tab                  |
+    /// | `\r`       | carriage return      |
+    /// | `\0`       | null                 |
+    /// | `\\`       | backslash            |
+    /// | `\"`       | double quote         |
+    /// | `\'`       | single quote         |
+    /// | `\a`       | bell                 |
+    /// | `\b`       | backspace            |
+    /// | `\f`       | form feed            |
+    /// | `\v`       | vertical tab         |
+    /// | `\e`       | escape (ESC)         |
+    /// | `\xHH`     | hex byte (1–2 digits)|
+    /// | `\uHHHH`   | unicode (4 digits)   |
+    /// | `\u{HHHH}` | unicode (braced)     |
     ///
     /// # Errors
     ///
@@ -159,7 +167,6 @@ impl Tokenizer {
         } else {
             character
         };
-
         if self.peek() != '\'' {
             return Err(self.err("unterminated character literal", self.current_span()));
         }

--- a/crates/rl-lexer/src/types/string_literal.rs
+++ b/crates/rl-lexer/src/types/string_literal.rs
@@ -53,30 +53,132 @@ impl Tokenizer {
 
                 // cache the next escaped character
                 let escaped_ch = self.peek();
-                // is it recognized escaped sequence?
-                let resolved_escape = match escaped_ch {
-                    'n' => '\n',
-                    't' => '\t',
-                    'r' => '\r',
-                    '0' => '\0',
-                    '\\' => '\\',
-                    '"' => '"',
-                    '\'' => '\'',
-                    'a' => '\x07',
-                    'b' => '\x08',
-                    'f' => '\x0C',
-                    'v' => '\x0B',
-                    'e' => '\x1B',
+                match escaped_ch {
+                    'n' => { value.push('\n'); }
+                    't' => { value.push('\t'); }
+                    'r' => { value.push('\r'); }
+                    '0' => { value.push('\0'); }
+                    '\\' => { value.push('\\'); }
+                    '"' => { value.push('"'); }
+                    '\'' => { value.push('\''); }
+                    'a' => { value.push('\x07'); }
+                    'b' => { value.push('\x08'); }
+                    'f' => { value.push('\x0C'); }
+                    'v' => { value.push('\x0B'); }
+                    'e' => { value.push('\x1B'); }
+                    'x' => {
+                        self.advance();
+                        let hex = self.read_hex_digits(2).map_err(|_| {
+                            self.err(
+                                "expected hex digits after '\\x'",
+                                self.current_span(),
+                            )
+                        })?;
+                        let byte = u8::from_str_radix(&hex, 16).map_err(|_| {
+                            self.err(
+                                format!("invalid hex escape '\\x{}'", hex),
+                                self.current_span(),
+                            )
+                        })?;
+                        value.push(byte as char);
+                        continue;
+                    }
+                    'u' => {
+                        self.advance();
+                        if self.is_at_end() {
+                            return Err(self.err(
+                                "unterminated unicode escape",
+                                self.current_span(),
+                            ));
+                        }
+                        if self.peek() == '{' {
+                            self.advance();
+                            let mut hex = String::new();
+                            while !self.is_at_end() && self.peek() != '}' {
+                                if self.peek().is_ascii_hexdigit() {
+                                    hex.push(self.advance());
+                                } else {
+                                    let invalid_ch = self.peek();
+                                    return Err(self.err(
+                                        format!(
+                                            "invalid character in unicode escape: '{}'",
+                                            invalid_ch
+                                        ),
+                                        self.current_span(),
+                                    ));
+                                }
+                            }
+                            if self.is_at_end() {
+                                return Err(self.err(
+                                    "unterminated unicode escape",
+                                    self.current_span(),
+                                ));
+                            }
+                            self.advance();
+                            if hex.is_empty() {
+                                return Err(self.err(
+                                    "expected hex digits in unicode escape",
+                                    self.current_span(),
+                                ));
+                            }
+                            let codepoint = u32::from_str_radix(&hex, 16).map_err(|_| {
+                                self.err(
+                                    format!("invalid unicode escape '\\u{{{}}}'", hex),
+                                    self.current_span(),
+                                )
+                            })?;
+                            let ch = char::from_u32(codepoint).ok_or_else(|| {
+                                self.err(
+                                    format!(
+                                        "invalid unicode codepoint '\\u{{{}}}'",
+                                        hex
+                                    ),
+                                    self.current_span(),
+                                )
+                            })?;
+                            value.push(ch);
+                            continue;
+                        } else {
+                            let hex = self.read_hex_digits(4).map_err(|_| {
+                                self.err(
+                                    "expected 4 hex digits after '\\u'",
+                                    self.current_span(),
+                                )
+                            })?;
+                            if hex.len() != 4 {
+                                return Err(self.err(
+                                    format!(
+                                        "expected 4 hex digits after '\\u', found {}",
+                                        hex.len()
+                                    ),
+                                    self.current_span(),
+                                ));
+                            }
+                            let codepoint = u32::from_str_radix(&hex, 16).map_err(|_| {
+                                self.err(
+                                    format!("invalid unicode escape '\\u{}'", hex),
+                                    self.current_span(),
+                                )
+                            })?;
+                            let ch = char::from_u32(codepoint).ok_or_else(|| {
+                                self.err(
+                                    format!("invalid unicode codepoint '\\u{}'", hex),
+                                    self.current_span(),
+                                )
+                            })?;
+                            value.push(ch);
+                            continue;
+                        }
+                    }
                     other => {
                         return Err(self.err(
                             format!("unknown escape sequence '\\{}'", other),
                             self.current_span(),
                         ));
                     }
-                };
+                }
 
-                // add the escaped sequence into value then advance
-                value.push(resolved_escape);
+                // single-character escapes: advance past the escape character
                 self.advance();
                 continue;
             }

--- a/crates/rl-lexer/src/types/string_literal.rs
+++ b/crates/rl-lexer/src/types/string_literal.rs
@@ -62,6 +62,11 @@ impl Tokenizer {
                     '\\' => '\\',
                     '"' => '"',
                     '\'' => '\'',
+                    'a' => '\x07',
+                    'b' => '\x08',
+                    'f' => '\x0C',
+                    'v' => '\x0B',
+                    'e' => '\x1B',
                     other => {
                         return Err(self.err(
                             format!("unknown escape sequence '\\{}'", other),

--- a/crates/rl-lexer/src/types/string_literal.rs
+++ b/crates/rl-lexer/src/types/string_literal.rs
@@ -10,15 +10,23 @@ impl Tokenizer {
     ///
     /// Supports multi-line strings and the following escape sequences:
     ///
-    /// | Sequence | Meaning        |
-    /// |----------|----------------|
-    /// | `\n`     | newline        |
-    /// | `\t`     | tab            |
-    /// | `\r`     | carriage return|
-    /// | `\0`     | null           |
-    /// | `\\`     | backslash      |
-    /// | `\"`     | double quote   |
-    /// | `\'`     | single quote   |
+    /// | Sequence   | Meaning              |
+    /// |------------|----------------------|
+    /// | `\n`       | newline              |
+    /// | `\t`       | tab                  |
+    /// | `\r`       | carriage return      |
+    /// | `\0`       | null                 |
+    /// | `\\`       | backslash            |
+    /// | `\"`       | double quote         |
+    /// | `\'`       | single quote         |
+    /// | `\a`       | bell                 |
+    /// | `\b`       | backspace            |
+    /// | `\f`       | form feed            |
+    /// | `\v`       | vertical tab         |
+    /// | `\e`       | escape (ESC)         |
+    /// | `\xHH`     | hex byte (1–2 digits)|
+    /// | `\uHHHH`   | unicode (4 digits)   |
+    /// | `\u{HHHH}` | unicode (braced)     |
     ///
     /// # Errors
     ///

--- a/crates/rl-lexer/src/utils/helper.rs
+++ b/crates/rl-lexer/src/utils/helper.rs
@@ -4,6 +4,7 @@
 //! directly on the [`Tokenizer`]'s byte position.
 use super::super::tokenizer::Tokenizer;
 use super::super::tokentypes::{Token, TokenType};
+use rl_utils::errors::Error;
 
 impl Tokenizer {
     /// Returns `true` if all characters have been consumed.
@@ -55,6 +56,21 @@ impl Tokenizer {
             self.newlines_since_trivia = 0;
         }
         self.tokens.push(tok);
+    }
+
+    /// Reads up to `max` consecutive ASCII hex digits, advancing the cursor.
+    ///
+    /// Returns the collected digits as a `String`, or an error if zero hex
+    /// digits are found at the current position.
+    pub fn read_hex_digits(&mut self, max: usize) -> Result<String, Error> {
+        let mut hex = String::new();
+        while hex.len() < max && !self.is_at_end() && self.peek().is_ascii_hexdigit() {
+            hex.push(self.advance());
+        }
+        if hex.is_empty() {
+            return Err(self.err("expected hex digits", self.current_span()));
+        }
+        Ok(hex)
     }
 
     pub fn flush_orphaned_trivia(&mut self) {

--- a/crates/rl-tests/tests/lexer/literals.rs
+++ b/crates/rl-tests/tests/lexer/literals.rs
@@ -69,3 +69,168 @@ fn eof_is_last_token() {
     let tokens = common::lex("42");
     assert_eq!(tokens.last().unwrap().token, TokenType::Eof);
 }
+
+// --- \x hex escape tests ---
+
+/// `\x41` in a string resolves to 'A'
+#[test]
+fn string_hex_escape_one_digit() {
+    let tokens = common::lex(r#""\x41""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("A".to_string())
+    );
+}
+
+/// `\xff` in a string resolves to '\u{FF}'
+#[test]
+fn string_hex_escape_two_digits() {
+    let tokens = common::lex(r#""\xff""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("\u{FF}".to_string())
+    );
+}
+
+/// `\x4` in a string resolves to '\u{04}' (single hex digit)
+#[test]
+fn string_hex_escape_single_digit() {
+    let tokens = common::lex(r#""\x4""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("\u{04}".to_string())
+    );
+}
+
+/// `'\xff'` as a character literal resolves to '\u{FF}'
+#[test]
+fn character_hex_escape() {
+    let tokens = common::lex(r"'\xff'");
+    assert_eq!(tokens[0].token, TokenType::CharacterLiteral('\u{FF}'));
+}
+
+/// `\x` with no hex digits in a string produces an error
+#[test]
+fn string_hex_escape_no_digits() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\x""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("expected hex digits"));
+}
+
+/// `\xG` (non-hex) in a string produces an error
+#[test]
+fn string_hex_escape_non_hex() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\xG""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("expected hex digits"));
+}
+
+// --- \u unicode escape tests ---
+
+/// `\u0041` (fixed 4-digit) in a string resolves to 'A'
+#[test]
+fn string_unicode_escape_fixed() {
+    let tokens = common::lex(r#""\u0041""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("A".to_string())
+    );
+}
+
+/// `\u{1F600}` (braced) in a string resolves to the grinning face emoji
+#[test]
+fn string_unicode_escape_braced() {
+    let tokens = common::lex(r#""\u{1F600}""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("\u{1F600}".to_string())
+    );
+}
+
+/// `\u{41}` (braced, short) in a string resolves to 'A'
+#[test]
+fn string_unicode_escape_braced_short() {
+    let tokens = common::lex(r#""\u{41}""#);
+    assert_eq!(
+        tokens[0].token,
+        TokenType::StringLiteral("A".to_string())
+    );
+}
+
+/// `\u0041` as a character literal resolves to 'A'
+#[test]
+fn character_unicode_escape_fixed() {
+    let tokens = common::lex(r"'\u0041'");
+    assert_eq!(tokens[0].token, TokenType::CharacterLiteral('A'));
+}
+
+/// `\u{1F600}` as a character literal resolves to the grinning face emoji
+#[test]
+fn character_unicode_escape_braced() {
+    let tokens = common::lex(r"'\u{1F600}'");
+    assert_eq!(tokens[0].token, TokenType::CharacterLiteral('\u{1F600}'));
+}
+
+/// `\u{}` (empty) in a string produces an error
+#[test]
+fn string_unicode_escape_empty() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\u{}""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("expected hex digits"));
+}
+
+/// `\u` with fewer than 4 hex digits (non-braced) in a string produces an error
+#[test]
+fn string_unicode_escape_too_few_digits() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\u004""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("expected 4 hex digits"));
+}
+
+/// `\u{110000}` (out of range) in a string produces an error
+#[test]
+fn string_unicode_escape_out_of_range() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\u{110000}""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("invalid unicode codepoint"));
+}
+
+/// `\u{ZZZZ}` (invalid char) in a string produces an error
+#[test]
+fn string_unicode_escape_invalid_char() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\u{ZZZZ}""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(err.message().contains("invalid character in unicode escape"));
+}
+
+/// `\u{` (unterminated) in a string produces an error
+#[test]
+fn string_unicode_escape_unterminated() {
+    let result = rl_lexer::tokenizer::Tokenizer::lex(
+        rl_utils::source::SourceFile::new("test", r#""\u{41""#.to_string()),
+    );
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    assert!(
+        err.message().contains("unterminated unicode escape")
+            || err.message().contains("invalid character in unicode escape")
+    );
+}

--- a/examples/scripts/escape_sequences.rl
+++ b/examples/scripts/escape_sequences.rl
@@ -1,0 +1,124 @@
+// ============================================================
+// ESCAPE SEQUENCE EXHAUSTIVE DEMO
+// ============================================================
+
+// --- Basic escapes ---
+std::io::println("=== Basic Escapes ===")
+std::io::println("newline\nhere")
+std::io::println("tab\there")
+std::io::println("carriage\rreturn")
+std::io::println("back\\slash")
+std::io::println("double\"quote")
+std::io::println("single\'quote")
+std::io::println("null\0char")
+
+// --- Control character escapes ---
+std::io::println("")
+std::io::println("=== Control Characters ===")
+std::io::println("bell\a")
+std::io::println("back\bspace")
+std::io::println("form\ffeed")
+std::io::println("vertical\vtab")
+
+// --- Hex escapes via \x ---
+std::io::println("")
+std::io::println("=== Hex Escapes (\\x) ===")
+std::io::println("\x41")  // A
+std::io::println("\x48\x65\x6c\x6c\x6f")  // Hello
+
+// --- Unicode escapes via \uHHHH ---
+std::io::println("")
+std::io::println("=== Unicode Fixed (\\uHHHH) ===")
+std::io::println("\u0048\u0065\u006c\u006c\u006f")  // Hello
+
+// --- Unicode escapes via \u{} ---
+std::io::println("")
+std::io::println("=== Unicode Braced (\\u{}) ===")
+std::io::println("\u{48}\u{65}\u{6c}\u{6c}\u{6f}")  // Hello
+std::io::println("\u{1F600}")  // 😀
+std::io::println("\u{1F4A9}")  // 💩
+std::io::println("\u{1F680}")  // 🚀
+
+// --- Stars and symbols ---
+std::io::println("")
+std::io::println("=== Symbols ===")
+std::io::println("\u{2605} \u{2605} \u{2605} \u{2606} \u{2606}")
+std::io::println("\u{2665}\u{2665}\u{2665} I love rl! \u{2665}\u{2665}\u{2665}")
+std::io::println("\u{2713} Pass")
+std::io::println("\u{2717} Fail")
+std::io::println("\u{26A0} Warning")
+
+// --- Arrows ---
+std::io::println("")
+std::io::println("=== Arrows ===")
+std::io::println("\u{2190} \u{2191} \u{2192} \u{2193}")
+std::io::println("\u{2B05}\u{2B06}\u{27A1}\u{2B07}")
+
+// --- Box drawing with \u{} ---
+std::io::println("")
+std::io::println("=== Box Drawing ===")
+std::io::println("\u{2554}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2557}")
+std::io::println("\u{2551}  HELLO WORLD  \u{2551}")
+std::io::println("\u{255A}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{2550}\u{255D}")
+
+// --- ANSI colors via \e ---
+std::io::println("")
+std::io::println("=== ANSI Colors ===")
+std::io::println("\e[31mRed\e[0m")
+std::io::println("\e[32mGreen\e[0m")
+std::io::println("\e[33mYellow\e[0m")
+std::io::println("\e[34mBlue\e[0m")
+std::io::println("\e[35mMagenta\e[0m")
+std::io::println("\e[36mCyan\e[0m")
+
+// --- ANSI colors via \x1b ---
+std::io::println("")
+std::io::println("=== ANSI via \\x1b ===")
+std::io::println("\x1b[31mRed\x1b[0m")
+std::io::println("\x1b[32mGreen\x1b[0m")
+
+// --- ANSI colors via \u001b ---
+std::io::println("")
+std::io::println("=== ANSI via \\u001b ===")
+std::io::println("\u001b[31mRed\u001b[0m")
+std::io::println("\u001b[32mGreen\u001b[0m")
+
+// --- Rainbow ---
+std::io::println("")
+std::io::println("=== Rainbow ===")
+std::io::println("\e[31mR\e[33mE\e[32mD\e[36m \e[34mY\e[35mO\e[31mU\e[33mR\e[0m")
+
+// --- Blinking + inverse ---
+std::io::println("")
+std::io::println("=== Blink + Inverse ===")
+std::io::println("\e[5;31;40m ⚠ BLINKING \e[0m")
+std::io::println("\e[7;32m INVERSE \e[0m")
+
+// --- RGB truecolor via \x ---
+std::io::println("")
+std::io::println("=== RGB Truecolor ===")
+std::io::println("\x1b[38;2;255;100;0mOrange\x1b[0m")
+std::io::println("\x1b[38;2;0;200;255mCyan\x1b[0m")
+std::io::println("\x1b[38;2;200;0;255mPurple\x1b[0m")
+
+// --- 256-color palette via \u001b ---
+std::io::println("")
+std::io::println("=== 256-Color Palette ===")
+std::io::println("\u001b[38;5;196m196\u001b[0m \u001b[38;5;208m208\u001b[0m \u001b[38;5;226m226\u001b[0m \u001b[38;5;34m34\u001b[0m \u001b[38;5;27m27\u001b[0m \u001b[38;5;93m93\u001b[0m")
+
+// --- Bell + flash ---
+std::io::println("")
+std::io::println("=== Bell ===")
+std::io::println("\a\e[5;7m FLASH \e[0m\a")
+
+// --- All three syntaxes side by side ---
+std::io::println("")
+std::io::println("=== Same char, 3 syntaxes ===")
+std::io::println("\e[32m\e  => 0x1B\e[0m")
+std::io::println("\x1b[32m\x1b  => 0x1B\x1b[0m")
+std::io::println("\u001b[32m\u001b  => 0x1B\u001b[0m")
+
+// --- Final combined demo ---
+std::io::println("")
+std::io::println("\e[1;36m\u{2713}\e[0m \u{2192} \e[1;33mAll escape sequences work!\e[0m")
+std::io::println("\e[32m\u{2605}\e[0m \u{2714} \e[31m\u{2718}\e[0m \u{2716} \e[33m\u{26A0}\e[0m")


### PR DESCRIPTION
## What does this PR do?

Add new escape sequences modes:
- `\xH`
- `\xHH`
- `\uHHHH`
- `\u{....}`

and new characters:
- `\e`
- `\a`
- `\v`
- `\b`
- `\f`

## Related issue

Closes #464

## Checklist

- [x] branched off `dev`
- [x] `cargo test --all-features` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] docs updated if needed
